### PR TITLE
Enable "display" standard library function

### DIFF
--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -13,7 +13,7 @@ import * as actionTypes from './actionTypes'
  */
 export enum WorkspaceLocations {
   assessment = 'assessment',
-  playground = 'playground',
+  playground = 'playground'
 }
 export type WorkspaceLocation = keyof typeof WorkspaceLocations
 

--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -12,8 +12,8 @@ import * as actionTypes from './actionTypes'
  * object in IWorkspaceManagerState.
  */
 export enum WorkspaceLocations {
-  assessment,
-  playground
+  assessment = 'assessment',
+  playground = 'playground',
 }
 export type WorkspaceLocation = keyof typeof WorkspaceLocations
 

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -1,3 +1,4 @@
+import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspace'
 import { Announcement } from '../components/Announcements'
 import { IAssessment, IAssessmentOverview } from '../components/assessment/assessmentShape'
 import { Context, createContext } from '../slang'
@@ -130,8 +131,8 @@ export const defaultApplication: IApplicationState = {
 
 export const defaultPlayground: IPlaygroundState = {}
 
-export const createDefaultWorkspace: () => IWorkspaceState = () => ({
-  context: createContext(latestSourceChapter),
+export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceState => ({
+  context: createContext<WorkspaceLocation>(latestSourceChapter, undefined, location),
   editorValue: undefined,
   editorWidth: '50%',
   isRunning: false,
@@ -144,8 +145,8 @@ export const createDefaultWorkspace: () => IWorkspaceState = () => ({
 export const defaultWorkspaceManager: IWorkspaceManagerState = {
   currentAssessment: undefined,
   currentQuestion: undefined,
-  assessment: { ...createDefaultWorkspace() },
-  playground: { ...createDefaultWorkspace() }
+  assessment: { ...createDefaultWorkspace(WorkspaceLocations.assessment) },
+  playground: { ...createDefaultWorkspace(WorkspaceLocations.playground) }
 }
 
 export const defaultSession: ISessionState = {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -1,4 +1,4 @@
-import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspace'
+import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspaces'
 import { Announcement } from '../components/Announcements'
 import { IAssessment, IAssessmentOverview } from '../components/assessment/assessmentShape'
 import { Context, createContext } from '../slang'

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -21,7 +21,7 @@ import {
   UPDATE_EDITOR_VALUE,
   UPDATE_REPL_VALUE
 } from '../actions/actionTypes'
-import { WorkspaceLocation } from '../actions/workspaces'
+import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspace'
 import { createContext } from '../slang'
 import {
   CodeOutput,
@@ -101,7 +101,7 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
         ...state,
         [location]: {
           ...state[location],
-          context: createContext(state[location].sourceChapter)
+          context: createContext<WorkspaceLocation>(state[location].sourceChapter, undefined, location)
         }
       }
     case CHANGE_CHAPTER:
@@ -220,7 +220,7 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
     case RESET_ASSESSMENT_WORKSPACE:
       return {
         ...state,
-        assessment: createDefaultWorkspace()
+        assessment: createDefaultWorkspace(WorkspaceLocations.assessment)
       }
     case UPDATE_CURRENT_ASSESSMENT_ID:
       return {

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -21,7 +21,7 @@ import {
   UPDATE_EDITOR_VALUE,
   UPDATE_REPL_VALUE
 } from '../actions/actionTypes'
-import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspace'
+import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspaces'
 import { createContext } from '../slang'
 import {
   CodeOutput,

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -121,12 +121,12 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
       if (lastOutput === undefined || lastOutput.type !== 'running') {
         newOutput = state[location].output.concat({
           type: 'running',
-          consoleLogs: [action.payload.log]
+          consoleLogs: [action.payload.logString]
         })
       } else {
         const updatedLastOutput = {
           type: lastOutput.type,
-          consoleLogs: lastOutput.consoleLogs.concat(action.payload.log)
+          consoleLogs: lastOutput.consoleLogs.concat(action.payload.logString)
         }
         newOutput = state[location].output.slice(0, -1).concat(updatedLastOutput)
       }

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -101,7 +101,11 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
         ...state,
         [location]: {
           ...state[location],
-          context: createContext<WorkspaceLocation>(state[location].sourceChapter, undefined, location)
+          context: createContext<WorkspaceLocation>(
+            state[location].sourceChapter,
+            undefined,
+            location
+          )
         }
       }
     case CHANGE_CHAPTER:

--- a/src/slang/createContext.ts
+++ b/src/slang/createContext.ts
@@ -17,9 +17,10 @@ const createEmptyRuntime = () => ({
   nodes: []
 })
 
-export const createEmptyContext = (chapter: number): Context => ({
+export const createEmptyContext = <T>(chapter: number, externalContext?: T): Context<T> => ({
   chapter,
   errors: [],
+  externalContext,
   cfg: createEmptyCFG(),
   runtime: createEmptyRuntime()
 })
@@ -130,8 +131,8 @@ export const importBuiltins = (context: Context) => {
   }
 }
 
-const createContext = (chapter = 1, externals = []) => {
-  const context = createEmptyContext(chapter)
+const createContext = <T>(chapter = 1, externals = [], externalContext?: T) => {
+  const context = createEmptyContext(chapter, externalContext)
 
   importBuiltins(context)
   importExternals(context, externals)

--- a/src/slang/createContext.ts
+++ b/src/slang/createContext.ts
@@ -60,8 +60,6 @@ export const importBuiltins = (context: Context) => {
   if (context.chapter >= 1) {
     defineSymbol(context, 'runtime', misc.runtime)
     defineSymbol(context, 'display', (value: Value) => misc.display(value, context.externalContext))
-    // tslint:disable-next-line:ban-types
-    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext))
     defineSymbol(context, 'error', misc.error_message)
     defineSymbol(context, 'prompt', prompt)
     defineSymbol(context, 'parse_int', misc.parse_int)
@@ -112,6 +110,8 @@ export const importBuiltins = (context: Context) => {
     // previously week 4
     defineSymbol(context, 'alert', alert)
     defineSymbol(context, 'math_floor', Math.floor)
+    // tslint:disable-next-line:ban-types
+    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext)) 
     // previously week 5
     defineSymbol(context, 'assoc', list.assoc)
     if (window.hasOwnProperty('ListVisualizer')) {

--- a/src/slang/createContext.ts
+++ b/src/slang/createContext.ts
@@ -111,7 +111,7 @@ export const importBuiltins = (context: Context) => {
     defineSymbol(context, 'alert', alert)
     defineSymbol(context, 'math_floor', Math.floor)
     // tslint:disable-next-line:ban-types
-    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext)) 
+    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext))
     // previously week 5
     defineSymbol(context, 'assoc', list.assoc)
     if (window.hasOwnProperty('ListVisualizer')) {

--- a/src/slang/createContext.ts
+++ b/src/slang/createContext.ts
@@ -61,7 +61,7 @@ export const importBuiltins = (context: Context) => {
     defineSymbol(context, 'runtime', misc.runtime)
     defineSymbol(context, 'display', (value: Value) => misc.display(value, context.externalContext))
     // tslint:disable-next-line:ban-types
-    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext)) // TODO move this back to Infinity (not assigned a chapter)
+    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext))
     defineSymbol(context, 'error', misc.error_message)
     defineSymbol(context, 'prompt', prompt)
     defineSymbol(context, 'parse_int', misc.parse_int)

--- a/src/slang/createContext.ts
+++ b/src/slang/createContext.ts
@@ -59,7 +59,9 @@ export const importBuiltins = (context: Context) => {
 
   if (context.chapter >= 1) {
     defineSymbol(context, 'runtime', misc.runtime)
-    defineSymbol(context, 'display', misc.display)
+    defineSymbol(context, 'display', (value: Value) => misc.display(value, context.externalContext))
+    // tslint:disable-next-line:ban-types
+    defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext)) // TODO move this back to Infinity (not assigned a chapter)
     defineSymbol(context, 'error', misc.error_message)
     defineSymbol(context, 'prompt', prompt)
     defineSymbol(context, 'parse_int', misc.parse_int)
@@ -110,7 +112,6 @@ export const importBuiltins = (context: Context) => {
     // previously week 4
     defineSymbol(context, 'alert', alert)
     defineSymbol(context, 'math_floor', Math.floor)
-    defineSymbol(context, 'timed', misc.timed)
     // previously week 5
     defineSymbol(context, 'assoc', list.assoc)
     if (window.hasOwnProperty('ListVisualizer')) {

--- a/src/slang/stdlib/misc.ts
+++ b/src/slang/stdlib/misc.ts
@@ -4,11 +4,11 @@ import { Value } from '../types'
 
 import { handleConsoleLog } from '../../actions'
 
-export function display(value: Value) {
+export function display(value: Value, location: any) {
   const output = toString(value)
   // TODO in 2019: fix this hack
   if (typeof (window as any).__REDUX_STORE__ !== 'undefined') {
-    ;(window as any).__REDUX_STORE__.dispatch(handleConsoleLog(output))
+    ;(window as any).__REDUX_STORE__.dispatch(handleConsoleLog(output, location))
   }
 }
 display.__SOURCE__ = 'display(a)'
@@ -20,7 +20,7 @@ export function error_message(value: Value) {
 error_message.__SOURCE__ = 'error(a)'
 
 // tslint:disable-next-line:no-any
-export function timed(this: any, f: Function) {
+export function timed(this: any, f: Function, location: any) {
   const self = this
   const timerType = Date
 
@@ -28,7 +28,7 @@ export function timed(this: any, f: Function) {
     const start = timerType.now()
     const result = f.apply(self, arguments)
     const diff = timerType.now() - start
-    display('Duration: ' + Math.round(diff) + 'ms')
+    display('Duration: ' + Math.round(diff) + 'ms', location)
     return result
   }
 }

--- a/src/slang/stdlib/misc.ts
+++ b/src/slang/stdlib/misc.ts
@@ -1,6 +1,6 @@
 /* tslint:disable: ban-types*/
 import { toString } from '../interop'
-import { Value } from '../types'
+import { Context, Value } from '../types'
 
 import { handleConsoleLog } from '../../actions'
 
@@ -20,14 +20,11 @@ export function error_message(value: Value) {
 error_message.__SOURCE__ = 'error(a)'
 
 // tslint:disable-next-line:no-any
-export function timed(this: any, f: Function, location: any) {
-  const self = this
-  const timerType = Date
-
-  return () => {
-    const start = timerType.now()
-    const result = f.apply(self, arguments)
-    const diff = timerType.now() - start
+export function timed(context: Context, f: Function, location: any) {
+  return (...args: any[]) => {
+    const start = runtime()
+    const result = f(...args)
+    const diff = runtime() - start
     display('Duration: ' + Math.round(diff) + 'ms', location)
     return result
   }

--- a/src/slang/types.ts
+++ b/src/slang/types.ts
@@ -117,7 +117,7 @@ export interface Context<T = any> {
    * For e.g, this can be used to store some application-related 
    * context for use in your own built-in functions (like `display(a)`)
    */
-  externalContext: T 
+  externalContext?: T 
 }
 
 // tslint:disable:no-any

--- a/src/slang/types.ts
+++ b/src/slang/types.ts
@@ -91,7 +91,7 @@ export interface TypeError extends SourceError {
   proof?: es.Node
 }
 
-export interface Context {
+export interface Context<T = any> {
   /** The source version used */
   chapter: number
 
@@ -111,6 +111,13 @@ export interface Context {
     frames: Frame[]
     nodes: es.Node[]
   }
+
+  /** 
+   * Used for storing external properties,
+   * e.g for interaction between slang and the 
+   * main application 
+   */
+  external: T 
 }
 
 // tslint:disable:no-any

--- a/src/slang/types.ts
+++ b/src/slang/types.ts
@@ -112,12 +112,12 @@ export interface Context<T = any> {
     nodes: es.Node[]
   }
 
-  /** 
+  /**
    * Used for storing external properties.
-   * For e.g, this can be used to store some application-related 
+   * For e.g, this can be used to store some application-related
    * context for use in your own built-in functions (like `display(a)`)
    */
-  externalContext?: T 
+  externalContext?: T
 }
 
 // tslint:disable:no-any

--- a/src/slang/types.ts
+++ b/src/slang/types.ts
@@ -113,11 +113,11 @@ export interface Context<T = any> {
   }
 
   /** 
-   * Used for storing external properties,
-   * e.g for interaction between slang and the 
-   * main application 
+   * Used for storing external properties.
+   * For e.g, this can be used to store some application-related 
+   * context for use in your own built-in functions (like `display(a)`)
    */
-  external: T 
+  externalContext: T 
 }
 
 // tslint:disable:no-any


### PR DESCRIPTION
### Features
- `display` and `timed` work
- Context now has a generic type that can be used to provide external properties, named `externalContext`. In this case, it is a `WorkspaceLocation`.

### Issues fixed
- Fixed an issue with WorkspaceLocation enums (untracked as blocking PR not merged)

### Caveat
- `display` and `timed` do not work unless `redux-persist` is turned off. This is related to #138 , where it attempts to stores the Context (when it is not supposed to), or something related to the workspace, and hence throw an error on trying to serialise an object with a circular structure. Once #138  is resolved, the functions will work.