### PR TITLE
Scaffold admin

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 
+import AdminContainer from '../containers/admin'
 import Device from '../containers/device'
 import Game from '../containers/GameContainer'
 import NavigationBar from './NavigationBar'
@@ -21,6 +21,7 @@ const Application: React.SFC<IApplicationProps> = props => {
       <div className="Application__main">
         <Switch>
           <Route path="/device" component={Device} />
+          <Route path="/admin" component={AdminContainer} />
           <Route path="/playground" component={Playground} />
           <Route path="/game" component={Game} />
           <Route exact={true} path="/" component={redirectToGame} />

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -28,6 +28,14 @@ const NavigationBar: React.SFC<INavigationBarProps> = ({ title }) => (
         <Icon icon={IconNames.DASHBOARD} />
         Device
       </NavLink>
+      <NavLink
+        to="/admin"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="eye-open" />
+        Admin
+      </NavLink>
     </NavbarGroup>
 
     <NavbarGroup className="pt-align-right">

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -33,7 +33,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = ({ title }) => (
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
-        <Icon icon="eye-open" />
+        <Icon icon={IconNames.EYE_OPEN} />
         Admin
       </NavLink>
     </NavbarGroup>

--- a/src/components/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Application.tsx.snap
@@ -6,6 +6,7 @@ exports[`Application renders correctly 1`] = `
   <div className=\\"Application__main\\">
     <Switch>
       <Route path=\\"/device\\" component={[Function: Connect]} />
+      <Route path=\\"/admin\\" component={[Function: Connect]} />
       <Route path=\\"/playground\\" component={[Function: Playground]} />
       <Route path=\\"/game\\" component={[Function: Connect]} />
       <Route exact={true} path=\\"/\\" component={[Function: redirectToGame]} />

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -15,6 +15,10 @@ exports[`NavigationBar renders correctly 1`] = `
       <Blueprint2.Icon icon=\\"dashboard\\" />
       Device
     </NavLink>
+    <NavLink to=\\"/admin\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
+      <Blueprint2.Icon icon=\\"eye-open\\" />
+      Admin
+    </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup className=\\"pt-align-right\\" align=\\"left\\">
     <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">

--- a/src/components/admin/AnnouncementManager.tsx
+++ b/src/components/admin/AnnouncementManager.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+class AnnouncementManager extends React.Component<{}, {}> {
+  public render() {
+    return <h2> Announcement Manager </h2>
+  }
+}
+
+export default AnnouncementManager

--- a/src/components/admin/AssessmentManager.tsx
+++ b/src/components/admin/AssessmentManager.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+class AssessmentManager extends React.Component<{}, {}> {
+  public render() {
+    return <h2> Assessment Manager </h2>
+  }
+}
+
+export default AssessmentManager

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -15,6 +15,14 @@ const NavigationBar: React.SFC<{}> = () => (
         Announcements
       </NavLink>
       <NavLink
+        to="/admin/assessments"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="tick" />
+        Assessments
+      </NavLink>
+      <NavLink
         to="/admin/materials"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -7,42 +7,7 @@ const NavigationBar: React.SFC<{}> = () => (
   <Navbar className="NavigationBar">
     <NavbarGroup align={Alignment.LEFT}>
       <NavLink
-        to="/device/missions"
-        activeClassName="pt-active"
-        className="NavigationBar__link pt-button pt-minimal"
-      >
-        <Icon icon="flame" />
-        Missions
-      </NavLink>
-      <NavLink
-        to="/device/sidequests"
-        activeClassName="pt-active"
-        className="NavigationBar__link pt-button pt-minimal"
-      >
-        <Icon icon="lightbulb" />
-        Sidequests
-      </NavLink>
-      <NavLink
-        to="/device/paths"
-        activeClassName="pt-active"
-        className="NavigationBar__link pt-button pt-minimal"
-      >
-        <Icon icon="predictive-analysis" />
-        Paths
-      </NavLink>
-      <NavLink
-        to="/device/contests"
-        activeClassName="pt-active"
-        className="NavigationBar__link pt-button pt-minimal"
-      >
-        <Icon icon="comparison" />
-        Contests
-      </NavLink>
-    </NavbarGroup>
-
-    <NavbarGroup align={Alignment.RIGHT}>
-      <NavLink
-        to="/device/announcements"
+        to="/admin/announcements"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
@@ -50,20 +15,12 @@ const NavigationBar: React.SFC<{}> = () => (
         Announcements
       </NavLink>
       <NavLink
-        to="/device/materials"
+        to="/admin/materials"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon="folder-open" />
         Materials
-      </NavLink>
-      <NavLink
-        to="/device/status"
-        activeClassName="pt-active"
-        className="NavigationBar__link pt-button pt-minimal"
-      >
-        <Icon icon="user" />
-        Profile
       </NavLink>
     </NavbarGroup>
   </Navbar>

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { Alignment, Icon, Navbar, NavbarGroup } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
 import { NavLink } from 'react-router-dom'
 
 const NavigationBar: React.SFC<{}> = () => (
@@ -11,7 +12,7 @@ const NavigationBar: React.SFC<{}> = () => (
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
-        <Icon icon="feed" />
+        <Icon icon={IconNames.FEED} />
         Announcements
       </NavLink>
       <NavLink
@@ -19,7 +20,7 @@ const NavigationBar: React.SFC<{}> = () => (
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
-        <Icon icon="tick" />
+        <Icon icon={IconNames.TICK} />
         Assessments
       </NavLink>
       <NavLink
@@ -27,7 +28,7 @@ const NavigationBar: React.SFC<{}> = () => (
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
-        <Icon icon="folder-open" />
+        <Icon icon={IconNames.FOLDER_OPEN} />
         Materials
       </NavLink>
     </NavbarGroup>

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+
+import { Alignment, Icon, Navbar, NavbarGroup } from '@blueprintjs/core'
+import { NavLink } from 'react-router-dom'
+
+const NavigationBar: React.SFC<{}> = () => (
+  <Navbar className="NavigationBar">
+    <NavbarGroup align={Alignment.LEFT}>
+      <NavLink
+        to="/device/missions"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="flame" />
+        Missions
+      </NavLink>
+      <NavLink
+        to="/device/sidequests"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="lightbulb" />
+        Sidequests
+      </NavLink>
+      <NavLink
+        to="/device/paths"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="predictive-analysis" />
+        Paths
+      </NavLink>
+      <NavLink
+        to="/device/contests"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="comparison" />
+        Contests
+      </NavLink>
+    </NavbarGroup>
+
+    <NavbarGroup align={Alignment.RIGHT}>
+      <NavLink
+        to="/device/announcements"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="feed" />
+        Announcements
+      </NavLink>
+      <NavLink
+        to="/device/materials"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="folder-open" />
+        Materials
+      </NavLink>
+      <NavLink
+        to="/device/status"
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+      >
+        <Icon icon="user" />
+        Profile
+      </NavLink>
+    </NavbarGroup>
+  </Navbar>
+)
+
+export default NavigationBar

--- a/src/components/admin/index.tsx
+++ b/src/components/admin/index.tsx
@@ -1,0 +1,33 @@
+import { Card } from '@blueprintjs/core'
+import * as React from 'react'
+import { Redirect, Route, Switch } from 'react-router'
+
+import AnnouncementsContainer from '../../containers/device/AnnouncementsContainer'
+import LoginContainer from '../../containers/LoginContainer'
+import AdminNavigationBar from './NavigationBar'
+
+const redirectToAnnouncements = () => <Redirect to="/admin/announcements" />
+
+const Admin: React.SFC<{}> = () => {
+  const redirectTo404 = () => <Redirect to="/404" />
+
+  return (
+    <div className="Admin">
+      <LoginContainer />
+      <AdminNavigationBar />
+      <div className="row center-xs">
+        <div className="col-xs-12 admin-content-parent">
+          <Card className="admin-content" elevation={1}>
+            <Switch>
+              <Route path="/admin/announcements" component={AnnouncementsContainer} />
+              <Route exact={true} path="/admin" component={redirectToAnnouncements} />
+              <Route component={redirectTo404} />
+            </Switch>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Admin

--- a/src/components/admin/index.tsx
+++ b/src/components/admin/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Redirect, Route, Switch } from 'react-router'
 
 import AnnouncementManager from '../../containers/admin/AnnouncementManagerContainer'
+import AssessmentManager from '../../containers/admin/AssessmentManagerContainer'
 import LoginContainer from '../../containers/LoginContainer'
 import AdminNavigationBar from './NavigationBar'
 
@@ -20,6 +21,7 @@ const Admin: React.SFC<{}> = () => {
           <Card className="admin-content" elevation={1}>
             <Switch>
               <Route path="/admin/announcements" component={AnnouncementManager} />
+              <Route path="/admin/assessments" component={AssessmentManager} />
               <Route exact={true} path="/admin" component={redirectToAnnouncements} />
               <Route component={redirectTo404} />
             </Switch>

--- a/src/components/admin/index.tsx
+++ b/src/components/admin/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@blueprintjs/core'
 import * as React from 'react'
 import { Redirect, Route, Switch } from 'react-router'
 
-import AnnouncementsContainer from '../../containers/device/AnnouncementsContainer'
+import AnnouncementManager from '../../containers/admin/AnnouncementManagerContainer'
 import LoginContainer from '../../containers/LoginContainer'
 import AdminNavigationBar from './NavigationBar'
 
@@ -19,7 +19,7 @@ const Admin: React.SFC<{}> = () => {
         <div className="col-xs-12 admin-content-parent">
           <Card className="admin-content" elevation={1}>
             <Switch>
-              <Route path="/admin/announcements" component={AnnouncementsContainer} />
+              <Route path="/admin/announcements" component={AnnouncementManager} />
               <Route exact={true} path="/admin" component={redirectToAnnouncements} />
               <Route component={redirectTo404} />
             </Switch>

--- a/src/containers/admin/AnnouncementManagerContainer.ts
+++ b/src/containers/admin/AnnouncementManagerContainer.ts
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux'
+
+import AnnouncementManager from '../../components/admin/AnnouncementManager'
+
+export default connect()(AnnouncementManager)

--- a/src/containers/admin/AssessmentManagerContainer.ts
+++ b/src/containers/admin/AssessmentManagerContainer.ts
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux'
+
+import AssessmentManager from '../../components/admin/AssessmentManager'
+
+export default connect()(AssessmentManager)

--- a/src/containers/admin/index.ts
+++ b/src/containers/admin/index.ts
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux'
+
+import Admin from '../../components/admin'
+
+export default connect()(Admin)

--- a/src/styles/_admin.scss
+++ b/src/styles/_admin.scss
@@ -1,0 +1,17 @@
+.Admin {
+  top: 50px;
+  height: 100%;
+  width: 100%;
+  flex: 1 1 100%;
+  .row {
+    margin-right: 0px;
+    margin-left: 0px;
+  }
+  .admin-content-parent {
+    .admin-content {
+      margin-top: 20px;
+      margin-bottom: 20px;
+      background-color: white;
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -5,6 +5,7 @@
 @import 'global';
 @import 'blueprint';
 
+@import 'admin';
 @import 'application';
 @import 'device';
 @import 'game';


### PR DESCRIPTION
### Features:
- Scaffold an `Admin` tab in the main nav bar
- Add AnnouncementManger and AssessmentMangaer for scaffolding.

#### Notes
- This does not interfere with #81.
- The plan is to scaffold the subsequent pages as we go along, with respect to the backend models. No point creating empty pages for every admin sub-page.

