### PR TITLE
Fix interpreter not running asynchronously

### DIFF
--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -117,7 +117,7 @@ function* playgroundSaga(): SagaIterator {
 
 function* evalCode(code: string, context: Context, location: WorkspaceLocation) {
   const { result, interrupted } = yield race({
-    result: call(runInContext, code, context, { scheduler: 'async' }),
+    result: call(runInContext, code, context),
     interrupted: take(actionTypes.INTERRUPT_EXECUTION)
   })
   if (result) {

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -117,7 +117,7 @@ function* playgroundSaga(): SagaIterator {
 
 function* evalCode(code: string, context: Context, location: WorkspaceLocation) {
   const { result, interrupted } = yield race({
-    result: call(runInContext, code, context),
+    result: call(runInContext, code, context, { scheduler: 'preemptive' }),
     interrupted: take(actionTypes.INTERRUPT_EXECUTION)
   })
   if (result) {

--- a/src/slang/__tests__/index.ts
+++ b/src/slang/__tests__/index.ts
@@ -6,7 +6,7 @@ import { Finished } from '../types'
 test('Empty code returns undefined', () => {
   const code = ''
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -17,7 +17,7 @@ test('Empty code returns undefined', () => {
 test('Single string self-evaluates to itself', () => {
   const code = "'42';"
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -28,7 +28,7 @@ test('Single string self-evaluates to itself', () => {
 test('Single number self-evaluates to itself', () => {
   const code = '42;'
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -39,7 +39,7 @@ test('Single number self-evaluates to itself', () => {
 test('Single boolean self-evaluates to itself', () => {
   const code = 'true;'
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -50,7 +50,7 @@ test('Single boolean self-evaluates to itself', () => {
 test('Arrow function definition returns itself', () => {
   const code = '() => 42;'
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -64,7 +64,7 @@ test('Factorial arrow function', () => {
     fac(5);
   `
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     expect(obj).toMatchSnapshot()
     expect(obj.status).toBe('finished')
@@ -75,7 +75,7 @@ test('Factorial arrow function', () => {
 test('parseError for missing semicolon', () => {
   const code = '42'
   const context = mockContext()
-  const promise = runInContext(code, context)
+  const promise = runInContext(code, context, { scheduler: 'preemptive' })
   return promise.then(obj => {
     const errors = parseError(context.errors)
     expect(errors).toMatchSnapshot()
@@ -87,7 +87,7 @@ test(
   () => {
     const code = '(x => x(x))(x => x(x));'
     const context = mockContext()
-    const promise = runInContext(code, context)
+    const promise = runInContext(code, context, { scheduler: 'preemptive' })
     return promise.then(obj => {
       const errors = parseError(context.errors)
       expect(errors).toMatchSnapshot()
@@ -104,7 +104,7 @@ test(
     f(list(1, 2 ));
   `
     const context = mockContext(2)
-    const promise = runInContext(code, context)
+    const promise = runInContext(code, context, { scheduler: 'preemptive' })
     return promise.then(obj => {
       const errors = parseError(context.errors)
       expect(errors).toMatchSnapshot()
@@ -121,7 +121,7 @@ test(
     f(0);
   `
     const context = mockContext()
-    const promise = runInContext(code, context)
+    const promise = runInContext(code, context, { scheduler: 'preemptive' })
     return promise.then(obj => {
       const errors = parseError(context.errors)
       expect(errors).toEqual(

--- a/src/slang/index.ts
+++ b/src/slang/index.ts
@@ -30,13 +30,13 @@ export function runInContext(
   context: Context,
   options: Partial<IOptions> = {}
 ): Promise<Result> {
-  const theOptions: IOptions = { ...options, ...DEFAULT_OPTIONS }
+  const theOptions: IOptions = { ...DEFAULT_OPTIONS, ...options }
   context.errors = []
   const program = parse(code, context)
   if (program) {
     const it = evaluate(program, context)
     let scheduler: Scheduler
-    if (options.scheduler === 'async') {
+    if (theOptions.scheduler === 'async') {
       scheduler = new AsyncScheduler()
     } else {
       scheduler = new PreemptiveScheduler(theOptions.steps)


### PR DESCRIPTION
Test with:

```javascript
const f = (i) => i < 3 ? 0 : f(i-1) + f(i-2);
const delay = () => f(15);

function countdown(n) {
    display(n);
    delay();
    return n < 1 ? 'Done!' : countdown(n-1);
}

countdown(15);
```

I went through the commit history and traced the bug to 09fddfb, where I added the argument `{ scheduler: 'async' }` to `runInContext` in the saga. ~~~Strangely enough, this should already be the default (see `src/slang/index.ts:19, 33`), so supplying this argument shouldn't change anything?~~~

The default scheduler is actually PreemptiveScheduler, because the if/else clause that checks this refers to the variable `options` rather than the default-included parameter `theOptions`.

```javascript
export function runInContext(
  code: string,
  context: Context,
  options: Partial<IOptions> = {}
): Promise<Result> {
  const theOptions: IOptions = { ...options, ...DEFAULT_OPTIONS }
  context.errors = []
  const program = parse(code, context)
  if (program) {
    const it = evaluate(program, context)
    let scheduler: Scheduler
    if (options.scheduler === 'async') {
      scheduler = new AsyncScheduler()
    } else {
      scheduler = new PreemptiveScheduler(theOptions.steps)
    }
    return scheduler.run(it, context)
  } else {
    return Promise.resolve({ status: 'error' } as Result)
  }
}
```

Fixed this functions options/default_options in 90efbc3.

Fixes #142.