### PR TITLE
Make NavigationBars Responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "astring": "^1.3.0",
     "common-tags": "^1.7.2",
     "flexboxgrid": "^6.3.1",
+    "flexboxgrid-helpers": "^1.1.3",
     "node-sass-chokidar": "^1.3.0",
     "normalize.css": "^8.0.0",
     "npm-run-all": "^4.1.3",

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -81,7 +81,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
             className="NavigationBar__link pt-button pt-minimal"
           >
             <Icon icon={IconNames.USER} />
-            {props.username}
+            <div className="navbar-button-text hidden-xs">{props.username}</div>
           </NavLink>
         </>
       )}

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -33,7 +33,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FEED} />
-        <div className="navbar-button hidden-xs">News</div>
+        <div className="navbar-button-text hidden-xs">News</div>
       </NavLink>
 
       <NavLink
@@ -42,7 +42,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FOLDER_OPEN} />
-        <div className="navbar-button hidden-xs">Material</div>
+        <div className="navbar-button-text hidden-xs">Material</div>
       </NavLink>
 
       <NavLink
@@ -51,7 +51,7 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.EYE_OPEN} />
-        <div className="navbar-button hidden-xs">Admin</div>
+        <div className="navbar-button-text hidden-xs">Admin</div>
       </NavLink>
     </NavbarGroup>
 
@@ -62,17 +62,16 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.CODE} />
-        <div className="navbar-button hidden-xs">Playground</div>
+        <div className="navbar-button-text hidden-xs">Playground</div>
       </NavLink>
-
-      <div className="visible-xs">
-        <NavbarDivider className="thin-divider" />
-      </div>
 
       {props.username === undefined ? (
         undefined
       ) : (
         <>
+          <div className="visible-xs">
+            <NavbarDivider className="thin-divider" />
+          </div>
           <div className="hidden-xs">
             <NavbarDivider className="default-divider" />
           </div>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -24,31 +24,34 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.SYMBOL_DIAMOND} />
-        <NavbarHeading>Source Academy</NavbarHeading>
+        <NavbarHeading className="hidden-xs">Source Academy</NavbarHeading>
       </NavLink>
+
       <NavLink
         to="/news"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FEED} />
-        News
+        <div className="navbar-button hidden-xs">News</div>
       </NavLink>
+
       <NavLink
         to="/material"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FOLDER_OPEN} />
-        Material
+        <div className="navbar-button hidden-xs">Material</div>
       </NavLink>
+
       <NavLink
         to="/admin"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.EYE_OPEN} />
-        Admin
+        <div className="navbar-button hidden-xs">Admin</div>
       </NavLink>
     </NavbarGroup>
 
@@ -59,13 +62,20 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.CODE} />
-        Playground
+        <div className="navbar-button hidden-xs">Playground</div>
       </NavLink>
