### PR TITLE
Fix some peeves from yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coverage": "./scripts/coverage-fix.sh do && react-scripts-ts test --env=jsdom --coverage && ./scripts/coverage-fix.sh undo",
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
     "format:ci": "prettier --list-different 'src/**/*.{ts,tsx}'",
-    "start-js": "react-scripts-ts start",
+    "start-js": "rm -r coverage; BROWSER=none react-scripts-ts start",
     "start": "npm-run-all -p watch-css start-js",
     "test": "react-scripts-ts test --env=jsdom",
     "update-ui-snapshots": "jest --updateSnapshot",


### PR DESCRIPTION
- coverage folder generated by yarn coverage contains bitwise operators that would cause tslint to raise an error.
- by default, yarn start always opens a new browser tab/window

I have some doubts about a one-line change PR, but the effects are quite noticeable, and this doesn't really fit anywhere else...