### PR TITLE
Remove throttle for editorValue, fix workspace bugs

### DIFF
--- a/src/actions/playground.ts
+++ b/src/actions/playground.ts
@@ -1,5 +1,12 @@
+import { ActionCreator } from 'redux'
+
 import * as actionTypes from './actionTypes'
 
 export const generateLzString = () => ({
   type: actionTypes.GENERATE_LZ_STRING
+})
+
+export const changeQueryString: ActionCreator<actionTypes.IAction> = (queryString: string) => ({
+  type: actionTypes.CHANGE_QUERY_STRING,
+  payload: queryString
 })

--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -41,14 +41,6 @@ export const changeEditorWidth: ActionCreator<actionTypes.IAction> = (
   payload: { widthChange, workspaceLocation }
 })
 
-export const changeQueryString: ActionCreator<actionTypes.IAction> = (
-  queryString: string,
-  workspaceLocation: WorkspaceLocation
-) => ({
-  type: actionTypes.CHANGE_QUERY_STRING,
-  payload: { queryString, workspaceLocation }
-})
-
 export const changeSideContentHeight: ActionCreator<actionTypes.IAction> = (
   height: number,
   workspaceLocation: WorkspaceLocation

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -1,3 +1,5 @@
+import { decompressFromEncodedURIComponent } from 'lz-string'
+import * as qs from 'query-string'
 import * as React from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 
@@ -5,25 +7,32 @@ import Academy from '../containers/academy'
 import Announcements from '../containers/AnnouncementsContainer'
 import Login from '../containers/LoginContainer'
 import Playground from '../containers/PlaygroundContainer'
+import { sourceChapters } from '../reducers/states'
 import NavigationBar from './NavigationBar'
 import NotFound from './NotFound'
 
-export interface IApplicationProps extends RouteComponentProps<{}> {
+export interface IApplicationProps extends IDispatchProps, RouteComponentProps<{}> {
   title: string
   accessToken?: string
   username?: string
+}
+
+export interface IDispatchProps {
+  handleChangeChapter: (chapter: number) => void
+  handleEditorValueChange: (val: string) => void
 }
 
 const Application: React.SFC<IApplicationProps> = props => {
   const redirectToNews = () => <Redirect to="/news" />
   const toAcademy = () => <Academy accessToken={props.accessToken} />
 
+  parsePlayground(props)
+
   return (
     <div className="Application">
       <NavigationBar title={props.title} username={props.username} />
       <div className="Application__main">
         <Switch>
-          // tslint: disable-next-line
           <Route path="/academy" component={toAcademy} />
           <Route path="/news" component={Announcements} />
           <Route path="/material" component={Announcements} />
@@ -36,6 +45,30 @@ const Application: React.SFC<IApplicationProps> = props => {
       </div>
     </div>
   )
+}
+
+export const parsePlayground = (props: IApplicationProps) => {
+  const prgrm = parsePrgrm(props)
+  const lib = parseLib(props)
+  if (prgrm) {
+    props.handleEditorValueChange(prgrm)
+  }
+  if (lib) {
+    props.handleChangeChapter(lib)
+  }
+}
+
+const parsePrgrm = (props: RouteComponentProps<{}>) => {
+  const qsParsed = qs.parse(props.location.hash)
+  // legacy support
+  const program = qsParsed.lz !== undefined ? qsParsed.lz : qsParsed.prgrm
+  return program !== undefined ? decompressFromEncodedURIComponent(program) : undefined
+}
+
+const parseLib = (props: RouteComponentProps<{}>) => {
+  const libQuery = qs.parse(props.location.hash).lib
+  const lib = libQuery === undefined ? NaN : parseInt(libQuery, 10)
+  return sourceChapters.includes(lib) ? lib : undefined
 }
 
 export default Application

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -18,6 +18,7 @@ export interface IStateProps {
   editorWidth: string
   isRunning: boolean
   output: InterpreterOutput[]
+  queryString?: string
   replValue: string
   sideContentHeight?: number
 }
@@ -28,6 +29,7 @@ export interface IDispatchProps {
   handleEditorEval: () => void
   handleEditorValueChange: (val: string) => void
   handleEditorWidthChange: (widthChange: number) => void
+  handleGenerateLz: () => void
   handleInterruptEval: () => void
   handleReplEval: () => void
   handleReplOutputClear: () => void
@@ -55,6 +57,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
       controlBarProps: {
         handleChapterSelect: this.props.handleChapterSelect,
         handleEditorEval: this.props.handleEditorEval,
+        handleGenerateLz: this.props.handleGenerateLz,
         handleInterruptEval: this.props.handleInterruptEval,
         handleReplEval: this.props.handleReplEval,
         handleReplOutputClear: this.props.handleReplOutputClear,
@@ -62,6 +65,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         hasPreviousButton: false,
         hasSubmitButton: false,
         isRunning: this.props.isRunning,
+        queryString: this.props.queryString,
         sourceChapter: parseLibrary(this.props) || 2
       },
       editorProps: {

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -14,7 +14,7 @@ export interface IPlaygroundProps extends IDispatchProps, IStateProps, RouteComp
 
 export interface IStateProps {
   activeTab: number
-  editorValue?: string
+  editorValue: string
   editorWidth: string
   isRunning: boolean
   output: InterpreterOutput[]
@@ -97,9 +97,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
   }
 
   private chooseEditorValue(props: IPlaygroundProps): string {
-    return parsePrgrm(this.props) || this.props.editorValue === undefined
-      ? defaultPlaygroundText
-      : this.props.editorValue
+    return parsePrgrm(this.props) || this.props.editorValue
   }
 
   private toggleIsGreen() {
@@ -122,7 +120,6 @@ const parseLibrary = (props: IPlaygroundProps) => {
 
 const SICP_SITE = 'http://www.comp.nus.edu.sg/~henz/sicp_js/'
 const CHAP = '\xa7'
-const defaultPlaygroundText = '// Type your code here!'
 const playgroundIntroduction: SideContentTab = {
   label: 'Introduction',
   icon: IconNames.COMPASS,

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -60,6 +60,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         handleInterruptEval: this.props.handleInterruptEval,
         handleReplEval: this.props.handleReplEval,
         handleReplOutputClear: this.props.handleReplOutputClear,
+        hasChapterSelect: true,
         hasNextButton: false,
         hasPreviousButton: false,
         hasSubmitButton: false,

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,12 +1,10 @@
 import { Text } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
-import { decompressFromEncodedURIComponent } from 'lz-string'
-import * as qs from 'query-string'
 import * as React from 'react'
 import { HotKeys } from 'react-hotkeys'
 import { RouteComponentProps } from 'react-router'
 
-import { InterpreterOutput, sourceChapters } from '../reducers/states'
+import { InterpreterOutput } from '../reducers/states'
 import Workspace, { WorkspaceProps } from './workspace'
 import { SideContentTab } from './workspace/side-content'
 
@@ -21,6 +19,7 @@ export interface IStateProps {
   queryString?: string
   replValue: string
   sideContentHeight?: number
+  sourceChapter: number
 }
 
 export interface IDispatchProps {
@@ -66,10 +65,10 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         hasSubmitButton: false,
         isRunning: this.props.isRunning,
         queryString: this.props.queryString,
-        sourceChapter: parseLibrary(this.props) || 2
+        sourceChapter: this.props.sourceChapter
       },
       editorProps: {
-        editorValue: this.chooseEditorValue(this.props),
+        editorValue: this.props.editorValue,
         handleEditorEval: this.props.handleEditorEval,
         handleEditorValueChange: this.props.handleEditorValueChange
       },
@@ -100,26 +99,9 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
     )
   }
 
-  private chooseEditorValue(props: IPlaygroundProps): string {
-    return parsePrgrm(this.props) || this.props.editorValue
-  }
-
   private toggleIsGreen() {
     this.setState({ isGreen: !this.state.isGreen })
   }
-}
-
-const parsePrgrm = (props: IPlaygroundProps) => {
-  const qsParsed = qs.parse(props.location.hash)
-  // legacy support
-  const program = qsParsed.lz !== undefined ? qsParsed.lz : qsParsed.prgrm
-  return program !== undefined ? decompressFromEncodedURIComponent(program) : undefined
-}
-
-const parseLibrary = (props: IPlaygroundProps) => {
-  const libQuery = qs.parse(props.location.hash).lib
-  const lib = libQuery === undefined ? NaN : parseInt(libQuery, 10)
-  return sourceChapters.includes(lib) ? lib : undefined
 }
 
 const SICP_SITE = 'http://www.comp.nus.edu.sg/~henz/sicp_js/'

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -7,7 +7,9 @@ import Application, { IApplicationProps } from '../Application'
 test('Application renders correctly', () => {
   const props: IApplicationProps = {
     ...mockRouterProps('/academy', {}),
-    title: 'Cadet'
+    title: 'Cadet',
+    handleChangeChapter: (chp: any) => {},
+    handleEditorValueChange: (val: string) => {}
   }
   const app = <Application {...props} />
   const tree = shallow(app)

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -10,6 +10,7 @@ const baseProps = {
   activeTab: 0,
   editorWidth: '50%',
   sideContentHeight: 40,
+  sourceChapter: 2,
   output: [],
   replValue: '',
   handleChapterSelect: (i: any, e: any) => {},

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -12,16 +12,17 @@ const baseProps = {
   sideContentHeight: 40,
   output: [],
   replValue: '',
-  handleEditorValueChange: () => {},
   handleChapterSelect: (i: any, e: any) => {},
   handleChangeActiveTab: (n: number) => {},
   handleEditorEval: () => {},
+  handleEditorValueChange: () => {},
+  handleEditorWidthChange: (widthChange: number) => {},
+  handleGenerateLz: () => {},
+  handleInterruptEval: () => {},
   handleReplEval: () => {},
   handleReplOutputClear: () => {},
-  handleInterruptEval: () => {},
-  handleEditorWidthChange: (widthChange: number) => {},
-  handleSideContentHeightChange: (h: number) => {},
-  handleReplValueChange: (code: string) => {}
+  handleReplValueChange: (code: string) => {},
+  handleSideContentHeightChange: (h: number) => {}
 }
 
 const testValueProps: IPlaygroundProps = {

--- a/src/components/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Application.tsx.snap
@@ -5,7 +5,6 @@ exports[`Application renders correctly 1`] = `
   <NavigationBar title=\\"Cadet\\" username={[undefined]} />
   <div className=\\"Application__main\\">
     <Switch>
-      // tslint: disable-next-line
       <Route path=\\"/academy\\" component={[Function: toAcademy]} />
       <Route path=\\"/news\\" component={[Function: Connect]} />
       <Route path=\\"/material\\" component={[Function: Connect]} />

--- a/src/components/academy/game/create-initializer.js
+++ b/src/components/academy/game/create-initializer.js
@@ -13,7 +13,7 @@ export default function (StoryXMLPlayer, story, username, attemptedAll) {
     openTemplate: function (name) {
       switch (name) {
         case 'textbook':
-          return window.open('https://www.comp.nus.edu.sg/~cs1101s/sicp/', '_blank');
+          return window.open('http://www.comp.nus.edu.sg/~cs1101s/sicp/', '_blank');
         case 'announcements':
           return history.push('/news');
         case 'lesson_plan':

--- a/src/components/academy/game/create-initializer.js
+++ b/src/components/academy/game/create-initializer.js
@@ -13,7 +13,7 @@ export default function (StoryXMLPlayer, story, username, attemptedAll) {
     openTemplate: function (name) {
       switch (name) {
         case 'textbook':
-          return window.open('http://www.comp.nus.edu.sg/~cs1101s/sicp/', '_blank');
+          return window.open('https://www.comp.nus.edu.sg/~cs1101s/sicp/', '_blank');
         case 'announcements':
           return history.push('/news');
         case 'lesson_plan':

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -1,4 +1,3 @@
-import { throttle } from 'lodash'
 import * as React from 'react'
 import AceEditor from 'react-ace'
 import { HotKeys } from 'react-hotkeys'
@@ -29,10 +28,7 @@ class Editor extends React.Component<IEditorProps, {}> {
             mode="javascript"
             theme="cobalt"
             value={this.props.editorValue}
-            onChange={throttle(this.props.handleEditorValueChange, 800, {
-              leading: false,
-              trailing: true
-            })}
+            onChange={this.props.handleEditorValueChange}
             height="100%"
             commands={[
               {

--- a/src/components/workspace/ReplInput.tsx
+++ b/src/components/workspace/ReplInput.tsx
@@ -1,4 +1,3 @@
-import { throttle } from 'lodash'
 import * as React from 'react'
 import AceEditor from 'react-ace'
 
@@ -21,10 +20,7 @@ class ReplInput extends React.Component<IReplInputProps, {}> {
         height="1px"
         width="100%"
         value={this.props.replValue}
-        onChange={throttle(this.props.handleReplValueChange, 2000, {
-          leading: false,
-          trailing: true
-        })}
+        onChange={this.props.handleReplValueChange}
         commands={[
           {
             name: 'evaluate',

--- a/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Editor renders correctly 1`] = `
 "<HotKeys className=\\"Editor\\" handlers={{...}}>
   <div className=\\"row editor-react-ace\\">
-    <ReactAce className=\\"react-ace\\" mode=\\"javascript\\" theme=\\"cobalt\\" value=\\"\\" onChange={[Function: debounced]} height=\\"100%\\" commands={{...}} width=\\"100%\\" fontSize={14} highlightActiveLine={false} name=\\"brace-editor\\" focus={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
+    <ReactAce className=\\"react-ace\\" mode=\\"javascript\\" theme=\\"cobalt\\" value=\\"\\" onChange={[Function: handleEditorValueChange]} height=\\"100%\\" commands={{...}} width=\\"100%\\" fontSize={14} highlightActiveLine={false} name=\\"brace-editor\\" focus={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} editorProps={{...}} style={{...}} scrollMargin={{...}} setOptions={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} />
   </div>
 </HotKeys>"
 `;

--- a/src/containers/ApplicationContainer.ts
+++ b/src/containers/ApplicationContainer.ts
@@ -1,6 +1,9 @@
-import { connect, MapStateToProps } from 'react-redux'
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux'
 import { withRouter } from 'react-router'
-import Application from '../components/Application'
+import { bindActionCreators, Dispatch } from 'redux'
+
+import { changeChapter, updateEditorValue } from '../actions'
+import Application, { IDispatchProps } from '../components/Application'
 import { IState } from '../reducers/states'
 
 /**
@@ -16,4 +19,13 @@ const mapStateToProps: MapStateToProps<{ title: string }, {}, IState> = state =>
   username: state.session.username
 })
 
-export default withRouter(connect(mapStateToProps)(Application))
+const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Dispatch<any>) =>
+  bindActionCreators(
+    {
+      handleChangeChapter: (chapter: number) => changeChapter(chapter, 'playground'),
+      handleEditorValueChange: (val: string) => updateEditorValue(val, 'playground')
+    },
+    dispatch
+  )
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Application))

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -10,6 +10,7 @@ import {
   clearReplOutput,
   evalEditor,
   evalRepl,
+  generateLzString,
   handleInterruptExecution,
   updateEditorValue,
   updateReplValue,
@@ -19,13 +20,14 @@ import Playground, { IDispatchProps, IStateProps } from '../components/Playgroun
 import { IState } from '../reducers/states'
 
 const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
-  editorValue: state.workspaces.playground.editorValue,
-  isRunning: state.workspaces.playground.isRunning,
   activeTab: state.workspaces.playground.sideContentActiveTab,
   editorWidth: state.workspaces.playground.editorWidth,
-  sideContentHeight: state.workspaces.playground.sideContentHeight,
+  editorValue: state.workspaces.playground.editorValue,
+  isRunning: state.workspaces.playground.isRunning,
   output: state.workspaces.playground.output,
-  replValue: state.workspaces.playground.replValue
+  queryString: state.playground.queryString,
+  replValue: state.workspaces.playground.replValue,
+  sideContentHeight: state.workspaces.playground.sideContentHeight
 })
 
 const location: WorkspaceLocation = 'playground'
@@ -39,6 +41,7 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
       handleEditorEval: () => evalEditor(location),
       handleEditorValueChange: (val: string) => updateEditorValue(val, location),
       handleEditorWidthChange: (widthChange: number) => changeEditorWidth(widthChange, location),
+      handleGenerateLz: generateLzString,
       handleInterruptEval: () => handleInterruptExecution(location),
       handleReplEval: () => evalRepl(location),
       handleReplOutputClear: () => clearReplOutput(location),

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -27,7 +27,8 @@ const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   output: state.workspaces.playground.output,
   queryString: state.playground.queryString,
   replValue: state.workspaces.playground.replValue,
-  sideContentHeight: state.workspaces.playground.sideContentHeight
+  sideContentHeight: state.workspaces.playground.sideContentHeight,
+  sourceChapter: state.workspaces.playground.sourceChapter
 })
 
 const location: WorkspaceLocation = 'playground'

--- a/src/reducers/playground.ts
+++ b/src/reducers/playground.ts
@@ -1,10 +1,15 @@
 import { Reducer } from 'redux'
 
-import { IAction } from '../actions/actionTypes'
+import { CHANGE_QUERY_STRING, IAction } from '../actions/actionTypes'
 import { defaultPlayground, IPlaygroundState } from './states'
 
 export const reducer: Reducer<IPlaygroundState> = (state = defaultPlayground, action: IAction) => {
   switch (action.type) {
+    case CHANGE_QUERY_STRING:
+      return {
+        ...state,
+        queryString: action.payload
+      }
     default:
       return state
   }

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -36,7 +36,7 @@ export interface IWorkspaceManagerState {
 
 interface IWorkspaceState {
   readonly context: Context
-  readonly editorValue?: string
+  readonly editorValue: string
   readonly editorWidth: string
   readonly isRunning: boolean
   readonly output: InterpreterOutput[]
@@ -138,7 +138,7 @@ export const defaultPlayground: IPlaygroundState = {}
 
 export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceState => ({
   context: createContext<WorkspaceLocation>(latestSourceChapter, undefined, location),
-  editorValue: undefined,
+  editorValue: '// Type your program in here!',
   editorWidth: '50%',
   isRunning: false,
   output: [],

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -138,7 +138,7 @@ export const defaultPlayground: IPlaygroundState = {}
 
 export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceState => ({
   context: createContext<WorkspaceLocation>(latestSourceChapter, undefined, location),
-  editorValue: '// Type your program in here!',
+  editorValue: defaultEditorValue,
   editorWidth: '50%',
   isRunning: false,
   output: [],
@@ -146,6 +146,8 @@ export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceS
   sideContentActiveTab: 0,
   sourceChapter: latestSourceChapter
 })
+
+export const defaultEditorValue = '// Type your program in here!'
 
 export const defaultWorkspaceManager: IWorkspaceManagerState = {
   currentAssessment: undefined,

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -3,7 +3,6 @@ import {
   CHANGE_ACTIVE_TAB,
   CHANGE_CHAPTER,
   CHANGE_EDITOR_WIDTH,
-  CHANGE_QUERY_STRING,
   CHANGE_SIDE_CONTENT_HEIGHT,
   CLEAR_CONTEXT,
   CLEAR_REPL_INPUT,
@@ -62,14 +61,6 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
             (
               parseFloat(state[location].editorWidth.slice(0, -1)) + action.payload.widthChange
             ).toString() + '%'
-        }
-      }
-    case CHANGE_QUERY_STRING:
-      return {
-        ...state,
-        [location]: {
-          ...state[location],
-          queryString: action.payload.queryString
         }
       }
     case CHANGE_SIDE_CONTENT_HEIGHT:

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -80,7 +80,7 @@ function* workspaceSaga(): SagaIterator {
 
   yield takeEvery(actionTypes.CHAPTER_SELECT, function*(action) {
     const location = (action as actionTypes.IAction).payload.workspaceLocation
-    const newChapter = parseInt((action as actionTypes.IAction).payload, 10)
+    const newChapter = (action as actionTypes.IAction).payload.chapter
     const oldChapter = yield select((state: IState) => state.workspaces[location].sourceChapter)
     if (newChapter !== oldChapter) {
       yield put(actions.changeChapter(newChapter, location))

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -9,7 +9,7 @@ import { WorkspaceLocation } from '../actions/workspaces'
 import { mockAssessmentOverviews, mockAssessments } from '../mocks/assessmentAPI'
 import { mockFetchGrading, mockFetchGradingOverview } from '../mocks/gradingAPI'
 import { MOCK_TRAINER_ACCESS_TOKEN } from '../mocks/userAPI'
-import { IState } from '../reducers/states'
+import { defaultEditorValue, IState } from '../reducers/states'
 import { Context, interrupt, runInContext } from '../slang'
 import { IVLE_KEY } from '../utils/constants'
 import { showSuccessMessage, showWarningMessage } from '../utils/notification'
@@ -124,7 +124,7 @@ function* playgroundSaga(): SagaIterator {
     const code = yield select((state: IState) => state.workspaces.playground.editorValue)
     const lib = yield select((state: IState) => state.workspaces.playground.sourceChapter)
     const newQueryString =
-      code === ''
+      code === '' || code === defaultEditorValue
         ? undefined
         : qs.stringify({
             prgrm: compressToEncodedURIComponent(code),


### PR DESCRIPTION
### Features

- Editor and repl value updates are no longer throttled. Fixes #154, fixes #147.
- Fix default playground value raising semi-colon error. Fixes #163.
- Fix share button not working. Fixes #165.
- Fix missing chapter select. Fixes #170.