### PR TITLE
Implement more reliable caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     }
   },
   "dependencies": {
-    "@types/lodash": "^4.14.110",
     "acorn": "^5.7.1",
     "astring": "^1.3.0",
     "common-tags": "^1.7.2",
@@ -73,6 +72,7 @@
     "@types/estree": "^0.0.39",
     "@types/invariant": "^2.2.29",
     "@types/jest": "^22.2.3",
+    "@types/lodash": "^4.14.110",
     "@types/lz-string": "^1.3.32",
     "@types/node": "^9.6.5",
     "@types/pixi.js": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     }
   },
   "dependencies": {
+    "@types/lodash": "^4.14.110",
     "acorn": "^5.7.1",
     "astring": "^1.3.0",
     "common-tags": "^1.7.2",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
+    "lodash": "^4.17.10",
     "lz-string": "^1.4.4",
     "node-sass-chokidar": "^1.3.0",
     "normalize.css": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
     "redux-mock-store": "^1.5.1",
-    "redux-persist": "5.9.1",
-    "redux-persist-transform-filter": "^0.0.18",
     "redux-saga": "^0.15.6",
     "typesafe-actions": "^1.1.2",
     "utility-types": "^2.0.0"

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash'
 import * as React from 'react'
 import AceEditor from 'react-ace'
 import { HotKeys } from 'react-hotkeys'
@@ -28,7 +29,10 @@ class Editor extends React.Component<IEditorProps, {}> {
             mode="javascript"
             theme="cobalt"
             value={this.props.editorValue}
-            onChange={this.props.handleEditorValueChange}
+            onChange={throttle(this.props.handleEditorValueChange, 800, {
+              leading: false, 
+              trailing: true
+            })}
             height="100%"
             commands={[
               {

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -30,7 +30,7 @@ class Editor extends React.Component<IEditorProps, {}> {
             theme="cobalt"
             value={this.props.editorValue}
             onChange={throttle(this.props.handleEditorValueChange, 800, {
-              leading: false, 
+              leading: false,
               trailing: true
             })}
             height="100%"

--- a/src/components/workspace/ReplInput.tsx
+++ b/src/components/workspace/ReplInput.tsx
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash'
 import * as React from 'react'
 import AceEditor from 'react-ace'
 
@@ -20,7 +21,10 @@ class ReplInput extends React.Component<IReplInputProps, {}> {
         height="1px"
         width="100%"
         value={this.props.replValue}
-        onChange={this.props.handleReplValueChange}
+        onChange={throttle(this.props.handleReplValueChange, 2000, {
+          leading: false, 
+          trailing: true
+        })}
         commands={[
           {
             name: 'evaluate',

--- a/src/components/workspace/ReplInput.tsx
+++ b/src/components/workspace/ReplInput.tsx
@@ -22,7 +22,7 @@ class ReplInput extends React.Component<IReplInputProps, {}> {
         width="100%"
         value={this.props.replValue}
         onChange={throttle(this.props.handleReplValueChange, 2000, {
-          leading: false, 
+          leading: false,
           trailing: true
         })}
         commands={[

--- a/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Editor renders correctly 1`] = `
 "<HotKeys className=\\"Editor\\" handlers={{...}}>
   <div className=\\"row editor-react-ace\\">
-    <ReactAce className=\\"react-ace\\" mode=\\"javascript\\" theme=\\"cobalt\\" value=\\"\\" onChange={[Function: handleEditorValueChange]} height=\\"100%\\" commands={{...}} width=\\"100%\\" fontSize={14} highlightActiveLine={false} name=\\"brace-editor\\" focus={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+    <ReactAce className=\\"react-ace\\" mode=\\"javascript\\" theme=\\"cobalt\\" value=\\"\\" onChange={[Function: debounced]} height=\\"100%\\" commands={{...}} width=\\"100%\\" fontSize={14} highlightActiveLine={false} name=\\"brace-editor\\" focus={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
   </div>
 </HotKeys>"
 `;

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -1,24 +1,23 @@
 import { History } from 'history'
 import { routerMiddleware, routerReducer } from 'react-router-redux'
-import { applyMiddleware, compose, createStore as _createStore, Store, StoreEnhancer } from 'redux'
-import { persistCombineReducers, PersistConfig, persistStore } from 'redux-persist'
-import { createFilter } from 'redux-persist-transform-filter'
-import storage from 'redux-persist/lib/storage' // defaults to localStorage
+import {
+  applyMiddleware,
+  combineReducers,
+  compose,
+  createStore as _createStore,
+  Store,
+  StoreEnhancer
+} from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
 import reducers from './reducers'
-import { IApplicationState, ISessionState, IState } from './reducers/states'
+import { IState } from './reducers/states'
 import mainSaga from './sagas'
 import { history as appHistory } from './utils/history'
 
 declare var __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: () => StoreEnhancer<IState>
 
-type IPersistState = Pick<IApplicationState, 'environment'> &
-  Pick<ISessionState, 'historyHelper'> &
-  Pick<ISessionState, 'token'> &
-  Pick<ISessionState, 'username'>
-
-function createStore(history: History) {
+function createStore(history: History): Store<IState> {
   let composeEnhancers: any = compose
   const sagaMiddleware = createSagaMiddleware()
   const middleware = [sagaMiddleware, routerMiddleware(history)]
@@ -27,31 +26,15 @@ function createStore(history: History) {
     composeEnhancers = __REDUX_DEVTOOLS_EXTENSION_COMPOSE__
   }
 
-  const transforms = [
-    createFilter<IState, IPersistState>('application', ['environment']),
-    createFilter<IState, IPersistState>('session', ['token', 'username', 'historyHelper'])
-  ]
-
-  const persistConfig: PersistConfig = {
-    key: 'root',
-    storage,
-    transforms: [...transforms]
-  }
-
-  const persistedReducer = persistCombineReducers<IState>(persistConfig, {
+  const rootReducer = combineReducers({
     ...reducers,
     router: routerReducer
   })
-
   const enchancers = composeEnhancers(applyMiddleware(...middleware))
-  const createdStore = _createStore(persistedReducer, enchancers) as Store<IState>
+  const createdStore = _createStore(rootReducer, enchancers)
+
   sagaMiddleware.run(mainSaga)
   return createdStore
 }
 
-function createPersistor(createdStore: Store<IState>) {
-  return persistStore(createdStore)
-}
-
-export const store = createStore(appHistory)
-export const persistor = createPersistor(store)
+export const store = createStore(appHistory) as Store<IState>

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -1,4 +1,5 @@
 import { History } from 'history'
+import { throttle } from 'lodash'
 import { routerMiddleware, routerReducer } from 'react-router-redux'
 import {
   applyMiddleware,
@@ -47,9 +48,9 @@ function createStore(history: History): Store<IState> {
 
   sagaMiddleware.run(mainSaga)
 
-  createdStore.subscribe(() => {
+  createdStore.subscribe(throttle(() => {
     saveState(store.getState())
-  })
+  }, 1000))
 
   return createdStore
 }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -10,7 +10,7 @@ import {
 } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
-import { loadStoredState } from './localStorage'
+import { loadStoredState, saveState } from './localStorage'
 import reducers from './reducers'
 import { defaultState, IState } from './reducers/states'
 import mainSaga from './sagas'
@@ -46,7 +46,13 @@ function createStore(history: History): Store<IState> {
   const createdStore = _createStore<IState>(rootReducer, initialStore, enchancers)
 
   sagaMiddleware.run(mainSaga)
+
+  createdStore.subscribe(() => {
+    saveState(store.getState())
+  })
+
   return createdStore
 }
 
 export const store = createStore(appHistory) as Store<IState>
+

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -48,12 +48,13 @@ function createStore(history: History): Store<IState> {
 
   sagaMiddleware.run(mainSaga)
 
-  createdStore.subscribe(throttle(() => {
-    saveState(store.getState())
-  }, 1000))
+  createdStore.subscribe(
+    throttle(() => {
+      saveState(store.getState())
+    }, 1000)
+  )
 
   return createdStore
 }
 
 export const store = createStore(appHistory) as Store<IState>
-

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -32,10 +32,17 @@ function createStore(history: History): Store<IState> {
     router: routerReducer
   })
   const enchancers = composeEnhancers(applyMiddleware(...middleware))
-  const loadedStore = loadStoredState() || defaultState
-  // tslint:disable-next-line
-  console.log("Loading: \n" + JSON.stringify(loadedStore))
-  const createdStore = _createStore(rootReducer, loadedStore, enchancers)
+  const loadedStore = loadStoredState() 
+  const initialStore: IState = loadedStore === undefined
+    ? defaultState
+    : {
+      ...defaultState,
+      session: {
+        ...defaultState.session,
+        ...loadedStore
+      }
+    }
+  const createdStore = _createStore<IState>(rootReducer, initialStore, enchancers)
 
   sagaMiddleware.run(mainSaga)
   return createdStore

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -10,8 +10,9 @@ import {
 } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
+import { loadStoredState } from './localStorage'
 import reducers from './reducers'
-import { IState } from './reducers/states'
+import { defaultState , IState } from './reducers/states'
 import mainSaga from './sagas'
 import { history as appHistory } from './utils/history'
 
@@ -26,12 +27,15 @@ function createStore(history: History): Store<IState> {
     composeEnhancers = __REDUX_DEVTOOLS_EXTENSION_COMPOSE__
   }
 
-  const rootReducer = combineReducers({
+  const rootReducer = combineReducers<IState>({
     ...reducers,
     router: routerReducer
   })
   const enchancers = composeEnhancers(applyMiddleware(...middleware))
-  const createdStore = _createStore(rootReducer, enchancers)
+  const loadedStore = loadStoredState() || defaultState
+  // tslint:disable-next-line
+  console.log("Loading: \n" + JSON.stringify(loadedStore))
+  const createdStore = _createStore(rootReducer, loadedStore, enchancers)
 
   sagaMiddleware.run(mainSaga)
   return createdStore

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -12,7 +12,7 @@ import createSagaMiddleware from 'redux-saga'
 
 import { loadStoredState } from './localStorage'
 import reducers from './reducers'
-import { defaultState , IState } from './reducers/states'
+import { defaultState, IState } from './reducers/states'
 import mainSaga from './sagas'
 import { history as appHistory } from './utils/history'
 
@@ -32,16 +32,17 @@ function createStore(history: History): Store<IState> {
     router: routerReducer
   })
   const enchancers = composeEnhancers(applyMiddleware(...middleware))
-  const loadedStore = loadStoredState() 
-  const initialStore: IState = loadedStore === undefined
-    ? defaultState
-    : {
-      ...defaultState,
-      session: {
-        ...defaultState.session,
-        ...loadedStore
-      }
-    }
+  const loadedStore = loadStoredState()
+  const initialStore: IState =
+    loadedStore === undefined
+      ? defaultState
+      : {
+          ...defaultState,
+          session: {
+            ...defaultState.session,
+            ...loadedStore
+          }
+        }
   const createdStore = _createStore<IState>(rootReducer, initialStore, enchancers)
 
   sagaMiddleware.run(mainSaga)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'react-router-redux'
 
 import ApplicationContainer from './containers/ApplicationContainer'
 import { store } from './createStore'
+import { saveState as _saveState } from './localStorage'
 import { VERSION } from './utils/constants'
 import { history } from './utils/history'
 import registerServiceWorker from './utils/registerServiceWorker'
@@ -20,6 +20,18 @@ console.log(
     'Please visit https://github.com/source-academy/cadet-frontend/issues to report bugs or issues.',
   'font-weight: bold;'
 )
+
+const saveState = (state: any) => {
+  // tslint:disable-next-line
+  console.log("Saving State: \n" + JSON.stringify(state))
+  _saveState(
+    state
+  )
+}
+
+store.subscribe(() => {
+  saveState(store.getState())
+});
 
 render(
   <Provider store={store}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ console.log(
 
 store.subscribe(() => {
   saveState(store.getState())
-});
+})
 
 render(
   <Provider store={store}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
+
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'react-router-redux'
-import { PersistGate } from 'redux-persist/integration/react'
 
 import ApplicationContainer from './containers/ApplicationContainer'
-import { persistor, store } from './createStore'
+import { store } from './createStore'
 import { VERSION } from './utils/constants'
 import { history } from './utils/history'
 import registerServiceWorker from './utils/registerServiceWorker'
@@ -23,11 +23,9 @@ console.log(
 
 render(
   <Provider store={store}>
-    <PersistGate loading={null} persistor={persistor}>
-      <ConnectedRouter history={history}>
-        <ApplicationContainer />
-      </ConnectedRouter>
-    </PersistGate>
+    <ConnectedRouter history={history}>
+      <ApplicationContainer />
+    </ConnectedRouter>
   </Provider>,
   rootContainer
 )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { ConnectedRouter } from 'react-router-redux'
 
 import ApplicationContainer from './containers/ApplicationContainer'
 import { store } from './createStore'
-import { saveState as _saveState } from './localStorage'
+import { saveState } from './localStorage'
 import { VERSION } from './utils/constants'
 import { history } from './utils/history'
 import registerServiceWorker from './utils/registerServiceWorker'
@@ -20,14 +20,6 @@ console.log(
     'Please visit https://github.com/source-academy/cadet-frontend/issues to report bugs or issues.',
   'font-weight: bold;'
 )
-
-const saveState = (state: any) => {
-  // tslint:disable-next-line
-  console.log("Saving State: \n" + JSON.stringify(state))
-  _saveState(
-    state
-  )
-}
 
 store.subscribe(() => {
   saveState(store.getState())

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import { ConnectedRouter } from 'react-router-redux'
 
 import ApplicationContainer from './containers/ApplicationContainer'
 import { store } from './createStore'
-import { saveState } from './localStorage'
 import { VERSION } from './utils/constants'
 import { history } from './utils/history'
 import registerServiceWorker from './utils/registerServiceWorker'
@@ -20,10 +19,6 @@ console.log(
     'Please visit https://github.com/source-academy/cadet-frontend/issues to report bugs or issues.',
   'font-weight: bold;'
 )
-
-store.subscribe(() => {
-  saveState(store.getState())
-})
 
 render(
   <Provider store={store}>

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,0 +1,23 @@
+import { IState } from './reducers/states'
+
+export const loadStoredState = (): IState | undefined => {
+  try {
+    const serializedState = localStorage.getItem('state')
+    if (serializedState === null) {
+      return undefined
+    } else {
+      return JSON.parse(serializedState) as IState
+    }
+  } catch (err) {
+    return undefined
+  }
+}
+
+export const saveState = (state: IState) => {
+  try {
+    const serializedState = JSON.stringify(state)
+    localStorage.setItem('state', serializedState)
+  } catch (err) {
+    // TODO catch possible errors
+  }
+}

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -13,8 +13,6 @@ export const loadStoredState = (): ISavedState | undefined => {
     if (serializedState === null) {
       return undefined
     } else {
-      // tslint:disable-next-line
-      console.log('Loading State: \n' + serializedState)
       return JSON.parse(serializedState) as ISavedState
     }
   } catch (err) {
@@ -29,11 +27,9 @@ export const saveState = (state: IState) => {
       username: state.session.username,
       historyHelper: state.session.historyHelper
     }
-    // tslint:disable-next-line
-    console.log('Saving State: \n' + JSON.stringify(stateToBeSaved))
     const serialized = JSON.stringify(stateToBeSaved)
     localStorage.setItem('storedState', serialized)
   } catch (err) {
-    // TODO catch possible errors
+    // Issue #143
   }
 }

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,12 +1,21 @@
 import { IState } from './reducers/states'
+import { HistoryHelper } from './utils/history'
 
-export const loadStoredState = (): IState | undefined => {
+export interface ISavedState {
+  historyHelper: HistoryHelper,
+  token?: string,
+  username?: string
+}
+
+export const loadStoredState = (): ISavedState | undefined => {
   try {
-    const serializedState = localStorage.getItem('state')
+    const serializedState = localStorage.getItem('storedState')
     if (serializedState === null) {
       return undefined
     } else {
-      return JSON.parse(serializedState) as IState
+      // tslint:disable-next-line
+      console.log("Loading State: \n" + serializedState)
+      return JSON.parse(serializedState) as ISavedState
     }
   } catch (err) {
     return undefined
@@ -15,8 +24,15 @@ export const loadStoredState = (): IState | undefined => {
 
 export const saveState = (state: IState) => {
   try {
-    const serializedState = JSON.stringify(state)
-    localStorage.setItem('state', serializedState)
+    const stateToBeSaved: ISavedState = {
+      token: state.session.token,
+      username: state.session.username,
+      historyHelper: state.session.historyHelper
+    }
+    // tslint:disable-next-line
+    console.log("Saving State: \n" + JSON.stringify(stateToBeSaved))
+    const serialized = JSON.stringify(stateToBeSaved)
+    localStorage.setItem('storedState', serialized)
   } catch (err) {
     // TODO catch possible errors
   }

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -2,8 +2,8 @@ import { IState } from './reducers/states'
 import { HistoryHelper } from './utils/history'
 
 export interface ISavedState {
-  historyHelper: HistoryHelper,
-  token?: string,
+  historyHelper: HistoryHelper
+  token?: string
   username?: string
 }
 
@@ -14,7 +14,7 @@ export const loadStoredState = (): ISavedState | undefined => {
       return undefined
     } else {
       // tslint:disable-next-line
-      console.log("Loading State: \n" + serializedState)
+      console.log('Loading State: \n' + serializedState)
       return JSON.parse(serializedState) as ISavedState
     }
   } catch (err) {
@@ -30,7 +30,7 @@ export const saveState = (state: IState) => {
       historyHelper: state.session.historyHelper
     }
     // tslint:disable-next-line
-    console.log("Saving State: \n" + JSON.stringify(stateToBeSaved))
+    console.log('Saving State: \n' + JSON.stringify(stateToBeSaved))
     const serialized = JSON.stringify(stateToBeSaved)
     localStorage.setItem('storedState', serialized)
   } catch (err) {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,11 +1,13 @@
 import { reducer as academy } from './academy'
 import { reducer as application } from './application'
+import { reducer as playground } from './playground'
 import { reducer as session } from './session'
 import { reducer as workspaces } from './workspaces'
 
 export default {
   academy,
   application,
-  workspaces,
-  session
+  playground,
+  session,
+  workspaces
 }

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -1,0 +1,11 @@
+import { Reducer } from 'redux'
+
+import { IAction } from '../actions/actionTypes'
+import { defaultPlayground, IPlaygroundState } from './states'
+
+export const reducer: Reducer<IPlaygroundState> = (state = defaultPlayground, action: IAction) => {
+  switch (action.type) {
+    default:
+      return state
+  }
+}

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -119,6 +119,7 @@ const currentEnvironment = (): ApplicationEnvironment => {
   }
 }
 
+
 export const defaultAcademy: IAcademyState = {
   gameCanvas: undefined
 }
@@ -166,4 +167,12 @@ export const defaultSession: ISessionState = {
   },
   token: undefined,
   username: undefined
+}
+
+export const defaultState: IState = {
+  academy: defaultAcademy,
+  application: defaultApplication,
+  playground: defaultPlayground,
+  session: defaultSession,
+  workspaces: defaultWorkspaceManager
 }

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -119,7 +119,6 @@ const currentEnvironment = (): ApplicationEnvironment => {
   }
 }
 
-
 export const defaultAcademy: IAcademyState = {
   gameCanvas: undefined
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5067,7 +5067,7 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
+lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
@@ -5083,10 +5083,6 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
-lodash.forin@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"
-
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -5094,10 +5090,6 @@ lodash.get@^4.4.2:
 lodash.isboolean@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
 lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
   version "4.5.0"
@@ -5127,14 +5119,6 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
-lodash.pickby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -5159,10 +5143,6 @@ lodash.templatesettings@^4.0.0:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-
-lodash.unset@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"
 
 "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
@@ -7069,22 +7049,6 @@ redux-mock-store@^1.5.1:
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
   dependencies:
     lodash.isplainobject "^4.0.6"
-
-redux-persist-transform-filter@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/redux-persist-transform-filter/-/redux-persist-transform-filter-0.0.18.tgz#bc9901a0267bd64631099b4e7bb4d48c00647418"
-  dependencies:
-    lodash.clonedeep "^4.5.0"
-    lodash.forin "^4.4.0"
-    lodash.get "^4.4.2"
-    lodash.isempty "^4.4.0"
-    lodash.pickby "^4.6.0"
-    lodash.set "^4.3.2"
-    lodash.unset "^4.5.2"
-
-redux-persist@5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.9.1.tgz#83bd4abd526ef768f63fceee338fa9d8ed6552d6"
 
 redux-saga@^0.15.6:
   version "0.15.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,10 @@
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
 
+"@types/lodash@^4.14.110":
+  version "4.14.110"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.110.tgz#fb07498f84152947f30ea09d89207ca07123461e"
+
 "@types/lz-string@^1.3.32":
   version "1.3.32"
   resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.32.tgz#60e26d0f70daa6bf385b9437bb02f661a5713f81"
@@ -5148,7 +5152,7 @@ lodash.uniq@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.0.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.17.10, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
### Features
- No more dependency on redux-persist (that caused the issues below)
- State is mapped more transparently onto a stored type (`IStoredState`) and stored onto localStorage
- Throttling is enabled for saving the state, and **for updating React-Ace editor values**.
- Empty playground reducer added for consistency, and preventing a jest error (wrong key 'playground' in state as there is no such reducer. The reducers passed to combineReducers must have names that [map to slices of the state](https://redux.js.org/api-reference/combinereducers)).

--- 

### Issues fixed:
- #138 
- #129