### PR TITLE
Scaffold playground page

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@blueprintjs/core": "^2.1.1",
     "normalize.css": "^8.0.0",
     "react": "^16.3.1",
+    "react-ace": "^6.1.1",
     "react-dom": "^16.3.1",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,3 +1,0 @@
-import { IUpdateEditorValue, UPDATE_EDITOR_VALUE, updateEditorValue } from './playground'
-
-export default { IUpdateEditorValue, UPDATE_EDITOR_VALUE, updateEditorValue }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,1 +1,16 @@
 export default {}
+
+export type UPDATE_PLAYGROUND_CODE = 'UPDATE_PLAYGROUND_CODE';
+export const  UPDATE_PLAYGROUND_CODE: UPDATE_PLAYGROUND_CODE = 'UPDATE_PLAYGROUND_CODE';
+
+export interface IUpdatePlaygroundCodeAction {
+    type: UPDATE_PLAYGROUND_CODE
+    playgroundCode: string
+  };
+
+export function updatePlaygroundCode(newCode: string): IUpdatePlaygroundCodeAction {
+    return {
+      type: UPDATE_PLAYGROUND_CODE,
+      playgroundCode: newCode
+    };
+  };

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,16 +1,3 @@
-export default {}
+import { IUpdateEditorValue, UPDATE_EDITOR_VALUE, updateEditorValue } from './playground'
 
-export type UPDATE_PLAYGROUND_CODE = 'UPDATE_PLAYGROUND_CODE';
-export const  UPDATE_PLAYGROUND_CODE: UPDATE_PLAYGROUND_CODE = 'UPDATE_PLAYGROUND_CODE';
-
-export interface IUpdatePlaygroundCodeAction {
-    type: UPDATE_PLAYGROUND_CODE
-    playgroundCode: string
-  };
-
-export function updatePlaygroundCode(newCode: string): IUpdatePlaygroundCodeAction {
-    return {
-      type: UPDATE_PLAYGROUND_CODE,
-      playgroundCode: newCode
-    };
-  };
+export default { IUpdateEditorValue, UPDATE_EDITOR_VALUE, updateEditorValue }

--- a/src/actions/playground.ts
+++ b/src/actions/playground.ts
@@ -8,7 +8,7 @@ export const UPDATE_EDITOR_VALUE: string = 'UPDATE_EDITOR_VALUE'
 
 /**
  * Represents an `Action` which updates the `editorValue` of a
- * `IPlaygroundState` 
+ * `IPlaygroundState`
  * @property type           - Unique string identifier for this `Action`
  * @property newEditorValue - The new string value for `editorValue`
  */
