### PR TITLE
Store IVLE API key in dotenv file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_IVLE_KEY=your_ivle_key_here

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 1. Install a stable version of Yarn and NodeJS.
 2. Run `yarn` to install dependencies.
-3. Set the environment variable `REACT_APP_IVLE_KEY` to contain your IVLE Lapi
-   key.
-4. Run desired script in `package.json`. `yarn start` starts the development
-   server.
+3. Copy the `.env.example` file as `.env` and set the variable `REACT_APP_IVLE_KEY`
+   to contain your IVLE Lapi key.
+4. Run `yarn start` to start the server at `localhost:80`. Admin permissions may
+   be required for your OS to serve at port 80.
 
 ## Application Structure
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/acorn": "^4.0.3",
     "@types/classnames": "^2.2.3",
     "@types/common-tags": "^1.4.0",
+    "@types/dotenv": "^4.0.3",
     "@types/enzyme": "^3.1.9",
     "@types/enzyme-adapter-react-16": "^1.0.2",
     "@types/estree": "^0.0.39",

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -17,7 +17,6 @@ function* mainSaga() {
 }
 
 function* interpreterSaga(): SagaIterator {
-  // let library = yield select((state: Shape) => state.config.library)
   let context: Context
 
   yield takeEvery(actionTypes.EVAL_EDITOR, function*() {
@@ -53,7 +52,6 @@ function* loginSaga(): SagaIterator {
     const apiLogin = 'https://ivle.nus.edu.sg/api/login/'
     const key = IVLE_KEY
     const callback = `${window.location.protocol}//${window.location.hostname}/academy`
-    alert(`${apiLogin}?apikey=${key}&url=${callback}`)
     window.location.href = `${apiLogin}?apikey=${key}&url=${callback}`
     yield undefined
   })

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,1 +1,5 @@
+import * as dotenv from 'dotenv'
+
+dotenv.config()
+
 export const IVLE_KEY = process.env.REACT_APP_IVLE_KEY

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,12 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.0.tgz#00dc42fed6b36a7a6dabb8f7a9c9e678ee644e05"
 
+"@types/dotenv@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-4.0.3.tgz#ebcfc40da7bc0728b705945b7db48485ec5b4b67"
+  dependencies:
+    "@types/node" "*"
+
 "@types/enzyme-adapter-react-16@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.2.tgz#15ae37c64d6221a6f4b3a4aacc357cf773859de4"


### PR DESCRIPTION
### Features

- The IVLE API  key is now stored in a `.env` file, [similar to backend](https://github.com/source-academy/cadet/pull/48). 
- Updated README accordingly.