### PR TITLE
Add green screen mode to playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "^16.3.1",
     "react-ace": "^6.1.1",
     "react-dom": "^16.3.1",
+    "react-hotkeys": "^1.1.4",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react'
+import { HotKeys } from 'react-hotkeys'
 
 import WorkspaceContainer from '../containers/workspace'
 
 const Playground: React.SFC<{}> = () => {
   return (
-    <div className="Playground pt-dark">
+    <HotKeys className="Playground pt-dark" keyMap={keyMap}>
       <WorkspaceContainer />
-    </div>
+    </HotKeys>
   )
+}
+
+const keyMap = {
+  goGreen: 'h u l k'
 }
 
 export default Playground

--- a/src/components/__tests__/__snapshots__/Playground.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Playground.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Playground renders correctly 1`] = `
-"<div className=\\"Playground pt-dark\\">
+"<HotKeys className=\\"Playground pt-dark\\" keyMap={{...}}>
   <Connect(Workspace) />
-</div>"
+</HotKeys>"
 `;

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import AceEditor from 'react-ace'
+import { HotKeys } from 'react-hotkeys'
 
 import 'brace/mode/javascript'
 import 'brace/theme/cobalt'
@@ -20,7 +21,7 @@ export interface IEditorProps {
 class Editor extends React.Component<IEditorProps, {}> {
   public render() {
     return (
-      <div className="Editor">
+      <HotKeys className="Editor" handlers={handlers}>
         <div className="row editor-react-ace">
           <AceEditor
             className="react-ace"
@@ -44,9 +45,14 @@ class Editor extends React.Component<IEditorProps, {}> {
             highlightActiveLine={false}
           />
         </div>
-      </div>
+      </HotKeys>
     )
   }
+}
+
+/* Override handler, so does not trigger when focus is in editor */
+const handlers = {
+  goGreen: () => {}
 }
 
 export default Editor

--- a/src/components/workspace/Repl.tsx
+++ b/src/components/workspace/Repl.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@blueprintjs/core'
 import * as React from 'react'
+import { HotKeys } from 'react-hotkeys'
 
 import { InterpreterOutput } from '../../reducers/states'
 import { parseError, toString } from '../../slang'
@@ -42,9 +43,9 @@ class Repl extends React.Component<IReplProps, {}> {
       <div className="Repl">
         <div className="repl-output-parent">
           {cards}
-          <div className="repl-input-parent row pt-card pt-elevation-0">
+          <HotKeys className="repl-input-parent row pt-card pt-elevation-0" handlers={handlers}>
             <ReplInput {...inputProps} />
-          </div>
+          </HotKeys>
           <div
             ref={el => {
               this.replBottom = el as HTMLDivElement
@@ -104,6 +105,11 @@ export const Output: React.SFC<IOutputProps> = props => {
     default:
       return <Card>''</Card>
   }
+}
+
+/* Override handler, so does not trigger when focus is in editor */
+const handlers = {
+  goGreen: () => {}
 }
 
 export default Repl

--- a/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Editor renders correctly 1`] = `
-"<div className=\\"Editor\\">
+"<HotKeys className=\\"Editor\\" handlers={{...}}>
   <div className=\\"row editor-react-ace\\">
     <ReactAce className=\\"react-ace\\" mode=\\"javascript\\" theme=\\"cobalt\\" value=\\"\\" onChange={[Function: handleEditorValueChange]} height=\\"100%\\" commands={{...}} width=\\"100%\\" fontSize={14} highlightActiveLine={false} name=\\"brace-editor\\" focus={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
   </div>
-</div>"
+</HotKeys>"
 `;

