### PR TITLE
Add navigation between Questions

### DIFF
--- a/src/components/academy/NavigationBar.tsx
+++ b/src/components/academy/NavigationBar.tsx
@@ -3,8 +3,8 @@ import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
-import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
-import { AssessmentCategories } from '../assessment/assessmentShape';
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers'
+import { AssessmentCategories } from '../assessment/assessmentShape'
 
 const NavigationBar: React.SFC<{}> = () => (
   <Navbar className="NavigationBar secondary-navbar">

--- a/src/components/academy/NavigationBar.tsx
+++ b/src/components/academy/NavigationBar.tsx
@@ -3,11 +3,14 @@ import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
+import { AssessmentCategories } from '../assessment/assessmentShape';
+
 const NavigationBar: React.SFC<{}> = () => (
   <Navbar className="NavigationBar secondary-navbar">
     <NavbarGroup align={Alignment.LEFT}>
       <NavLink
-        to="/academy/missions"
+        to={`/academy/${assessmentCategoryLink(AssessmentCategories.MISSION)}`}
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
@@ -16,7 +19,7 @@ const NavigationBar: React.SFC<{}> = () => (
       </NavLink>
 
       <NavLink
-        to="/academy/sidequests"
+        to={`/academy/${assessmentCategoryLink(AssessmentCategories.SIDEQUEST)}`}
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
@@ -25,7 +28,7 @@ const NavigationBar: React.SFC<{}> = () => (
       </NavLink>
 
       <NavLink
-        to="/academy/paths"
+        to={`/academy/${assessmentCategoryLink(AssessmentCategories.PATH)}`}
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >
@@ -34,7 +37,7 @@ const NavigationBar: React.SFC<{}> = () => (
       </NavLink>
 
       <NavLink
-        to="/academy/contests"
+        to={`/academy/${assessmentCategoryLink(AssessmentCategories.CONTEST)}`}
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
       >

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -31,7 +31,7 @@ const assessmentListingRenderFactory = (cat: AssessmentCategory) => (
   routerProps: RouteComponentProps<any>
 ) => <AssessmentListingContainer assessmentCategory={cat} />
 
-const assessmentRegExp = '/:assessmentId?(\\d+)/:questionId?(\\d+)'
+const assessmentRegExp = ':assessmentId(\\d+)?/:questionId(\\d+)?'
 
 export const Academy: React.SFC<IAcademyProps> = props => (
   <div className="Academy">

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -41,12 +41,7 @@ export const Academy: React.SFC<IAcademyProps> = props => (
       />
       <Route path="/academy/game" component={Game} />
       <Route
-        exact={true}
-        path="/academy/missions"
-        render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
-      />
-      <Route
-        path="/academy/missions/:assessmentId"
+        path="/academy/missions/:assessmentId?/:questionId?"
         render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
       />
       <Route

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -39,12 +39,16 @@ export const Academy: React.SFC<IAcademyProps> = props => (
     <Switch>
       {checkLoggedIn(props)}
       <Route
-        path={`/academy/${assessmentCategoryLink(AssessmentCategories.CONTEST)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(
+          AssessmentCategories.CONTEST
+        )}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.CONTEST)}
       />
-      <Route path='/academy/game' component={Game} />
+      <Route path="/academy/game" component={Game} />
       <Route
-        path={`/academy/${assessmentCategoryLink(AssessmentCategories.MISSION)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(
+          AssessmentCategories.MISSION
+        )}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
       />
       <Route
@@ -52,10 +56,12 @@ export const Academy: React.SFC<IAcademyProps> = props => (
         render={assessmentListingRenderFactory(AssessmentCategories.PATH)}
       />
       <Route
-        path={`/academy/${assessmentCategoryLink(AssessmentCategories.SIDEQUEST)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(
+          AssessmentCategories.SIDEQUEST
+        )}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.SIDEQUEST)}
       />
-      <Route exact={true} path='/academy' component={dynamicRedirect(props)} />
+      <Route exact={true} path="/academy" component={dynamicRedirect(props)} />
       <Route component={redirectTo404} />
     </Switch>
   </div>

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -36,7 +36,7 @@ export const Academy: React.SFC<IAcademyProps> = props => (
     <Switch>
       {checkLoggedIn(props)}
       <Route
-        path="/academy/contests"
+        path="/academy/contests/:assessmentId?/:questionId?"
         render={assessmentListingRenderFactory(AssessmentCategories.CONTEST)}
       />
       <Route path="/academy/game" component={Game} />
@@ -45,11 +45,11 @@ export const Academy: React.SFC<IAcademyProps> = props => (
         render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
       />
       <Route
-        path="/academy/paths"
+        path="/academy/paths/:assessmentId?/:questionId?"
         render={assessmentListingRenderFactory(AssessmentCategories.PATH)}
       />
       <Route
-        path="/academy/sidequests"
+        path="/academy/sidequests/:assessmentId?/:questionId?"
         render={assessmentListingRenderFactory(AssessmentCategories.SIDEQUEST)}
       />
       <Route exact={true} path="/academy" component={dynamicRedirect(props)} />

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -8,6 +8,7 @@ import AssessmentListingContainer from '../../containers/assessment/AssessmentLi
 import Game from '../../containers/GameContainer'
 import { isAcademyRe } from '../../reducers/session'
 import { HistoryHelper } from '../../utils/history'
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers'
 import { AssessmentCategories, AssessmentCategory } from '../assessment/assessmentShape'
 import AcademyNavigationBar from './NavigationBar'
 
@@ -31,7 +32,6 @@ const assessmentListingRenderFactory = (cat: AssessmentCategory) => (
 ) => <AssessmentListingContainer assessmentCategory={cat} />
 
 const assessmentRegExp = '/:assessmentId?(\\d+)/:questionId?(\\d+)'
-const categoryToLink = (cat: AssessmentCategory): string => cat.toLowerCase().concat('s')
 
 export const Academy: React.SFC<IAcademyProps> = props => (
   <div className="Academy">
@@ -39,20 +39,20 @@ export const Academy: React.SFC<IAcademyProps> = props => (
     <Switch>
       {checkLoggedIn(props)}
       <Route
-        path={`/academy/${categoryToLink(AssessmentCategories.CONTEST)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(AssessmentCategories.CONTEST)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.CONTEST)}
       />
       <Route path='/academy/game' component={Game} />
       <Route
-        path={`/academy/${categoryToLink(AssessmentCategories.MISSION)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(AssessmentCategories.MISSION)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
       />
       <Route
-        path={`/academy/${categoryToLink(AssessmentCategories.PATH)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(AssessmentCategories.PATH)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.PATH)}
       />
       <Route
-        path={`/academy/${categoryToLink(AssessmentCategories.SIDEQUEST)}/${assessmentRegExp}`}
+        path={`/academy/${assessmentCategoryLink(AssessmentCategories.SIDEQUEST)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.SIDEQUEST)}
       />
       <Route exact={true} path='/academy' component={dynamicRedirect(props)} />

--- a/src/components/academy/index.tsx
+++ b/src/components/academy/index.tsx
@@ -30,29 +30,32 @@ const assessmentListingRenderFactory = (cat: AssessmentCategory) => (
   routerProps: RouteComponentProps<any>
 ) => <AssessmentListingContainer assessmentCategory={cat} />
 
+const assessmentRegExp = '/:assessmentId?(\\d+)/:questionId?(\\d+)'
+const categoryToLink = (cat: AssessmentCategory): string => cat.toLowerCase().concat('s')
+
 export const Academy: React.SFC<IAcademyProps> = props => (
   <div className="Academy">
     <AcademyNavigationBar />
     <Switch>
       {checkLoggedIn(props)}
       <Route
-        path="/academy/contests/:assessmentId?/:questionId?"
+        path={`/academy/${categoryToLink(AssessmentCategories.CONTEST)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.CONTEST)}
       />
-      <Route path="/academy/game" component={Game} />
+      <Route path='/academy/game' component={Game} />
       <Route
-        path="/academy/missions/:assessmentId?/:questionId?"
+        path={`/academy/${categoryToLink(AssessmentCategories.MISSION)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.MISSION)}
       />
       <Route
-        path="/academy/paths/:assessmentId?/:questionId?"
+        path={`/academy/${categoryToLink(AssessmentCategories.PATH)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.PATH)}
       />
       <Route
-        path="/academy/sidequests/:assessmentId?/:questionId?"
+        path={`/academy/${categoryToLink(AssessmentCategories.SIDEQUEST)}/${assessmentRegExp}`}
         render={assessmentListingRenderFactory(AssessmentCategories.SIDEQUEST)}
       />
-      <Route exact={true} path="/academy" component={dynamicRedirect(props)} />
+      <Route exact={true} path='/academy' component={dynamicRedirect(props)} />
       <Route component={redirectTo404} />
     </Switch>
   </div>

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -9,6 +9,7 @@ import { OwnProps as AssessmentProps } from '../assessment'
 import { AssessmentCategory } from '../assessment/assessmentShape'
 import { IAssessmentOverview } from '../assessment/assessmentShape'
 import ContentDisplay, { IContentDisplayProps } from '../commons/ContentDisplay'
+import { stringParamToInt } from '../../utils/paramParseHelpers'
 
 export interface IAssessmentParams {
   assessmentId?: string
@@ -27,18 +28,14 @@ export type StateProps = Pick<IAssessmentListingProps, 'assessmentOverviews'>
 
 class AssessmentListing extends React.Component<IAssessmentListingProps, {}> {
   public render() {
-    // make assessmentId a number
-    let assessmentIdParam: number | null =
-      this.props.match.params.assessmentId === undefined
-        ? NaN
-        : parseInt(this.props.match.params.assessmentId, 10)
-    // set as null if the parsing failed
-    assessmentIdParam = Number.isInteger(assessmentIdParam) ? assessmentIdParam : null
+    const assessmentIdParam: number | null = stringParamToInt(this.props.match.params.assessmentId)
+    // default questionId is 0 (the first question)
+    const questionIdParam: number = stringParamToInt(this.props.match.params.questionId) || 0
 
     // if there is no assessmentId specified, Render only information.
     if (assessmentIdParam === null) {
       const props: IContentDisplayProps = {
-        display: <AssessmentOverviewCard assessmentOverviews={this.props.assessmentOverviews} />,
+        display: <AssessmentOverviewCard assessmentOverviews={this.props.assessmentOverviews} questionId={questionIdParam}/>,
         loadContentDispatch: this.props.handleAssessmentOverviewFetch
       }
       return (
@@ -57,7 +54,7 @@ class AssessmentListing extends React.Component<IAssessmentListingProps, {}> {
 
 interface IAssessmentOverviewCardProps {
   assessmentOverviews?: IAssessmentOverview[]
-  questionId?: number
+  questionId: number
 }
 
 export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = props => {

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -5,11 +5,11 @@ import { RouteComponentProps } from 'react-router'
 import { NavLink } from 'react-router-dom'
 
 import AssessmentContainer from '../../containers/assessment'
+import { stringParamToInt } from '../../utils/paramParseHelpers'
 import { OwnProps as AssessmentProps } from '../assessment'
 import { AssessmentCategory } from '../assessment/assessmentShape'
 import { IAssessmentOverview } from '../assessment/assessmentShape'
 import ContentDisplay, { IContentDisplayProps } from '../commons/ContentDisplay'
-import { stringParamToInt } from '../../utils/paramParseHelpers'
 
 export interface IAssessmentParams {
   assessmentId?: string

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -12,6 +12,7 @@ import ContentDisplay, { IContentDisplayProps } from '../commons/ContentDisplay'
 
 export interface IAssessmentParams {
   assessmentId?: string
+  questionId?: string
 }
 
 export interface IAssessmentListingProps extends RouteComponentProps<IAssessmentParams> {
@@ -56,9 +57,11 @@ class AssessmentListing extends React.Component<IAssessmentListingProps, {}> {
 
 interface IAssessmentOverviewCardProps {
   assessmentOverviews?: IAssessmentOverview[]
+  questionId?: number
 }
 
 export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = props => {
+  const questionId = props.questionId === undefined ? 0 : props.questionId
   if (props.assessmentOverviews === undefined) {
     return <NonIdealState description="Fetching assessment..." visual={<Spinner />} />
   } else if (props.assessmentOverviews.length === 0) {
@@ -86,7 +89,7 @@ export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = p
               </Text>
             </div>
             <div className="col-xs">
-              <NavLink to={`/academy/missions/${overview.id.toString()}`}>
+              <NavLink to={`/academy/${overview.category.toLowerCase().concat('s')}/${overview.id.toString()}/${questionId.toString()}`}>
                 <Button
                   className="listing-skip-button"
                   minimal={true}

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -50,7 +50,8 @@ class AssessmentListing extends React.Component<IAssessmentListingProps, {}> {
       )
     } else {
       const props: AssessmentProps = {
-        assessmentId: assessmentIdParam
+        assessmentId: assessmentIdParam,
+        questionId: questionIdParam
       }
       return <AssessmentContainer {...props} />
     }

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -35,7 +35,12 @@ class AssessmentListing extends React.Component<IAssessmentListingProps, {}> {
     // if there is no assessmentId specified, Render only information.
     if (assessmentIdParam === null) {
       const props: IContentDisplayProps = {
-        display: <AssessmentOverviewCard assessmentOverviews={this.props.assessmentOverviews} questionId={questionIdParam}/>,
+        display: (
+          <AssessmentOverviewCard
+            assessmentOverviews={this.props.assessmentOverviews}
+            questionId={questionIdParam}
+          />
+        ),
         loadContentDispatch: this.props.handleAssessmentOverviewFetch
       }
       return (
@@ -86,7 +91,11 @@ export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = p
               </Text>
             </div>
             <div className="col-xs">
-              <NavLink to={`/academy/${overview.category.toLowerCase().concat('s')}/${overview.id.toString()}/${questionId.toString()}`}>
+              <NavLink
+                to={`/academy/${overview.category
+                  .toLowerCase()
+                  .concat('s')}/${overview.id.toString()}/${questionId.toString()}`}
+              >
                 <Button
                   className="listing-skip-button"
                   minimal={true}

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -93,7 +93,9 @@ export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = p
             </div>
             <div className="col-xs">
               <NavLink
-                to={`/academy/${assessmentCategoryLink(overview.category)}/${overview.id.toString()}/${questionId.toString()}`}
+                to={`/academy/${assessmentCategoryLink(
+                  overview.category
+                )}/${overview.id.toString()}/${questionId.toString()}`}
               >
                 <Button
                   className="listing-skip-button"

--- a/src/components/assessment/AssessmentListing.tsx
+++ b/src/components/assessment/AssessmentListing.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps } from 'react-router'
 import { NavLink } from 'react-router-dom'
 
 import AssessmentContainer from '../../containers/assessment'
-import { stringParamToInt } from '../../utils/paramParseHelpers'
+import { assessmentCategoryLink, stringParamToInt } from '../../utils/paramParseHelpers'
 import { OwnProps as AssessmentProps } from '../assessment'
 import { AssessmentCategory } from '../assessment/assessmentShape'
 import { IAssessmentOverview } from '../assessment/assessmentShape'
@@ -93,9 +93,7 @@ export const AssessmentOverviewCard: React.SFC<IAssessmentOverviewCardProps> = p
             </div>
             <div className="col-xs">
               <NavLink
-                to={`/academy/${overview.category
-                  .toLowerCase()
-                  .concat('s')}/${overview.id.toString()}/${questionId.toString()}`}
+                to={`/academy/${assessmentCategoryLink(overview.category)}/${overview.id.toString()}/${questionId.toString()}`}
               >
                 <Button
                   className="listing-skip-button"

--- a/src/components/assessment/__tests__/__snapshots__/AssessmentListing.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/AssessmentListing.tsx.snap
@@ -10,7 +10,7 @@ exports[`AssessmentListing page "loading" content renders correctly 1`] = `
             <div className=\\"col-xs-10 contentdisplay-content-parent\\">
               <Blueprint2.Card className=\\"contentdisplay-content\\" elevation={1} interactive={false}>
                 <div className=\\"pt-card pt-elevation-1 contentdisplay-content\\">
-                  <Component assessmentOverviews={[undefined]}>
+                  <Component assessmentOverviews={[undefined]} questionId={0}>
                     <NonIdealState description=\\"Fetching assessment...\\" visual={{...}}>
                       <div className=\\"pt-non-ideal-state\\">
                         <div className=\\"pt-non-ideal-state-visual\\">
@@ -52,7 +52,7 @@ exports[`AssessmentListing page with 0 missions renders correctly 1`] = `
             <div className=\\"col-xs-10 contentdisplay-content-parent\\">
               <Blueprint2.Card className=\\"contentdisplay-content\\" elevation={1} interactive={false}>
                 <div className=\\"pt-card pt-elevation-1 contentdisplay-content\\">
-                  <Component assessmentOverviews={{...}}>
+                  <Component assessmentOverviews={{...}} questionId={0}>
                     <NonIdealState title=\\"There are no assessments.\\" visual=\\"flame\\">
                       <div className=\\"pt-non-ideal-state\\">
                         <div className=\\"pt-non-ideal-state-visual pt-non-ideal-state-icon\\">
@@ -92,7 +92,7 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
             <div className=\\"col-xs-10 contentdisplay-content-parent\\">
               <Blueprint2.Card className=\\"contentdisplay-content\\" elevation={1} interactive={false}>
                 <div className=\\"pt-card pt-elevation-1 contentdisplay-content\\">
-                  <Component assessmentOverviews={{...}}>
+                  <Component assessmentOverviews={{...}} questionId={0}>
                     <div>
                       <Blueprint2.Card className=\\"row listing\\" elevation={0} interactive={false}>
                         <div className=\\"pt-card pt-elevation-0 row listing\\">
@@ -132,10 +132,10 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
                                 </Text>
                               </div>
                               <div className=\\"col-xs\\">
-                                <NavLink to=\\"/academy/missions/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
-                                  <Route path=\\"/academy/missions/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                    <Link to=\\"/academy/missions/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
-                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/0\\">
+                                <NavLink to=\\"/academy/missions/0/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
+                                  <Route path=\\"/academy/missions/0/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                    <Link to=\\"/academy/missions/0/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
+                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/0/0\\">
                                         <Blueprint2.Button className=\\"listing-skip-button\\" minimal={true} intent=\\"primary\\" icon=\\"flame\\">
                                           <button type=\\"button\\" className=\\"pt-button pt-minimal pt-intent-primary listing-skip-button\\" disabled={[undefined]} onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]}>
                                             <Blueprint2.Icon icon=\\"flame\\">
@@ -201,10 +201,10 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
                                 </Text>
                               </div>
                               <div className=\\"col-xs\\">
-                                <NavLink to=\\"/academy/missions/1\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
-                                  <Route path=\\"/academy/missions/1\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                    <Link to=\\"/academy/missions/1\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
-                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/1\\">
+                                <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
+                                  <Route path=\\"/academy/missions/1/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                    <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
+                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/1/0\\">
                                         <Blueprint2.Button className=\\"listing-skip-button\\" minimal={true} intent=\\"primary\\" icon=\\"flame\\">
                                           <button type=\\"button\\" className=\\"pt-button pt-minimal pt-intent-primary listing-skip-button\\" disabled={[undefined]} onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]}>
                                             <Blueprint2.Icon icon=\\"flame\\">
@@ -270,10 +270,10 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
                                 </Text>
                               </div>
                               <div className=\\"col-xs\\">
-                                <NavLink to=\\"/academy/missions/2\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
-                                  <Route path=\\"/academy/missions/2\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                    <Link to=\\"/academy/missions/2\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
-                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/2\\">
+                                <NavLink to=\\"/academy/sidequests/2/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
+                                  <Route path=\\"/academy/sidequests/2/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                    <Link to=\\"/academy/sidequests/2/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
+                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/sidequests/2/0\\">
                                         <Blueprint2.Button className=\\"listing-skip-button\\" minimal={true} intent=\\"primary\\" icon=\\"flame\\">
                                           <button type=\\"button\\" className=\\"pt-button pt-minimal pt-intent-primary listing-skip-button\\" disabled={[undefined]} onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]}>
                                             <Blueprint2.Icon icon=\\"flame\\">
@@ -339,10 +339,10 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
                                 </Text>
                               </div>
                               <div className=\\"col-xs\\">
-                                <NavLink to=\\"/academy/missions/3\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
-                                  <Route path=\\"/academy/missions/3\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                    <Link to=\\"/academy/missions/3\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
-                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/3\\">
+                                <NavLink to=\\"/academy/missions/3/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
+                                  <Route path=\\"/academy/missions/3/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                    <Link to=\\"/academy/missions/3/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
+                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/3/0\\">
                                         <Blueprint2.Button className=\\"listing-skip-button\\" minimal={true} intent=\\"primary\\" icon=\\"flame\\">
                                           <button type=\\"button\\" className=\\"pt-button pt-minimal pt-intent-primary listing-skip-button\\" disabled={[undefined]} onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]}>
                                             <Blueprint2.Icon icon=\\"flame\\">
@@ -408,10 +408,10 @@ exports[`AssessmentListing page with multiple loaded missions renders correctly 
                                 </Text>
                               </div>
                               <div className=\\"col-xs\\">
-                                <NavLink to=\\"/academy/missions/4\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
-                                  <Route path=\\"/academy/missions/4\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                    <Link to=\\"/academy/missions/4\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
-                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/missions/4\\">
+                                <NavLink to=\\"/academy/sidequests/4/0\\" activeClassName=\\"active\\" ariaCurrent=\\"true\\">
+                                  <Route path=\\"/academy/sidequests/4/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                    <Link to=\\"/academy/sidequests/4/0\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
+                                      <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/academy/sidequests/4/0\\">
                                         <Blueprint2.Button className=\\"listing-skip-button\\" minimal={true} intent=\\"primary\\" icon=\\"flame\\">
                                           <button type=\\"button\\" className=\\"pt-button pt-minimal pt-intent-primary listing-skip-button\\" disabled={[undefined]} onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]}>
                                             <Blueprint2.Icon icon=\\"flame\\">

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -62,13 +62,16 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
       icon: IconNames.BRIEFCASE,
       body: briefing
     }
-    const currentLink = `/academy/${this.props.assessment.category.toLowerCase().concat('s')}/${this.props.assessment.id.toString()}`
+    const currentLink = `/academy/${this.props.assessment.category
+      .toLowerCase()
+      .concat('s')}/${this.props.assessment.id.toString()}`
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,
       hasNextButton: this.props.questionId < this.props.assessment.questions.length - 1,
       onClickNext: () => history.push(currentLink + `/${(this.props.questionId + 1).toString()}`),
       hasPreviousButton: this.props.questionId > 0,
-      onClickPrevious: () => history.push(currentLink + `/${(this.props.questionId - 1).toString()}`),
+      onClickPrevious: () =>
+        history.push(currentLink + `/${(this.props.questionId - 1).toString()}`),
       hasSaveButton: true,
       hasShareButton: false
     }

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -24,10 +24,13 @@ export type DispatchProps = {
 }
 
 class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean }> {
-  public state = { showOverlay: true }
+  public state = { showOverlay: false }
 
   public componentWillMount() {
     this.props.handleAssessmentFetch(this.props.assessmentId)
+    if (this.props.questionId === 0) {
+      this.setState({ showOverlay: true })
+    }
   }
 
   public render() {

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -62,17 +62,18 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
       icon: IconNames.BRIEFCASE,
       body: briefing
     }
-    const listingPath =`/academy/${this.props.assessment.category.toLowerCase().concat('s')}`
+    const listingPath = `/academy/${this.props.assessment.category.toLowerCase().concat('s')}`
     const assessmentPath = listingPath + `/${this.props.assessment.id.toString()}`
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,
       hasNextButton: this.props.questionId < this.props.assessment.questions.length - 1,
       hasPreviousButton: this.props.questionId > 0,
       hasSubmitButton: this.props.questionId === this.props.assessment.questions.length - 1,
-      onClickNext: () => history.push(assessmentPath + `/${(this.props.questionId + 1).toString()}`),
+      onClickNext: () =>
+        history.push(assessmentPath + `/${(this.props.questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(assessmentPath + `/${(this.props.questionId - 1).toString()}`),
-      onClickSubmit:() => history.push(listingPath),
+      onClickSubmit: () => history.push(listingPath),
       hasSaveButton: true,
       hasShareButton: false
     }

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 
 import Workspace from '../../containers/workspace'
 import { history } from '../../utils/history'
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers'
 import { OwnProps as ControlBarOwnProps } from '../workspace/ControlBar'
 import { SideContentTab } from '../workspace/side-content'
 import { IAssessment } from './assessmentShape'
@@ -62,7 +63,7 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
       icon: IconNames.BRIEFCASE,
       body: briefing
     }
-    const listingPath = `/academy/${this.props.assessment.category.toLowerCase().concat('s')}`
+    const listingPath = `/academy/${assessmentCategoryLink(this.props.assessment.category)}`
     const assessmentPath = listingPath + `/${this.props.assessment.id.toString()}`
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -13,7 +13,10 @@ export type StateProps = {
   assessment?: IAssessment
 }
 
-export type OwnProps = { assessmentId: number }
+export type OwnProps = {
+  assessmentId: number
+  questionId: number
+}
 
 export type DispatchProps = {
   handleAssessmentFetch: (assessmentId: number) => void
@@ -27,7 +30,7 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
   }
 
   public render() {
-    if (this.props.assessment === undefined) {
+    if (this.props.assessment === undefined || this.props.assessment.questions.length === 0) {
       return (
         <NonIdealState
           className="Assessment pt-dark"
@@ -57,8 +60,8 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
     }
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,
-      hasNextButton: true,
-      hasPreviousButton: true,
+      hasNextButton: this.props.questionId < this.props.assessment.questions.length - 1,
+      hasPreviousButton: this.props.questionId > 0,
       hasSaveButton: true,
       hasShareButton: false
     }

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -3,6 +3,7 @@ import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 
 import Workspace from '../../containers/workspace'
+import { history } from '../../utils/history'
 import { OwnProps as ControlBarOwnProps } from '../workspace/ControlBar'
 import { SideContentTab } from '../workspace/side-content'
 import { IAssessment } from './assessmentShape'
@@ -58,10 +59,13 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
       icon: IconNames.BRIEFCASE,
       body: briefing
     }
+    const currentLink = `/academy/${this.props.assessment.category.toLowerCase().concat('s')}/${this.props.assessment.id.toString()}`
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,
       hasNextButton: this.props.questionId < this.props.assessment.questions.length - 1,
+      onClickNext: () => history.push(currentLink + `/${(this.props.questionId + 1).toString()}`),
       hasPreviousButton: this.props.questionId > 0,
+      onClickPrevious: () => history.push(currentLink + `/${(this.props.questionId - 1).toString()}`),
       hasSaveButton: true,
       hasShareButton: false
     }

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -62,16 +62,17 @@ class Assessment extends React.Component<AssessmentProps, { showOverlay: boolean
       icon: IconNames.BRIEFCASE,
       body: briefing
     }
-    const currentLink = `/academy/${this.props.assessment.category
-      .toLowerCase()
-      .concat('s')}/${this.props.assessment.id.toString()}`
+    const listingPath =`/academy/${this.props.assessment.category.toLowerCase().concat('s')}`
+    const assessmentPath = listingPath + `/${this.props.assessment.id.toString()}`
     const controlBarOptions: ControlBarOwnProps = {
       hasChapterSelect: false,
       hasNextButton: this.props.questionId < this.props.assessment.questions.length - 1,
-      onClickNext: () => history.push(currentLink + `/${(this.props.questionId + 1).toString()}`),
       hasPreviousButton: this.props.questionId > 0,
+      hasSubmitButton: this.props.questionId === this.props.assessment.questions.length - 1,
+      onClickNext: () => history.push(assessmentPath + `/${(this.props.questionId + 1).toString()}`),
       onClickPrevious: () =>
-        history.push(currentLink + `/${(this.props.questionId - 1).toString()}`),
+        history.push(assessmentPath + `/${(this.props.questionId - 1).toString()}`),
+      onClickSubmit:() => history.push(listingPath),
       hasSaveButton: true,
       hasShareButton: false
     }

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -22,11 +22,13 @@ export type OwnProps = {
   hasChapterSelect?: boolean
   hasNextButton?: boolean
   hasPreviousButton?: boolean
+  hasSubmitButton?: boolean
   hasSaveButton?: boolean
   hasShareButton?: boolean
   onClickNext?(): any
   onClickPrevious?(): any
   onClickSave?(): any
+  onClickSubmit?(): any
 }
 
 export type StateProps = {
@@ -45,11 +47,13 @@ class ControlBar extends React.Component<ControlBarProps, {}> {
     hasChapterSelect: true,
     hasNextButton: false,
     hasPreviousButton: false,
+    hasSubmitButton: false,
     hasSaveButton: false,
     hasShareButton: true,
     onClickNext: () => {},
     onClickPrevious: () => {},
-    onClickSave: () => {}
+    onClickSave: () => {},
+    onClickSubmit: () => {}
   }
 
   private shareInputElem: HTMLInputElement
@@ -125,9 +129,13 @@ class ControlBar extends React.Component<ControlBarProps, {}> {
     const nextButton = this.props.hasNextButton
       ? controlButton('Next', IconNames.ARROW_RIGHT, this.props.onClickNext, { iconOnRight: true })
       : undefined
+    const submitButton = this.props.hasSubmitButton
+      ? controlButton('Submit', IconNames.TICK_CIRCLE, this.props.onClickSubmit, { iconOnRight: true })
+      : undefined
+
     return (
       <div className="ControlBar_flow pt-button-group">
-        {previousButton} {nextButton}
+        {previousButton} {nextButton} {submitButton}
       </div>
     )
   }

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -130,7 +130,9 @@ class ControlBar extends React.Component<ControlBarProps, {}> {
       ? controlButton('Next', IconNames.ARROW_RIGHT, this.props.onClickNext, { iconOnRight: true })
       : undefined
     const submitButton = this.props.hasSubmitButton
-      ? controlButton('Submit', IconNames.TICK_CIRCLE, this.props.onClickSubmit, { iconOnRight: true })
+      ? controlButton('Submit', IconNames.TICK_CIRCLE, this.props.onClickSubmit, {
+          iconOnRight: true
+        })
       : undefined
 
     return (

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -3,9 +3,10 @@
  * (pasesed by react-router) into integers. A null value is returned
  * if the integer could not be parsed, or if the parameter was undefined.
  */
-export const parseStringToInt = (param?: string): number | null => {
-  if(param === undefined)
+export const stringParamToInt = (param?: string): number | null => {
+  if(param === undefined) {
     return null
+  }
   const num: number = parseInt(param, 10)
   return Number.isInteger(num) ? num : null
 }

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -4,15 +4,14 @@ import { AssessmentCategory } from '../components/assessment/assessmentShape'
  * Converts an AssessmentCategory into a string for use in URLs.
  * E.g Mission -> missions
  */
-export const assessmentCategoryLink = (cat: AssessmentCategory): string => cat.toLowerCase().concat('s')
+export const assessmentCategoryLink = (cat: AssessmentCategory): string =>
+  cat.toLowerCase().concat('s')
 
 /* Converts an optinal string parameter into an integer or null value. */
 export const stringParamToInt = (str?: string): number | null => {
-  if(str === undefined) {
+  if (str === undefined) {
     return null
-  } 
+  }
   const num = parseInt(str, 10)
-  return Number.isInteger(num) 
-    ? num
-    : null
+  return Number.isInteger(num) ? num : null
 }

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -3,16 +3,16 @@ import { AssessmentCategory } from '../components/assessment/assessmentShape'
 /**
  * Converts an AssessmentCategory into a string for use in URLs.
  *
- * @param {AssessmentCategory} cat - Any AssessmentCategory, usually 
+ * @param {AssessmentCategory} cat - Any AssessmentCategory, usually
  *   retrieved from the AssessmentCategories enum
  */
 export const assessmentCategoryLink = (cat: AssessmentCategory): string =>
   cat.toLowerCase().concat('s')
 
-/** Converts an optinal string 
+/** Converts an optinal string
  *  parameter into an integer or null value.
  *
- *  @param {string} str - An optional string to be 
+ *  @param {string} str - An optional string to be
  *    converted to an integer.
  */
 export const stringParamToInt = (str?: string): number | null => {

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -1,13 +1,20 @@
 import { AssessmentCategory } from '../components/assessment/assessmentShape'
 
-/*
+/**
  * Converts an AssessmentCategory into a string for use in URLs.
- * E.g Mission -> missions
+ *
+ * @param {AssessmentCategory} cat - Any AssessmentCategory, usually 
+ *   retrieved from the AssessmentCategories enum
  */
 export const assessmentCategoryLink = (cat: AssessmentCategory): string =>
   cat.toLowerCase().concat('s')
 
-/* Converts an optinal string parameter into an integer or null value. */
+/** Converts an optinal string 
+ *  parameter into an integer or null value.
+ *
+ *  @param {string} str - An optional string to be 
+ *    converted to an integer.
+ */
 export const stringParamToInt = (str?: string): number | null => {
   if (str === undefined) {
     return null

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -4,7 +4,7 @@
  * if the integer could not be parsed, or if the parameter was undefined.
  */
 export const stringParamToInt = (param?: string): number | null => {
-  if(param === undefined) {
+  if (param === undefined) {
     return null
   }
   const num: number = parseInt(param, 10)

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -1,12 +1,18 @@
+import { AssessmentCategory } from '../components/assessment/assessmentShape'
+
 /*
- * A helper function for parsing possibly optional string parameters 
- * (pasesed by react-router) into integers. A null value is returned
- * if the integer could not be parsed, or if the parameter was undefined.
+ * Converts an AssessmentCategory into a string for use in URLs.
+ * E.g Mission -> missions
  */
-export const stringParamToInt = (param?: string): number | null => {
-  if (param === undefined) {
+export const assessmentCategoryLink = (cat: AssessmentCategory): string => cat.toLowerCase().concat('s')
+
+/* Converts an optinal string parameter into an integer or null value. */
+export const stringParamToInt = (str?: string): number | null => {
+  if(str === undefined) {
     return null
-  }
-  const num: number = parseInt(param, 10)
-  return Number.isInteger(num) ? num : null
+  } 
+  const num = parseInt(str, 10)
+  return Number.isInteger(num) 
+    ? num
+    : null
 }

--- a/src/utils/paramParseHelpers.ts
+++ b/src/utils/paramParseHelpers.ts
@@ -1,0 +1,11 @@
+/*
+ * A helper function for parsing possibly optional string parameters 
+ * (pasesed by react-router) into integers. A null value is returned
+ * if the integer could not be parsed, or if the parameter was undefined.
+ */
+export const parseStringToInt = (param?: string): number | null => {
+  if(param === undefined)
+    return null
+  const num: number = parseInt(param, 10)
+  return Number.isInteger(num) ? num : null
+}


### PR DESCRIPTION
### Features
- User can now navigate between questions in an assessment
- Last question will show a 'Submit' button instead of a 'Next' button, that redirects to the appropriate assessment listing
- Regex handling of `id`-related URL parameters
- Utility function to handle parsing of react-router URL parameters e.g `assessmentId` and parsing `AssessmentCategory` to the strings we use for links. 

### Issues fixed
- #118 