### PR TITLE
Hotfix uncaught error from failed fetch

### DIFF
--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -78,12 +78,10 @@ function* loginSaga(): SagaIterator {
   })
 
   yield takeEvery(actionTypes.FETCH_USERNAME, function*() {
-    const apiUsername = 'https://ivle.nus.edu.sg/api/Lapi.svc/UserName_Get'
-    const key = IVLE_KEY
-    const token = yield select((state: IState) => state.session.token)
-    const username = yield call(() =>
-      fetch(`${apiUsername}?APIKey=${key}&Token=${token}`).then(response => response.json())
-    )
+    // TODO: use an API call to the backend; an api call to IVLE raises an
+    // uncaught error due to restrictive Access-Control-Allow-Origin headers,
+    // causing the staging server to bug out
+    const username = yield call(() => 'IVLE USER')
     yield put(actions.setUsername(username))
   })
 }


### PR DESCRIPTION
### Features

- Fixed an uncaught error with minified files where an uncaught error would be raised due to a failed fetch call. This is due to restrictive Access-Control-Allow-Origin at IVLE, and would cause the playground to malfunction.
- This is not much of an issue in the future, since the API call removed in this PR will be sent to the backend rather than IVLE (UsernameGet).
  - We probably have to wrap all fetch calls in a try/catch eventually though, so that the site will not fail in a similar manner if IVLE/backend is offline, or if the client is offline.