--- a/src/components/workspace/__tests__/__snapshots__/Repl.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/Repl.tsx.snap
@@ -44,9 +44,9 @@ exports[`Repl renders correctly 1`] = `
     <Component output={{...}} />
     <Component output={{...}} />
     <Component output={{...}} />
-    <div className=\\"repl-input-parent row pt-card pt-elevation-0\\">
+    <HotKeys className=\\"repl-input-parent row pt-card pt-elevation-0\\" handlers={{...}}>
       <ReplInput output={{...}} replValue=\\"\\" handleReplValueChange={[Function: handleReplValueChange]} handleReplEval={[Function: handleReplEval]} handleReplOutputClear={[Function: handleReplOutputClear]} />
-    </div>
+    </HotKeys>
     <div />
   </div>
 </div>"

--- a/src/components/workspace/index.tsx
+++ b/src/components/workspace/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { HotKeys } from 'react-hotkeys'
 
 import Resizable from 're-resizable'
 
@@ -14,7 +15,7 @@ export interface IWorkspaceProps {
 class Workspace extends React.Component<IWorkspaceProps, {}> {
   public render() {
     return (
-      <div className="workspace">
+      <HotKeys className="workspace" handlers={handlers}>
         <ControlBarContainer />
         <div className="row ide-content-parent">
           <Resizable
@@ -42,9 +43,13 @@ class Workspace extends React.Component<IWorkspaceProps, {}> {
             <ReplContainer />
           </div>
         </div>
-      </div>
+      </HotKeys>
     )
   }
+}
+
+const handlers = {
+  goGreen: () => require('../../styles/workspace-green.css')
 }
 
 export default Workspace

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -128,3 +128,8 @@ $code-color-error: #ff4444;
     }
   }
 }
+
+/* otherwise, a think outline will show on click due to react-hotkeys */
+.workspace:focus {
+  outline: 0;
+}

--- a/src/styles/workspace-green.scss
+++ b/src/styles/workspace-green.scss
@@ -9,12 +9,17 @@ $dark-green: #00e000;
   background: $pure-green !important;
 }
 
-.editor-react-ace {
-  border: 0.1rem solid $dark-green !important;
-}
-
 #brace-editor {
   background: $pure-green !important;
+}
+
+.ace_print-margin {
+  background: $dark-green !important;
+}
+
+/* editor specific */
+.editor-react-ace {
+  border: 0.1rem solid $dark-green !important;
 }
 
 .ace_gutter {
@@ -25,6 +30,7 @@ $dark-green: #00e000;
   background: $pure-green !important;
 }
 
+/* repl specific */
 .pt-card {
   background: $pure-green !important;
   box-shadow: none !important;

--- a/src/styles/workspace-green.scss
+++ b/src/styles/workspace-green.scss
@@ -1,0 +1,27 @@
+$pure-green: #00ff00;
+$dark-green: #00f000;
+
+.NavigationBar {
+  display: none !important;
+}
+
+.Application {
+  background: $pure-green !important;
+}
+
+#brace-editor {
+  background: $dark-green !important;
+}
+
+.ace_gutter {
+  background: $dark-green !important;
+}
+
+.ace_gutter-layer {
+  background: $dark-green !important;
+}
+
+.pt-card {
+  background: $dark-green !important;
+  box-shadow: none !important;
+}

--- a/src/styles/workspace-green.scss
+++ b/src/styles/workspace-green.scss
@@ -1,5 +1,5 @@
 $pure-green: #00ff00;
-$dark-green: #00f000;
+$dark-green: #00e000;
 
 .NavigationBar {
   display: none !important;
@@ -9,19 +9,24 @@ $dark-green: #00f000;
   background: $pure-green !important;
 }
 
+.editor-react-ace {
+  border: 0.1rem solid $dark-green !important;
+}
+
 #brace-editor {
-  background: $dark-green !important;
+  background: $pure-green !important;
 }
 
 .ace_gutter {
-  background: $dark-green !important;
+  background: $pure-green !important;
 }
 
 .ace_gutter-layer {
-  background: $dark-green !important;
+  background: $pure-green !important;
 }
 
 .pt-card {
-  background: $dark-green !important;
+  background: $pure-green !important;
   box-shadow: none !important;
+  border: 0.1rem solid $dark-green !important;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4799,13 +4799,21 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash.isequal@^4.1.1:
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+
+lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isfunction@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -5115,6 +5123,10 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mousetrap@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.1.tgz#2a085f5c751294c75e7e81f6ec2545b29cbf42d9"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6404,6 +6416,16 @@ react-dom@^16.3.1:
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+
+react-hotkeys@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-1.1.4.tgz#a0712aa2e0c03a759fd7885808598497a4dace72"
+  dependencies:
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isobject "^3.0.2"
+    mousetrap "^1.5.2"
+    prop-types "^15.6.0"
 
 react-is@^16.3.1:
   version "16.3.1"


### PR DESCRIPTION
### Features

- Add a green screen mode to the playground
- Green screen mode hides the navigation bar, and changes backgrounds to `#00ff00`
- Some elements have a border of `#00e000` dark green. It is otherwise difficult to tell where things like the editor and the repl end
- Green screen mode is activated with a sequence of keys while focus is in the playground (currently, the sequence of keys is _'hulk'_)
- Green screen mode is irreversible for the page (refresh to return to the default colour scheme)

![2018-06-01-124413_1920x1080_scrot](https://user-images.githubusercontent.com/22320312/40821484-e7a9f788-6599-11e8-9d27-1c4195bd4d78.png)