@@ -18,7 +18,7 @@ export interface IUpdateEditorValue extends Action {
 }
 
 /**
- * An `ActionCreator` returning an `IUpdateEditorValue` `Action` 
+ * An `ActionCreator` returning an `IUpdateEditorValue` `Action`
  * @param newEditorValue - The new string value for `editorValue`
  */
 export const updateEditorValue: ActionCreator<IUpdateEditorValue> = (newEditorValue: string) => ({

--- a/src/actions/playground.ts
+++ b/src/actions/playground.ts
@@ -1,12 +1,13 @@
 import { Action, ActionCreator } from 'redux'
 
-export type UPDATE_EDITOR_VALUE = 'UPDATE_EDITOR_VALUE'
-const UPDATE_EDITOR_VALUE: UPDATE_EDITOR_VALUE = 'UPDATE_EDITOR_VALUE'
+export const UPDATE_EDITOR_VALUE: string = 'UPDATE_EDITOR_VALUE'
+
 export interface IUpdateEditorValue extends Action {
-  type: UPDATE_EDITOR_VALUE
+  type: string
   newEditorValue: string
 }
+
 export const updateEditorValue: ActionCreator<IUpdateEditorValue> = (newEditorValue: string) => ({
-  UPDATE_EDITOR_VALUE,
+  type: UPDATE_EDITOR_VALUE,
   newEditorValue
 })

--- a/src/actions/playground.ts
+++ b/src/actions/playground.ts
@@ -1,12 +1,26 @@
 import { Action, ActionCreator } from 'redux'
 
+/**
+ * The `type` attribute for an `Action` which updates the `IPlaygroundState`
+ * `editorValue`
+ */
 export const UPDATE_EDITOR_VALUE: string = 'UPDATE_EDITOR_VALUE'
 
+/**
+ * Represents an `Action` which updates the `editorValue` of a
+ * `IPlaygroundState` 
+ * @property type           - Unique string identifier for this `Action`
+ * @property newEditorValue - The new string value for `editorValue`
+ */
 export interface IUpdateEditorValue extends Action {
   type: string
   newEditorValue: string
 }
 
+/**
+ * An `ActionCreator` returning an `IUpdateEditorValue` `Action` 
+ * @param newEditorValue - The new string value for `editorValue`
+ */
 export const updateEditorValue: ActionCreator<IUpdateEditorValue> = (newEditorValue: string) => ({
   type: UPDATE_EDITOR_VALUE,
   newEditorValue

--- a/src/actions/playground.ts
+++ b/src/actions/playground.ts
@@ -1,0 +1,12 @@
+import { Action, ActionCreator } from 'redux'
+
+export type UPDATE_EDITOR_VALUE = 'UPDATE_EDITOR_VALUE'
+const UPDATE_EDITOR_VALUE: UPDATE_EDITOR_VALUE = 'UPDATE_EDITOR_VALUE'
+export interface IUpdateEditorValue extends Action {
+  type: UPDATE_EDITOR_VALUE
+  newEditorValue: string
+}
+export const updateEditorValue: ActionCreator<IUpdateEditorValue> = (newEditorValue: string) => ({
+  UPDATE_EDITOR_VALUE,
+  newEditorValue
+})

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 
 import DashboardContainer from '../containers/DashboardContainer'
+import PlaygroundContainer from '../containers/PlaygroundContainer'
 import { IApplicationState } from '../reducers/application'
 import NavigationBar from './NavigationBar'
 import NotFound from './NotFound'
@@ -20,6 +21,7 @@ const Application: React.SFC<IApplicationProps> = ({ application }) => {
       <div className="Application__main">
         <Switch>
           <Route path="/dashboard" component={DashboardContainer} />
+          <Route path="/playground" component={PlaygroundContainer} />
           <Route exact={true} path="/" component={redirectToDashboard} />
           <Route component={NotFound} />
         </Switch>

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -5,11 +5,13 @@ import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import DashboardContainer from '../containers/DashboardContainer'
 import PlaygroundContainer from '../containers/PlaygroundContainer'
 import { IApplicationState } from '../reducers/application'
+import { IPlaygroundState } from '../reducers/playground'
 import NavigationBar from './NavigationBar'
 import NotFound from './NotFound'
 
 export interface IApplicationProps extends RouteComponentProps<{}> {
   application: IApplicationState
+  playground: IPlaygroundState
 }
 
 const Application: React.SFC<IApplicationProps> = ({ application }) => {

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -4,22 +4,19 @@ import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 
 import DashboardContainer from '../containers/DashboardContainer'
 import PlaygroundContainer from '../containers/PlaygroundContainer'
-import { IApplicationState } from '../reducers/application'
-import { IPlaygroundState } from '../reducers/playground'
 import NavigationBar from './NavigationBar'
 import NotFound from './NotFound'
 
 export interface IApplicationProps extends RouteComponentProps<{}> {
-  application: IApplicationState
-  playground: IPlaygroundState
+  title: string
 }
 
-const Application: React.SFC<IApplicationProps> = ({ application }) => {
+const Application: React.SFC<IApplicationProps> = (props: IApplicationProps) => {
   const redirectToDashboard = () => <Redirect to="/dashboard" />
 
   return (
     <div className="Application">
-      <NavigationBar title={application.title} />
+      <NavigationBar title={props.title} />
       <div className="Application__main">
         <Switch>
           <Route path="/dashboard" component={DashboardContainer} />

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -21,6 +21,17 @@ const NavigationBar: React.SFC<INavigationBarProps> = ({ title }) => (
         Dashboard
       </NavLink>
     </NavbarGroup>
+
+    <NavbarGroup className="pt-align-right">
+      <NavLink
+        to="/playground"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="dashboard" />
+        Playground
+      </NavLink>
+    </NavbarGroup>
   </Navbar>
 )
 

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -28,7 +28,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = ({ title }) => (
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
-        <Icon icon="dashboard" />
+        <Icon icon="code" />
         Playground
       </NavLink>
     </NavbarGroup>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -9,7 +9,7 @@ export interface INavigationBarProps {
 
 const NavigationBar: React.SFC<INavigationBarProps> = ({ title }) => (
   <Navbar className="NavigationBar pt-dark">
-    <NavbarGroup>
+    <NavbarGroup className="pt-align-left">
       <NavbarHeading>{title}</NavbarHeading>
       <NavbarDivider />
       <NavLink

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -22,14 +22,14 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
     return (
       <div className="Playground">
         <h2>Playground</h2>
-          <AceEditor
-            height='90%'
-            width='90%'
-            mode="javascript"
-            theme="github"
-            value={this.props.editorValue}
-            onChange={this.props.updateCode}
-          />
+        <AceEditor
+          height="90%"
+          width="90%"
+          mode="javascript"
+          theme="github"
+          value={this.props.editorValue}
+          onChange={this.props.updateCode}
+        />
       </div>
     )
   }

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import AceEditor from 'react-ace'
 
 export interface IPlaygroundProps {
-  initialCode: string;
+  editorValue: string;
   updateCode: (newCode: string) => void;
 };
 
@@ -14,7 +14,7 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
         <AceEditor 
           mode="java"
           theme="github"
-          value={this.props.initialCode}
+          value={this.props.editorValue}
           onChange={this.props.updateCode}
         />
       </div>

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import AceEditor from 'react-ace'
 
+import 'brace/mode/javascript'
+import 'brace/theme/github'
+
 export interface IPlaygroundProps {
   editorValue: string
   updateCode: (newCode: string) => void
@@ -12,7 +15,7 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
       <div className="Playground">
         <h2>Playground</h2>
         <AceEditor
-          mode="java"
+          mode="javascript"
           theme="github"
           value={this.props.editorValue}
           onChange={this.props.updateCode}

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 
+import AceEditor from 'react-ace'
+
 const Playground: React.SFC<{}> = () => (
   <div className="Playground">
     <h2>Playground</h2>
+    <AceEditor />
   </div>
 )
 

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import AceEditor from 'react-ace'
-import 'brace/mode/java';
-import 'brace/theme/github';
 
 export interface IPlaygroundProps {
   initialCode: string;
+  updateCode: (newCode: string) => void;
 };
 
 export default class Playground extends React.Component<IPlaygroundProps, {}> {
@@ -16,6 +15,7 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
           mode="java"
           theme="github"
           value={this.props.initialCode}
+          onChange={this.props.updateCode}
         />
       </div>
     );

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react'
 import AceEditor from 'react-ace'
-
+import 'brace/mode/java';
+import 'brace/theme/github';
 
 export interface IPlaygroundProps {
   initialCode: string;
 };
-
-function onChange(newValue : string) : void {
-  // console.log('change', newValue);
-}
 
 export default class Playground extends React.Component<IPlaygroundProps, {}> {
   public render() {
@@ -16,8 +13,10 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
       <div className="Playground">
        <h2>Playground</h2>
         <AceEditor 
+          mode="java"
+          theme="github"
           value={this.props.initialCode}
-          onChange={onChange} />
+        />
       </div>
     );
   }

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react'
-
 import AceEditor from 'react-ace'
-import { IApplicationProps } from './Application'
 
-const Playground: React.SFC<IApplicationProps> = ({ application }) => (
-  <div className="Playground">
-    <h2>Playground</h2>
-    <AceEditor value={application.title} />
-  </div>
-)
 
-export default Playground
+export interface IPlaygroundProps {
+  initialCode: string;
+};
+
+function onChange(newValue : string) : void {
+  // console.log('change', newValue);
+}
+
+export default class Playground extends React.Component<IPlaygroundProps, {}> {
+  public render() {
+    return (
+      <div className="Playground">
+       <h2>Playground</h2>
+        <AceEditor 
+          value={this.props.initialCode}
+          onChange={onChange} />
+      </div>
+    );
+  }
+}

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -2,22 +2,22 @@ import * as React from 'react'
 import AceEditor from 'react-ace'
 
 export interface IPlaygroundProps {
-  editorValue: string;
-  updateCode: (newCode: string) => void;
-};
+  editorValue: string
+  updateCode: (newCode: string) => void
+}
 
 export default class Playground extends React.Component<IPlaygroundProps, {}> {
   public render() {
     return (
       <div className="Playground">
-       <h2>Playground</h2>
-        <AceEditor 
+        <h2>Playground</h2>
+        <AceEditor
           mode="java"
           theme="github"
           value={this.props.editorValue}
           onChange={this.props.updateCode}
         />
       </div>
-    );
+    )
   }
 }

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+const Playground: React.SFC<{}> = () => (
+  <div className="Playground">
+    <h2>Playground</h2>
+  </div>
+)
+
+export default Playground

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 
 import AceEditor from 'react-ace'
+import { IApplicationProps } from './Application'
 
-const Playground: React.SFC<{}> = () => (
+const Playground: React.SFC<IApplicationProps> = ({ application }) => (
   <div className="Playground">
     <h2>Playground</h2>
-    <AceEditor />
+    <AceEditor value={application.title} />
   </div>
 )
 

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -14,12 +14,14 @@ export default class Playground extends React.Component<IPlaygroundProps, {}> {
     return (
       <div className="Playground">
         <h2>Playground</h2>
-        <AceEditor
-          mode="javascript"
-          theme="github"
-          value={this.props.editorValue}
-          onChange={this.props.updateCode}
-        />
+          <AceEditor
+            height='90%'
+            width='90%'
+            mode="javascript"
+            theme="github"
+            value={this.props.editorValue}
+            onChange={this.props.updateCode}
+          />
       </div>
     )
   }

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -4,11 +4,19 @@ import AceEditor from 'react-ace'
 import 'brace/mode/javascript'
 import 'brace/theme/github'
 
+/**
+ * A prop that is passed to the Playground
+ * @property editorValue - The string content of the react-ace editor
+ * @property updateCode  - A callback function for the react-ace editor's `onChange`
+ */
 export interface IPlaygroundProps {
   editorValue: string
   updateCode: (newCode: string) => void
 }
 
+/**
+ * A component representing the Playground
+ */
 export default class Playground extends React.Component<IPlaygroundProps, {}> {
   public render() {
     return (

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -11,8 +11,7 @@ test('Application renders correctly', () => {
     ...mockRouterProps('/dashboard', {}),
     application: {
       title: 'Cadet',
-      environment: ApplicationEnvironment.Development,
-      playgroundCode: ''
+      environment: ApplicationEnvironment.Development
     }
   }
   const app = <Application {...props} />

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -12,6 +12,9 @@ test('Application renders correctly', () => {
     application: {
       title: 'Cadet',
       environment: ApplicationEnvironment.Development
+    },
+    playground: {
+      editorValue: ''
     }
   }
   const app = <Application {...props} />

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -11,7 +11,8 @@ test('Application renders correctly', () => {
     ...mockRouterProps('/dashboard', {}),
     application: {
       title: 'Cadet',
-      environment: ApplicationEnvironment.Development
+      environment: ApplicationEnvironment.Development,
+      playgroundCode: ''
     }
   }
   const app = <Application {...props} />

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -3,19 +3,12 @@ import * as React from 'react'
 import { shallow } from 'enzyme'
 
 import { mockRouterProps } from '../../mocks/components'
-import { ApplicationEnvironment } from '../../reducers/application'
 import Application, { IApplicationProps } from '../Application'
 
 test('Application renders correctly', () => {
   const props: IApplicationProps = {
     ...mockRouterProps('/dashboard', {}),
-    application: {
-      title: 'Cadet',
-      environment: ApplicationEnvironment.Development
-    },
-    playground: {
-      editorValue: ''
-    }
+    title: 'Cadet'
   }
   const app = <Application {...props} />
   const tree = shallow(app)

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -7,7 +7,7 @@ import { IPlaygroundProps as PlaygroundProps } from '../Playground'
 
 test('Playground renders correctly', () => {
   const props: PlaygroundProps = {
-    editorValue: 'Hello the world',
+    editorValue: '',
     updateCode: (newCode: string) => {
       return
     }

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -2,18 +2,12 @@ import * as React from 'react'
 
 import { shallow } from 'enzyme'
 
-import { mockRouterProps } from '../../mocks/components'
-import { ApplicationEnvironment } from '../../reducers/application'
-import { IApplicationProps } from '../Application'
 import Playground from '../Playground'
+import { IPlaygroundProps as PlaygroundProps } from '../Playground';
 
 test('Playground renders correctly', () => {
-  const props: IApplicationProps = {
-    ...mockRouterProps('/dashboard', {}),
-    application: {
-      title: 'Cadet',
-      environment: ApplicationEnvironment.Development
-    }
+  const props: PlaygroundProps = {
+    initialCode: 'Hello World'
   }
   const app = <Playground {...props} />
   const tree = shallow(app)

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -3,12 +3,14 @@ import * as React from 'react'
 import { shallow } from 'enzyme'
 
 import Playground from '../Playground'
-import { IPlaygroundProps as PlaygroundProps } from '../Playground';
+import { IPlaygroundProps as PlaygroundProps } from '../Playground'
 
 test('Playground renders correctly', () => {
   const props: PlaygroundProps = {
     editorValue: 'Hello the world',
-    updateCode: (newCode : string ) => { return;}
+    updateCode: (newCode: string) => {
+      return
+    }
   }
   const app = <Playground {...props} />
   const tree = shallow(app)

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -2,9 +2,20 @@ import * as React from 'react'
 
 import { shallow } from 'enzyme'
 
+import { mockRouterProps } from '../../mocks/components'
+import { ApplicationEnvironment } from '../../reducers/application'
+import { IApplicationProps } from '../Application'
 import Playground from '../Playground'
 
 test('Playground renders correctly', () => {
-  const tree = shallow(<Playground />)
+  const props: IApplicationProps = {
+    ...mockRouterProps('/dashboard', {}),
+    application: {
+      title: 'Cadet',
+      environment: ApplicationEnvironment.Development
+    }
+  }
+  const app = <Playground {...props} />
+  const tree = shallow(app)
   expect(tree.debug()).toMatchSnapshot()
 })

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -7,7 +7,8 @@ import { IPlaygroundProps as PlaygroundProps } from '../Playground';
 
 test('Playground renders correctly', () => {
   const props: PlaygroundProps = {
-    initialCode: 'Hello World'
+    initialCode: 'Hello the world',
+    updateCode: (newCode : string ) => { return;}
   }
   const app = <Playground {...props} />
   const tree = shallow(app)

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -7,7 +7,7 @@ import { IPlaygroundProps as PlaygroundProps } from '../Playground';
 
 test('Playground renders correctly', () => {
   const props: PlaygroundProps = {
-    initialCode: 'Hello the world',
+    editorValue: 'Hello the world',
     updateCode: (newCode : string ) => { return;}
   }
   const app = <Playground {...props} />

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+
+import { shallow } from 'enzyme'
+
+import Playground from '../Playground'
+
+test('Playground renders correctly', () => {
+  const tree = shallow(<Playground title="Cadet" />)
+  expect(tree.debug()).toMatchSnapshot()
+})

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -5,6 +5,6 @@ import { shallow } from 'enzyme'
 import Playground from '../Playground'
 
 test('Playground renders correctly', () => {
-  const tree = shallow(<Playground title="Cadet" />)
+  const tree = shallow(<Playground />)
   expect(tree.debug()).toMatchSnapshot()
 })

--- a/src/components/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Application.tsx.snap
@@ -6,6 +6,7 @@ exports[`Application renders correctly 1`] = `
   <div className=\\"Application__main\\">
     <Switch>
       <Route path=\\"/dashboard\\" component={[Function: Connect]} />
+      <Route path=\\"/playground\\" component={[Function: Connect]} />
       <Route exact={true} path=\\"/\\" component={[Function: redirectToDashboard]} />
       <Route component={[Function: NotFound]} />
     </Switch>

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NavigationBar renders correctly 1`] = `
 "<Blueprint2.Navbar className=\\"NavigationBar pt-dark\\">
-  <Blueprint2.NavbarGroup align=\\"left\\">
+  <Blueprint2.NavbarGroup className=\\"pt-align-left\\" align=\\"left\\">
     <Blueprint2.NavbarHeading>
       Cadet
     </Blueprint2.NavbarHeading>
@@ -10,6 +10,12 @@ exports[`NavigationBar renders correctly 1`] = `
     <NavLink to=\\"/dashboard\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"dashboard\\" />
       Dashboard
+    </NavLink>
+  </Blueprint2.NavbarGroup>
+  <Blueprint2.NavbarGroup className=\\"pt-align-right\\" align=\\"left\\">
+    <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
+      <Blueprint2.Icon icon=\\"code\\" />
+      Playground
     </NavLink>
   </Blueprint2.NavbarGroup>
 </Blueprint2.Navbar>"

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -5,6 +5,6 @@ exports[`Playground renders correctly 1`] = `
   <h2>
     Playground
   </h2>
-  <ReactAce mode=\\"java\\" theme=\\"github\\" value=\\"Hello the world\\" onChange={[Function: updateCode]} name=\\"brace-editor\\" focus={false} height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+  <ReactAce mode=\\"javascript\\" theme=\\"github\\" value=\\"Hello the world\\" onChange={[Function: updateCode]} name=\\"brace-editor\\" focus={false} height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
 </div>"
 `;

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -5,6 +5,6 @@ exports[`Playground renders correctly 1`] = `
   <h2>
     Playground
   </h2>
-  <ReactAce mode=\\"javascript\\" theme=\\"github\\" value=\\"Hello the world\\" onChange={[Function: updateCode]} name=\\"brace-editor\\" focus={false} height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+  <ReactAce height=\\"90%\\" width=\\"90%\\" mode=\\"javascript\\" theme=\\"github\\" value=\\"\\" onChange={[Function: updateCode]} name=\\"brace-editor\\" focus={false} fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
 </div>"
 `;

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Playground renders correctly 1`] = `
+"<div className=\\"Playground\\">
+  <h2>
+    Playground
+  </h2>
+</div>"
+`;

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -5,7 +5,6 @@ exports[`Playground renders correctly 1`] = `
   <h2>
     Playground
   </h2>
-  <input id=\\"greeting-input\\" type=\\"text\\" />
-  <ReactAce value=\\"\\" onChange={[Function: onChange]} name=\\"brace-editor\\" focus={false} mode=\\"\\" theme=\\"\\" height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+  <ReactAce mode=\\"java\\" theme=\\"github\\" value=\\"Hello the world\\" onChange={[Function: updateCode]} name=\\"brace-editor\\" focus={false} height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
 </div>"
 `;

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -5,6 +5,7 @@ exports[`Playground renders correctly 1`] = `
   <h2>
     Playground
   </h2>
-  <ReactAce name=\\"brace-editor\\" focus={false} mode=\\"\\" theme=\\"\\" height=\\"500px\\" width=\\"500px\\" value=\\"\\" fontSize={12} showGutter={true} onChange={{...}} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+  <input id=\\"greeting-input\\" type=\\"text\\" />
+  <ReactAce value=\\"\\" onChange={[Function: onChange]} name=\\"brace-editor\\" focus={false} mode=\\"\\" theme=\\"\\" height=\\"500px\\" width=\\"500px\\" fontSize={12} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
 </div>"
 `;

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -5,5 +5,6 @@ exports[`Playground renders correctly 1`] = `
   <h2>
     Playground
   </h2>
+  <ReactAce name=\\"brace-editor\\" focus={false} mode=\\"\\" theme=\\"\\" height=\\"500px\\" width=\\"500px\\" value=\\"\\" fontSize={12} showGutter={true} onChange={{...}} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} highlightActiveLine={true} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
 </div>"
 `;

--- a/src/containers/ApplicationContainer.ts
+++ b/src/containers/ApplicationContainer.ts
@@ -5,7 +5,8 @@ import Application, { IApplicationProps } from '../components/Application'
 import { IState } from '../reducers'
 
 const mapStateToProps: MapStateToProps<IState, {}, IApplicationProps> = state => ({
-  application: state.application
+  application: state.application,
+  playground: state.playground
 })
 
 export default withRouter(connect(mapStateToProps)(Application))

--- a/src/containers/ApplicationContainer.ts
+++ b/src/containers/ApplicationContainer.ts
@@ -1,12 +1,17 @@
 import { connect, MapStateToProps } from 'react-redux'
 import { withRouter } from 'react-router'
-
-import Application, { IApplicationProps } from '../components/Application'
+import Application from '../components/Application'
 import { IState } from '../reducers'
 
-const mapStateToProps: MapStateToProps<IState, {}, IApplicationProps> = state => ({
-  application: state.application,
-  playground: state.playground
+/**
+ * Provides the title of the application for display.
+ * An object with the relevant properties must be
+ * returned instead of an object of type @type {IApplicationProps},
+ * as the routing properties of @type {RouteComponentProps} are
+ * provided using the withRouter() method below.
+ */
+const mapStateToProps: MapStateToProps<{ title: string }, {}, IState> = state => ({
+  title: state.application.title
 })
 
 export default withRouter(connect(mapStateToProps)(Application))

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -2,7 +2,10 @@ import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { updateEditorValue } from '../actions/playground'
-import { default as PlaygroundComponent, IPlaygroundProps as PlaygroundProps} from '../components/Playground'
+import {
+  default as PlaygroundComponent,
+  IPlaygroundProps as PlaygroundProps
+} from '../components/Playground'
 import { IState } from '../reducers'
 
 type StateProps = Pick<PlaygroundProps, 'editorValue'>
@@ -14,11 +17,11 @@ const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   }
 }
 
-const mapDispatchToProps : MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) => {
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) => {
   return {
     updateCode: (newCode: string) => {
-      dispatch(updateEditorValue(newCode));
-    },
+      dispatch(updateEditorValue(newCode))
+    }
   }
 }
 

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -11,12 +11,19 @@ import { IState } from '../reducers'
 type StateProps = Pick<PlaygroundProps, 'editorValue'>
 type DispatchProps = Pick<PlaygroundProps, 'updateCode'>
 
+/** Provides the editorValue of the `IPlaygroundState` of the `IState` as a
+ * `StateProps` to the Playground component
+ */
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   return {
     editorValue: state.playground.editorValue
   }
 }
 
+/** Provides a callback function `updateCode` which supplies the `Action`
+ * `updateEditorValue` with `newCode`, the updated contents of the react-ace
+ * editor.
+ */
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) => {
   return {
     updateCode: (newCode: string) => {

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -1,14 +1,12 @@
-import * as Actions from '../actions/index'
-import PlaygroundComponent from '../components/Playground';
-
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux'
-import { Dispatch } from 'redux';
-import { IPlaygroundProps as PlaygroundProps} from '../components/Playground';
-import { IState } from '../reducers';
+import { Dispatch } from 'redux'
 
+import { updateEditorValue } from '../actions/playground'
+import { default as PlaygroundComponent, IPlaygroundProps as PlaygroundProps} from '../components/Playground'
+import { IState } from '../reducers'
 
-type StateProps = Pick<PlaygroundProps, 'editorValue'>;
-type DispatchProps = Pick<PlaygroundProps, 'updateCode'>;
+type StateProps = Pick<PlaygroundProps, 'editorValue'>
+type DispatchProps = Pick<PlaygroundProps, 'updateCode'>
 
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   return {
@@ -19,9 +17,9 @@ const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
 const mapDispatchToProps : MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) => {
   return {
     updateCode: (newCode: string) => {
-      dispatch(Actions.updatePlaygroundCode(newCode));
+      dispatch(updateEditorValue(newCode));
     },
-  };
-};
+  }
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(PlaygroundComponent)

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -1,14 +1,27 @@
-import { connect, MapStateToProps } from 'react-redux'
-
-import { IPlaygroundProps as PlaygroundProps } from '../components/Playground';
+import * as Actions from '../actions/index'
 import PlaygroundComponent from '../components/Playground';
+
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux'
+import { Dispatch } from 'redux';
+import { IPlaygroundProps as PlaygroundProps} from '../components/Playground';
 import { IState } from '../reducers';
 
-const mapStateToProps: MapStateToProps<PlaygroundProps, {}, IState> = state => {
-  console.log('MapStateToProps with inittialCode ' + state.application.playgroundCode)
+
+type StateProps = Pick<PlaygroundProps, 'initialCode'>;
+type DispatchProps = Pick<PlaygroundProps, 'updateCode'>;
+
+const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   return {
-  initialCode: state.application.playgroundCode
-}
+    initialCode: state.application.playgroundCode
+  }
 }
 
-export default connect(mapStateToProps)(PlaygroundComponent)
+const mapDispatchToProps : MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) => {
+  return {
+    updateCode: (newCode: string) => {
+      dispatch(Actions.updatePlaygroundCode(newCode));
+    },
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(PlaygroundComponent)

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -1,12 +1,14 @@
 import { connect, MapStateToProps } from 'react-redux'
 
-import { IApplicationProps } from '../components/Application'
-import { IState } from '../reducers'
+import { IPlaygroundProps as PlaygroundProps } from '../components/Playground';
+import PlaygroundComponent from '../components/Playground';
+import { IState } from '../reducers';
 
-import Playground from '../components/Playground'
+const mapStateToProps: MapStateToProps<PlaygroundProps, {}, IState> = state => {
+  console.log('MapStateToProps with inittialCode ' + state.application.playgroundCode)
+  return {
+  initialCode: state.application.playgroundCode
+}
+}
 
-const mapStateToProps: MapStateToProps<IState, {}, IApplicationProps> = state => ({
-  application: state.application
-})
-
-export default connect(mapStateToProps)(Playground)
+export default connect(mapStateToProps)(PlaygroundComponent)

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -10,7 +10,7 @@ type DispatchProps = Pick<PlaygroundProps, 'updateCode'>
 
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   return {
-    editorValue: state.application.playgroundCode
+    editorValue: state.playground.editorValue
   }
 }
 

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux'
+
+import Playground from '../components/Playground'
+
+export default connect()(Playground)

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -1,5 +1,12 @@
-import { connect } from 'react-redux'
+import { connect, MapStateToProps } from 'react-redux'
+
+import { IApplicationProps } from '../components/Application'
+import { IState } from '../reducers'
 
 import Playground from '../components/Playground'
 
-export default connect()(Playground)
+const mapStateToProps: MapStateToProps<IState, {}, IApplicationProps> = state => ({
+  application: state.application
+})
+
+export default connect(mapStateToProps)(Playground)

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -7,12 +7,12 @@ import { IPlaygroundProps as PlaygroundProps} from '../components/Playground';
 import { IState } from '../reducers';
 
 
-type StateProps = Pick<PlaygroundProps, 'initialCode'>;
+type StateProps = Pick<PlaygroundProps, 'editorValue'>;
 type DispatchProps = Pick<PlaygroundProps, 'updateCode'>;
 
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => {
   return {
-    initialCode: state.application.playgroundCode
+    editorValue: state.application.playgroundCode
   }
 }
 

--- a/src/mocks/store.ts
+++ b/src/mocks/store.ts
@@ -9,7 +9,8 @@ export function mockInitialStore<P>(): Store<IState> {
   const state: IState = {
     application: {
       title: 'Cadet',
-      environment: ApplicationEnvironment.Development
+      environment: ApplicationEnvironment.Development,
+      playgroundCode: 'Hello World'
     }
   }
   return createStore(state)

--- a/src/mocks/store.ts
+++ b/src/mocks/store.ts
@@ -9,8 +9,10 @@ export function mockInitialStore<P>(): Store<IState> {
   const state: IState = {
     application: {
       title: 'Cadet',
-      environment: ApplicationEnvironment.Development,
-      playgroundCode: 'Hello World'
+      environment: ApplicationEnvironment.Development
+    },
+    playground: {
+      editorValue: ''
     }
   }
   return createStore(state)

--- a/src/reducers/__tests__/__snapshots__/application.ts.snap
+++ b/src/reducers/__tests__/__snapshots__/application.ts.snap
@@ -3,6 +3,6 @@
 exports[`initial state should match a snapshot 1`] = `
 Object {
   "environment": "test",
-  "title": "Conveyor",
+  "title": "Cadet",
 }
 `;

--- a/src/reducers/__tests__/__snapshots__/application.ts.snap
+++ b/src/reducers/__tests__/__snapshots__/application.ts.snap
@@ -3,6 +3,7 @@
 exports[`initial state should match a snapshot 1`] = `
 Object {
   "environment": "test",
+  "playgroundCode": "Hello the world",
   "title": "Cadet",
 }
 `;

--- a/src/reducers/__tests__/__snapshots__/application.ts.snap
+++ b/src/reducers/__tests__/__snapshots__/application.ts.snap
@@ -3,7 +3,6 @@
 exports[`initial state should match a snapshot 1`] = `
 Object {
   "environment": "test",
-  "playgroundCode": "Hello the world",
   "title": "Cadet",
 }
 `;

--- a/src/reducers/application.ts
+++ b/src/reducers/application.ts
@@ -1,5 +1,4 @@
-import { Reducer } from 'redux'
-import { IUpdatePlaygroundCodeAction as UpdatePlaygroundCodeAction, UPDATE_PLAYGROUND_CODE } from '../actions/index'
+import { Action, Reducer } from 'redux'
 
 export enum ApplicationEnvironment {
   Development = 'development',
@@ -10,7 +9,6 @@ export enum ApplicationEnvironment {
 export interface IApplicationState {
   title: string
   environment: ApplicationEnvironment
-  playgroundCode: string
 }
 
 const currentEnvironment = (): ApplicationEnvironment => {
@@ -27,22 +25,8 @@ const currentEnvironment = (): ApplicationEnvironment => {
 const defaultState: IApplicationState = {
   title: 'Cadet',
   environment: currentEnvironment(),
-  playgroundCode: 'Hello the world'
 }
 
-type Action = UpdatePlaygroundCodeAction;
-
-
 export const reducer: Reducer<IApplicationState> = (state = defaultState, action: Action) => {
-  switch (action.type) {
-
-  case UPDATE_PLAYGROUND_CODE:
-    return {
-      ...state,
-      playgroundCode : action.playgroundCode
-    };
-
-  default:
-    return state;
-  }
+  return state;
 };

--- a/src/reducers/application.ts
+++ b/src/reducers/application.ts
@@ -1,4 +1,5 @@
-import { Action, Reducer } from 'redux'
+import { Reducer } from 'redux'
+import { IUpdatePlaygroundCodeAction as UpdatePlaygroundCodeAction, UPDATE_PLAYGROUND_CODE } from '../actions/index'
 
 export enum ApplicationEnvironment {
   Development = 'development',
@@ -29,6 +30,19 @@ const defaultState: IApplicationState = {
   playgroundCode: 'Hello the world'
 }
 
+type Action = UpdatePlaygroundCodeAction;
+
+
 export const reducer: Reducer<IApplicationState> = (state = defaultState, action: Action) => {
-  return state
-}
+  switch (action.type) {
+
+  case UPDATE_PLAYGROUND_CODE:
+    return {
+      ...state,
+      playgroundCode : action.playgroundCode
+    };
+
+  default:
+    return state;
+  }
+};

--- a/src/reducers/application.ts
+++ b/src/reducers/application.ts
@@ -24,9 +24,9 @@ const currentEnvironment = (): ApplicationEnvironment => {
 
 const defaultState: IApplicationState = {
   title: 'Cadet',
-  environment: currentEnvironment(),
+  environment: currentEnvironment()
 }
 
 export const reducer: Reducer<IApplicationState> = (state = defaultState, action: Action) => {
-  return state;
-};
+  return state
+}

--- a/src/reducers/application.ts
+++ b/src/reducers/application.ts
@@ -9,6 +9,7 @@ export enum ApplicationEnvironment {
 export interface IApplicationState {
   title: string
   environment: ApplicationEnvironment
+  playgroundCode: string
 }
 
 const currentEnvironment = (): ApplicationEnvironment => {
@@ -24,7 +25,8 @@ const currentEnvironment = (): ApplicationEnvironment => {
 
 const defaultState: IApplicationState = {
   title: 'Cadet',
-  environment: currentEnvironment()
+  environment: currentEnvironment(),
+  playgroundCode: 'Hello the world'
 }
 
 export const reducer: Reducer<IApplicationState> = (state = defaultState, action: Action) => {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,9 +1,12 @@
 import { IApplicationState, reducer as application } from './application'
+import { IPlaygroundState, reducer as playground } from './playground'
 
 export interface IState {
   readonly application: IApplicationState
+  readonly playground: IPlaygroundState
 }
 
 export default {
-  application
+  application,
+  playground
 }

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -16,7 +16,6 @@ export const reducer: Reducer<IPlaygroundState> = (state = defaultState, action:
         ...state,
         editorValue: (action as IUpdateEditorValue).newEditorValue
       }
-
     default:
       return state
   }

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -1,0 +1,24 @@
+import { Action, Reducer } from 'redux'
+import { IUpdateEditorValue, UPDATE_EDITOR_VALUE } from '../actions/playground'
+
+export interface IPlaygroundState {
+  editorValue: string
+}
+
+const defaultState: IPlaygroundState = {
+  editorValue: ''
+}
+
+export const reducer: Reducer<IPlaygroundState> = (state = defaultState, action: Action) => {
+  switch (action.type) {
+
+  case UPDATE_EDITOR_VALUE:
+    return {
+      ...state,
+      editorValue : (<IUpdateEditorValue> action).newEditorValue
+    };
+
+  default:
+    return state;
+  }
+};

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -1,14 +1,26 @@
 import { Action, Reducer } from 'redux'
 import { IUpdateEditorValue, UPDATE_EDITOR_VALUE } from '../actions/playground'
 
+/**
+ * A state for the playground container
+ * @property editorValue - The string content of the react-ace editor
+ */
 export interface IPlaygroundState {
   editorValue: string
 }
 
+/**
+ * The default (initial) state of the `IPlaygroundState`
+ */
 const defaultState: IPlaygroundState = {
   editorValue: ''
 }
 
+/**
+ * The reducer for `IPlaygroundState`
+ *
+ * UPDATE_EDITOR_VALUE: Update the `editorValue` property
+ */
 export const reducer: Reducer<IPlaygroundState> = (state = defaultState, action: Action) => {
   switch (action.type) {
     case UPDATE_EDITOR_VALUE:

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -11,14 +11,13 @@ const defaultState: IPlaygroundState = {
 
 export const reducer: Reducer<IPlaygroundState> = (state = defaultState, action: Action) => {
   switch (action.type) {
+    case UPDATE_EDITOR_VALUE:
+      return {
+        ...state,
+        editorValue: (action as IUpdateEditorValue).newEditorValue
+      }
 
-  case UPDATE_EDITOR_VALUE:
-    return {
-      ...state,
-      editorValue : (<IUpdateEditorValue> action).newEditorValue
-    };
-
-  default:
-    return state;
+    default:
+      return state
   }
-};
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,4 +2,5 @@
 @import "~@blueprintjs/core/lib/css/blueprint.css";
 @import "./blueprint.css";
 @import "./application.css";
+@import "./playground.css";
 @import "./navigationBar.css";

--- a/src/styles/playground.css
+++ b/src/styles/playground.css
@@ -1,0 +1,11 @@
+.Playground {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    width: 100vh;
+}
+
+.Playground__main {
+    margin-top: 1rem;
+    margin-left: 1rem;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,8 @@
 {
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "rules": {
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-console": false
   },
   "linterOptions": {
     "exclude": [

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,7 @@
 {
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "rules": {
-    "object-literal-sort-keys": false,
-    "no-console": false
+    "object-literal-sort-keys": false
   },
   "linterOptions": {
     "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,10 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -2189,6 +2193,10 @@ detect-port-alt@1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff-match-patch@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.1.tgz#d5f880213d82fbc124d2b95111fb3c033dbad7fa"
 
 diff@^3.2.0:
   version "3.5.0"
@@ -4549,6 +4557,14 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isequal@^4.1.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.isfunction@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
@@ -5819,7 +5835,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5972,6 +5988,16 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-ace@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-6.1.1.tgz#c8339b4f0a27401bff53f477f125d3d7eac2a090"
+  dependencies:
+    brace "^0.11.0"
+    diff-match-patch "^1.0.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.1.1"
+    prop-types "^15.5.8"
 
 react-dev-utils@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Addresses #2, _'Scaffold Playground Layout'_.

- Playground is a child of application
- Playground is associated with new state `IPlaygroundState` which is a child of `IState`
- `IPlaygroundState` stores the contents of the playground editor, allowing it to persist between pages
- Use the library `react-ace` to implement the editor