### PR TITLE
Restrict conditions to booleans values, for IfStatements and ConditonalExpression

### DIFF
--- a/src/slang/interpreter.ts
+++ b/src/slang/interpreter.ts
@@ -351,6 +351,12 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
   *IfStatement(node: es.IfStatement, context: Context) {
     const test = yield* evaluate(node.test, context)
+    const error = rttc.checkIfStatement(context, test)
+    if (error) {
+      handleError(context, error)
+      return undefined
+    }
+
     if (test) {
       return yield* evaluate(node.consequent, context)
     } else if (node.alternate) {

--- a/src/slang/utils/__tests__/rttc.ts
+++ b/src/slang/utils/__tests__/rttc.ts
@@ -1,6 +1,6 @@
 import { BinaryOperator, UnaryOperator } from 'estree'
 import { mockClosure, mockRuntimeContext } from '../../../mocks/context'
-import { checkBinaryExpression, checkLogicalExpression, checkUnaryExpression } from '../rttc'
+import * as rttc from '../rttc'
 
 const num = 0
 const bool = true
@@ -11,7 +11,7 @@ test('Valid unary type combinations are OK', () => {
   const operatorValue = [['!', bool], ['+', num], ['-', num]]
   const context = mockRuntimeContext()
   const errors = operatorValue.map(opVals => {
-    return checkUnaryExpression(context, opVals[0] as UnaryOperator, opVals[1])
+    return rttc.checkUnaryExpression(context, opVals[0] as UnaryOperator, opVals[1])
   })
   errors.map(error => expect(error).toBe(undefined))
 })
@@ -30,7 +30,7 @@ test('Invalid unary type combinations return TypeError', () => {
   ]
   const context = mockRuntimeContext()
   const errors = operatorValue.map(opVals => {
-    return checkUnaryExpression(context, opVals[0] as UnaryOperator, opVals[1])
+    return rttc.checkUnaryExpression(context, opVals[0] as UnaryOperator, opVals[1])
   })
   errors.map(error => expect(error).toBeDefined())
 })
@@ -47,7 +47,7 @@ test('Valid binary type combinations are OK for +', () => {
   ]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
+    return rttc.checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
   })
   errors.map(error => expect(error).toBe(undefined))
 })
@@ -101,7 +101,7 @@ test('Invalid binary type combinations for (-|*|/|%) return TypeError', () => {
   ]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
+    return rttc.checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
   })
   errors.map(error => expect(error).toBeDefined())
 })
@@ -119,7 +119,7 @@ test('Valid binary type combinations are OK for (===|!==)', () => {
   ]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
+    return rttc.checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
   })
   errors.map(error => expect(error).toBe(undefined))
 })
@@ -143,7 +143,7 @@ test('Invalid binary type combinations for (<|>|<==|>==) return TypeError', () =
   ]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
+    return rttc.checkBinaryExpression(context, opVals[0] as BinaryOperator, opVals[1], opVals[2])
   })
   errors.map(error => expect(error).toBeDefined())
 })
@@ -152,7 +152,7 @@ test('Valid logical type combinations are OK', () => {
   const operatorValues = [[bool, bool], [bool, bool]]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkLogicalExpression(context, opVals[0], opVals[1])
+    return rttc.checkLogicalExpression(context, opVals[0], opVals[1])
   })
   errors.map(error => expect(error).toBe(undefined))
 })
@@ -169,7 +169,21 @@ test('Invalid logical type combinations return TypeError', () => {
   ]
   const context = mockRuntimeContext()
   const errors = operatorValues.map(opVals => {
-    return checkLogicalExpression(context, opVals[0], opVals[1])
+    return rttc.checkLogicalExpression(context, opVals[0], opVals[1])
   })
+  errors.map(error => expect(error).toBeDefined())
+})
+
+test('Valid ternary/if test expressions are OK', () => {
+  const operatorValues = [bool]
+  const context = mockRuntimeContext()
+  const errors = operatorValues.map(opVal => rttc.checkIfStatement(context, opVal))
+  errors.map(error => expect(error).toBe(undefined))
+})
+
+test('Invalid ternary/if test expressions return TypeError', () => {
+  const operatorValues = [num, str, func]
+  const context = mockRuntimeContext()
+  const errors = operatorValues.map(opVal => rttc.checkIfStatement(context, opVal))
   errors.map(error => expect(error).toBeDefined())
 })

--- a/src/slang/utils/rttc.ts
+++ b/src/slang/utils/rttc.ts
@@ -136,7 +136,5 @@ export const checkLogicalExpression = (context: Context, left: Value, right: Val
 
 export const checkIfStatement = (context: Context, test: Value) => {
   const node = context.runtime.nodes[0]
-  return isBool(test)
-    ? undefined
-    : new TypeError(node, ' as condition', 'boolean', typeOf(test))
+  return isBool(test) ? undefined : new TypeError(node, ' as condition', 'boolean', typeOf(test))
 }

--- a/src/slang/utils/rttc.ts
+++ b/src/slang/utils/rttc.ts
@@ -133,3 +133,10 @@ export const checkLogicalExpression = (context: Context, left: Value, right: Val
     return
   }
 }
+
+export const checkIfStatement = (context: Context, test: Value) => {
+  const node = context.runtime.nodes[0]
+  return isBool(test)
+    ? undefined
+    : new TypeError(node, ' as condition', 'boolean', typeOf(test))
+}


### PR DESCRIPTION
This PR depends on #24 as it uses the convenience function `isBool` and test file `src/slang/utils/__tests__rttc.ts`.

---

### Summary

- In the programs `a ? b : c;` or `if (a) { 1; } else { 0; }`, `a` must be a boolean value, or a error is raised, and the program is stopped.

### Issues fixed

- #26 