### PR TITLE
Fix some CSS issues

### DIFF
--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -81,7 +81,7 @@ $code-color-error: #ff4444;
     overflow: hidden;
     .mcq-content-parent {
       height: 100%;
-      overflow: scroll;
+      overflow: auto;
     }
     .mcq-options-parent {
       margin-bottom: 20px;
@@ -122,6 +122,8 @@ $code-color-error: #ff4444;
       overflow-y: auto;
 
       .pt-card {
+        display: flex;
+        flex-direction: column;
         background-color: $cadet-color-2;
         color: $code-color-result;
         height: 100%;


### PR DESCRIPTION
- Scrollbars would show up for MCQs even with no overflow for me. Fixed by setting overflow to `auto` instead of `scroll`.
<p align="center">
<img src="https://thumbs.gfycat.com/ActiveRegularElephantbeetle-size_restricted.gif">
</p>
- CSS class side-content-text height being set to 100% would cause it to overflow when the side-content-tab buttons were being rendered. Fixed by setting flex.