+
+      <div className="visible-xs">
+        <NavbarDivider className="thin-divider" />
+      </div>
+
       {props.username === undefined ? (
         undefined
       ) : (
         <>
-          <NavbarDivider />
+          <div className="hidden-xs">
+            <NavbarDivider className="default-divider" />
+          </div>
           <NavLink
             to="/status"
             activeClassName="pt-active"

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -16,7 +16,7 @@ export interface INavigationBarProps {
 }
 
 const NavigationBar: React.SFC<INavigationBarProps> = props => (
-  <Navbar className="NavigationBar pt-dark">
+  <Navbar className="NavigationBar primary-navbar pt-dark">
     <NavbarGroup align={Alignment.LEFT}>
       <NavLink
         to="/academy"

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -83,7 +83,9 @@ exports[`NavigationBar renders correctly with username 1`] = `
       </div>
       <NavLink to=\\"/status\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
         <Blueprint2.Icon icon=\\"user\\" />
-        Evis Rucer
+        <div className=\\"navbar-button-text hidden-xs\\">
+          Evis Rucer
+        </div>
       </NavLink>
     </Symbol(react.fragment)>
   </Blueprint2.NavbarGroup>

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavigationBar renders "Not logged in" correctly 1`] = `
-"<Blueprint2.Navbar className=\\"NavigationBar pt-dark\\">
+"<Blueprint2.Navbar className=\\"NavigationBar primary-navbar pt-dark\\">
   <Blueprint2.NavbarGroup align=\\"left\\">
     <NavLink to=\\"/academy\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"symbol-diamond\\" />
@@ -32,7 +32,7 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
 `;
 
 exports[`NavigationBar renders correctly with username 1`] = `
-"<Blueprint2.Navbar className=\\"NavigationBar pt-dark\\">
+"<Blueprint2.Navbar className=\\"NavigationBar primary-navbar pt-dark\\">
   <Blueprint2.NavbarGroup align=\\"left\\">
     <NavLink to=\\"/academy\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"symbol-diamond\\" />

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -5,28 +5,39 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
   <Blueprint2.NavbarGroup align=\\"left\\">
     <NavLink to=\\"/academy\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"symbol-diamond\\" />
-      <Blueprint2.NavbarHeading>
+      <Blueprint2.NavbarHeading className=\\"hidden-xs\\">
         Source Academy
       </Blueprint2.NavbarHeading>
     </NavLink>
     <NavLink to=\\"/news\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"feed\\" />
-      News
+      <div className=\\"navbar-button hidden-xs\\">
+        News
+      </div>
     </NavLink>
     <NavLink to=\\"/material\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"folder-open\\" />
-      Material
+      <div className=\\"navbar-button hidden-xs\\">
+        Material
+      </div>
     </NavLink>
     <NavLink to=\\"/admin\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"eye-open\\" />
-      Admin
+      <div className=\\"navbar-button hidden-xs\\">
+        Admin
+      </div>
     </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"code\\" />
-      Playground
+      <div className=\\"navbar-button hidden-xs\\">
+        Playground
+      </div>
     </NavLink>
+    <div className=\\"visible-xs\\">
+      <Blueprint2.NavbarDivider className=\\"thin-divider\\" />
+    </div>
   </Blueprint2.NavbarGroup>
 </Blueprint2.Navbar>"
 `;
@@ -36,30 +47,43 @@ exports[`NavigationBar renders correctly with username 1`] = `
   <Blueprint2.NavbarGroup align=\\"left\\">
     <NavLink to=\\"/academy\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"symbol-diamond\\" />
-      <Blueprint2.NavbarHeading>
+      <Blueprint2.NavbarHeading className=\\"hidden-xs\\">
         Source Academy
       </Blueprint2.NavbarHeading>
     </NavLink>
     <NavLink to=\\"/news\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"feed\\" />
-      News
+      <div className=\\"navbar-button hidden-xs\\">
+        News
+      </div>
     </NavLink>
     <NavLink to=\\"/material\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"folder-open\\" />
-      Material
+      <div className=\\"navbar-button hidden-xs\\">
+        Material
+      </div>
     </NavLink>
     <NavLink to=\\"/admin\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"eye-open\\" />
-      Admin
+      <div className=\\"navbar-button hidden-xs\\">
+        Admin
+      </div>
     </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"code\\" />
-      Playground
+      <div className=\\"navbar-button hidden-xs\\">
+        Playground
+      </div>
     </NavLink>
+    <div className=\\"visible-xs\\">
+      <Blueprint2.NavbarDivider className=\\"thin-divider\\" />
+    </div>
     <Symbol(react.fragment)>
-      <Blueprint2.NavbarDivider />
+      <div className=\\"hidden-xs\\">
+        <Blueprint2.NavbarDivider className=\\"default-divider\\" />
+      </div>
       <NavLink to=\\"/status\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
         <Blueprint2.Icon icon=\\"user\\" />
         Evis Rucer

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -11,19 +11,19 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
     </NavLink>
     <NavLink to=\\"/news\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"feed\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         News
       </div>
     </NavLink>
     <NavLink to=\\"/material\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"folder-open\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Material
       </div>
     </NavLink>
     <NavLink to=\\"/admin\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"eye-open\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Admin
       </div>
     </NavLink>
@@ -31,13 +31,10 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Playground
       </div>
     </NavLink>
-    <div className=\\"visible-xs\\">
-      <Blueprint2.NavbarDivider className=\\"thin-divider\\" />
-    </div>
   </Blueprint2.NavbarGroup>
 </Blueprint2.Navbar>"
 `;
@@ -53,19 +50,19 @@ exports[`NavigationBar renders correctly with username 1`] = `
     </NavLink>
     <NavLink to=\\"/news\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"feed\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         News
       </div>
     </NavLink>
     <NavLink to=\\"/material\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"folder-open\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Material
       </div>
     </NavLink>
     <NavLink to=\\"/admin\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"eye-open\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Admin
       </div>
     </NavLink>
@@ -73,14 +70,14 @@ exports[`NavigationBar renders correctly with username 1`] = `
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/playground\\" activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" ariaCurrent=\\"true\\">
       <Blueprint2.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button hidden-xs\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Playground
       </div>
     </NavLink>
-    <div className=\\"visible-xs\\">
-      <Blueprint2.NavbarDivider className=\\"thin-divider\\" />
-    </div>
     <Symbol(react.fragment)>
+      <div className=\\"visible-xs\\">
+        <Blueprint2.NavbarDivider className=\\"thin-divider\\" />
+      </div>
       <div className=\\"hidden-xs\\">
         <Blueprint2.NavbarDivider className=\\"default-divider\\" />
       </div>

--- a/src/components/academy/NavigationBar.tsx
+++ b/src/components/academy/NavigationBar.tsx
@@ -12,31 +12,34 @@ const NavigationBar: React.SFC<{}> = () => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FLAME} />
-        Missions
+        <div className="navbar-button-text hidden-xs">Missions</div>
       </NavLink>
+
       <NavLink
         to="/academy/sidequests"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.LIGHTBULB} />
