### PR TITLE
Wrap the right side of the Workspace 

### DIFF
--- a/src/components/workspace/index.tsx
+++ b/src/components/workspace/index.tsx
@@ -99,15 +99,17 @@ class Workspace extends React.Component<IWorkspaceProps, {}> {
    * in the case of < 5%.
    */
   private toggleEditorDividerDisplay: ResizeCallback = (e, dir, ref) => {
+    const leftThreshold = 2
+    const rightThreshold = 95
     const editorWidthPercentage = (ref as HTMLDivElement).clientWidth / window.innerWidth * 100
     // update resizable size
-    if (editorWidthPercentage > 95) {
+    if (editorWidthPercentage > rightThreshold) {
       this.leftParentResizable.updateSize({ width: '100%', height: '100%' })
-    } else if (editorWidthPercentage < 5) {
+    } else if (editorWidthPercentage < leftThreshold) {
       this.leftParentResizable.updateSize({ width: '0%', height: '100%' })
     }
     // Update divider margin
-    if (editorWidthPercentage < 5) {
+    if (editorWidthPercentage < leftThreshold) {
       this.editorDividerDiv.style.marginRight = '0.6rem'
     } else {
       this.editorDividerDiv.style.marginRight = '0'

--- a/src/components/workspace/side-content/index.tsx
+++ b/src/components/workspace/side-content/index.tsx
@@ -25,7 +25,7 @@ class SideContent extends React.Component<ISideContentProps, {}> {
       <div className="side-content">
         <Card>
           {this.renderHeader()}
-          {this.props.tabs[this.props.activeTab].body}
+          <div className="side-content-text">{this.props.tabs[this.props.activeTab].body}</div>
         </Card>
       </div>
     )

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -97,6 +97,9 @@ $code-color-error: #ff4444;
 
         .side-content-text {
           height: 100%;
+          /* word-wrap and word-break are added to make text wrap. */
+          word-wrap: break-word;
+          word-break: break-word;
         }
       }
     }
@@ -147,7 +150,12 @@ $code-color-error: #ff4444;
         color: inherit;
         padding: 0px;
         margin: 0px;
+        /* white-space, word-wrap and word-break 
+         * are specified to allow all output to wrap.
+         */
         white-space: pre-wrap;
+        word-wrap: break-word;
+        word-break: break-word;
       }
 
       .codeOutput {


### PR DESCRIPTION
### Features:
- Side content text and repl output wrap, breaking big works (e.g the output of `build_list(50, x => x);`)

### Issues fixed:
#66 

#### Known problem:
- The wrapping of repl works to a tee, but the wrapping of the side content depends on how the content (passed in through a prop) is formatted. Some things cannot be wrapped, like images. 