-        Sidequests
+        <div className="navbar-button-text hidden-xs">Sidequests</div>
       </NavLink>
+
       <NavLink
         to="/academy/paths"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.PREDICTIVE_ANALYSIS} />
-        Paths
+        <div className="navbar-button-text hidden-xs">Paths</div>
       </NavLink>
+
       <NavLink
         to="/academy/contests"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.COMPARISON} />
-        Contests
+        <div className="navbar-button-text hidden-xs">Contests</div>
       </NavLink>
     </NavbarGroup>
   </Navbar>

--- a/src/components/academy/NavigationBar.tsx
+++ b/src/components/academy/NavigationBar.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
 const NavigationBar: React.SFC<{}> = () => (
-  <Navbar className="NavigationBar">
+  <Navbar className="NavigationBar secondary-navbar">
     <NavbarGroup align={Alignment.LEFT}>
       <NavLink
         to="/academy/missions"

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -5,7 +5,7 @@ import { IconNames } from '@blueprintjs/icons'
 import { NavLink } from 'react-router-dom'
 
 const NavigationBar: React.SFC<{}> = () => (
-  <Navbar className="NavigationBar">
+  <Navbar className="NavigationBar secondary-navbar">
     <NavbarGroup align={Alignment.LEFT}>
       <NavLink
         to="/admin/announcements"

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -13,23 +13,25 @@ const NavigationBar: React.SFC<{}> = () => (
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FEED} />
-        Announcements
+        <div className="navbar-button-text hidden-xs">Announcements</div>
       </NavLink>
+
       <NavLink
         to="/admin/assessments"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.TICK} />
-        Assessments
+        <div className="navbar-button-text hidden-xs">Assessments</div>
       </NavLink>
+
       <NavLink
         to="/admin/materials"
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
         <Icon icon={IconNames.FOLDER_OPEN} />
-        Materials
+        <div className="navbar-button-text hidden-xs">Materials</div>
       </NavLink>
     </NavbarGroup>
   </Navbar>

--- a/src/styles/_navigationBar.scss
+++ b/src/styles/_navigationBar.scss
@@ -1,6 +1,14 @@
 .NavigationBar {
   width: 100%;
   flex: 0 0 auto;
+}
+
+.NavigationBar__link :first-child {
+  margin-left: 0.1rem !important;
+  margin-right: 0.3rem !important;
+}
+
+.primary-navbar {
   .pt-button {
     font-weight: 500;
   }
@@ -17,13 +25,8 @@
 %thin-navbar {
   .NavigationBar {
     height: 40px;
-
-    .pt-navbar-group {
-      height: 40px;
-    }
   }
-
-  .NavigationBar .pt-button {
+  .pt-button {
     text-transform: initial;
     font-weight: 250;
   }

--- a/src/styles/_navigationBar.scss
+++ b/src/styles/_navigationBar.scss
@@ -9,9 +9,6 @@
     margin-left: 0px;
     margin-right: 0px;
   }
-  .pt-icon {
-    // margin-right: 1.6px;
-  }
   .navbar-button-text {
     /* This provides some space between the icon and the text on larger displays. */
     margin-left: 0.2rem;
@@ -42,8 +39,9 @@
  * Style for the navigation bar of particular sections (e.g Admin). This is the
  * "nested" navigation bar under the primary one.
  */
-%thin-navbar {
-  .NavigationBar {
+.secondary-navbar {
+  height: 40px;
+  .pt-navbar-group {
     height: 40px;
   }
   /* Create less emphasis on secondary navbar buttons */
@@ -51,12 +49,4 @@
     text-transform: initial;
     font-weight: 250;
   }
-}
-
-.Academy {
-  @extend %thin-navbar;
-}
-
-.Admin {
-  @extend %thin-navbar;
 }

--- a/src/styles/_navigationBar.scss
+++ b/src/styles/_navigationBar.scss
@@ -1,6 +1,10 @@
 .NavigationBar {
   width: 100%;
   flex: 0 0 auto;
+  .thin-divider {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
 }
 
 .NavigationBar__link :first-child {

--- a/src/styles/_navigationBar.scss
+++ b/src/styles/_navigationBar.scss
@@ -1,17 +1,34 @@
+/*
+ * Style for all navigation bars.
+ */
 .NavigationBar {
   width: 100%;
   flex: 0 0 auto;
   .thin-divider {
+    /* Used to lessen the space between icon-only buttons (on small displays). */
     margin-left: 0px;
     margin-right: 0px;
+  }
+  .pt-icon {
+    // margin-right: 1.6px;
+  }
+  .navbar-button-text {
+    /* This provides some space between the icon and the text on larger displays. */
+    margin-left: 0.2rem;
   }
 }
 
 .NavigationBar__link :first-child {
+  /* An even margin is kept (instead of the right side having a higher margin)
+   * to allow for even spacing when viewed on mobile.
+   */
   margin-left: 0.1rem !important;
-  margin-right: 0.3rem !important;
+  margin-right: 0.1rem !important;
 }
 
+/*
+ * Style for the navigation bar of the entire site (used in Application)
+ */
 .primary-navbar {
   .pt-button {
     font-weight: 500;
@@ -21,15 +38,15 @@
   }
 }
 
-.NavigationBar__link :first-child {
-  margin-left: 0.1rem !important;
-  margin-right: 0.3rem !important;
-}
-
+/*
+ * Style for the navigation bar of particular sections (e.g Admin). This is the
+ * "nested" navigation bar under the primary one.
+ */
 %thin-navbar {
   .NavigationBar {
     height: 40px;
   }
+  /* Create less emphasis on secondary navbar buttons */
   .pt-button {
     text-transform: initial;
     font-weight: 250;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,6 +1,7 @@
 @import '~normalize.css/normalize.css';
 @import '~@blueprintjs/core/lib/css/blueprint.css';
 @import '~flexboxgrid/dist/flexboxgrid.css';
+@import '~flexboxgrid-helpers/dist/flexboxgrid-helpers.min.css';
 
 @import 'global';
 @import 'blueprint';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,6 +3170,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+flexboxgrid-helpers@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/flexboxgrid-helpers/-/flexboxgrid-helpers-1.1.3.tgz#a8bbd15fd46dc9fd229e681bcfefb07b375068ab"
+
 flexboxgrid@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/flexboxgrid/-/flexboxgrid-6.3.1.tgz#e99898afc07b7047722bb81a958a5fba4d4e20fd"


### PR DESCRIPTION
### Features:
- Navbar buttons become icons once the `xs` size is reached.
- Margin on the icons are even, and the button text has a slight margin left to have the same visual space.

---

### Issues Fixed:
- #71 (using specificity)
- #76 

---

#### Known problem:
- Although usability is not affected, the iPad screen (not sure which iPad version, I was using chrome devtools) in portrait mode is just in the domain of the `xs` size, causing text to not show up. However, iPad Pro screen is larger than that, making the text render. Even phones render the text in landscape mode, though.