### PR TITLE
Change Submission Semantics

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -63,7 +63,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         hasChapterSelect: true,
         hasNextButton: false,
         hasPreviousButton: false,
-        hasSubmitButton: false,
+        hasDoneButton: false,
         isRunning: this.props.isRunning,
         queryString: this.props.queryString,
         sourceChapter: this.props.sourceChapter

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -61,9 +61,11 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         handleReplEval: this.props.handleReplEval,
         handleReplOutputClear: this.props.handleReplOutputClear,
         hasChapterSelect: true,
+        hasDoneButton: false,
         hasNextButton: false,
         hasPreviousButton: false,
-        hasDoneButton: false,
+        hasSaveButton: false,
+        hasShareButton: true,
         isRunning: this.props.isRunning,
         queryString: this.props.queryString,
         sourceChapter: this.props.sourceChapter

--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -144,7 +144,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
         history.push(gradingWorkspacePath + `/${(this.props.questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(gradingWorkspacePath + `/${(this.props.questionId - 1).toString()}`),
-      sourceChapter: 2 // TODO dynamic library changing
+      sourceChapter: this.props.grading![this.props.questionId].question.library.chapter
     }
   }
 }

--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -64,10 +64,15 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       )
     }
 
+    /* If questionId is out of bounds, set it to the max. */
+    const questionId =
+      this.props.questionId >= this.props.grading.length
+        ? this.props.grading.length - 1
+        : this.props.questionId
     /* Get the question to be graded */
-    const question = this.props.grading[this.props.questionId].question as IQuestion
+    const question = this.props.grading[questionId].question as IQuestion
     const workspaceProps: WorkspaceProps = {
-      controlBarProps: this.controlBarProps(this.props),
+      controlBarProps: this.controlBarProps(this.props, questionId),
       editorProps:
         question.type === QuestionTypes.programming
           ? {
@@ -84,7 +89,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       handleSideContentHeightChange: this.props.handleSideContentHeightChange,
       mcq: question as IMCQQuestion,
       sideContentHeight: this.props.sideContentHeight,
-      sideContentProps: this.sideContentProps(this.props),
+      sideContentProps: this.sideContentProps(this.props, questionId),
       replProps: {
         output: this.props.output,
         replValue: this.props.replValue,
@@ -100,29 +105,29 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
   }
 
   /** Pre-condition: Grading has been loaded */
-  private sideContentProps: (p: GradingWorkspaceProps) => SideContentProps = (
-    props: GradingWorkspaceProps
+  private sideContentProps: (p: GradingWorkspaceProps, q: number) => SideContentProps = (
+    props: GradingWorkspaceProps, questionId: number
   ) => ({
     activeTab: props.activeTab,
     handleChangeActiveTab: props.handleChangeActiveTab,
     tabs: [
       {
-        label: `Grading: Question ${props.questionId}`,
+        label: `Grading: Question ${questionId}`,
         icon: IconNames.TICK,
         /* Render an editor with the xp given to the current question. */
-        body: <GradingEditor maximumXP={props.grading![props.questionId].maximumXP} />
+        body: <GradingEditor maximumXP={props.grading![questionId].maximumXP} />
       },
       {
-        label: `Task ${props.questionId}`,
+        label: `Task ${questionId}`,
         icon: IconNames.NINJA,
-        body: <Text> {props.grading![props.questionId].question.content} </Text>
+        body: <Text> {props.grading![questionId].question.content} </Text>
       }
     ]
   })
 
   /** Pre-condition: Grading has been loaded */
-  private controlBarProps: (p: GradingWorkspaceProps) => ControlBarProps = (
-    props: GradingWorkspaceProps
+  private controlBarProps: (p: GradingWorkspaceProps, q: number) => ControlBarProps = (
+    props: GradingWorkspaceProps, questionId: number
   ) => {
     const listingPath = `/academy/grading`
     const gradingWorkspacePath = listingPath + `/${this.props.submissionId}`
@@ -133,18 +138,18 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       handleReplEval: this.props.handleReplEval,
       handleReplOutputClear: this.props.handleReplOutputClear,
       hasChapterSelect: false,
-      hasDoneButton: this.props.questionId === this.props.grading!.length - 1,
-      hasNextButton: this.props.questionId < this.props.grading!.length - 1,
-      hasPreviousButton: this.props.questionId > 0,
+      hasDoneButton: questionId === this.props.grading!.length - 1,
+      hasNextButton: questionId < this.props.grading!.length - 1,
+      hasPreviousButton: questionId > 0,
       hasSaveButton: false,
       hasShareButton: false,
       isRunning: this.props.isRunning,
       onClickDone: () => history.push(listingPath),
       onClickNext: () =>
-        history.push(gradingWorkspacePath + `/${(this.props.questionId + 1).toString()}`),
+        history.push(gradingWorkspacePath + `/${(questionId + 1).toString()}`),
       onClickPrevious: () =>
-        history.push(gradingWorkspacePath + `/${(this.props.questionId - 1).toString()}`),
-      sourceChapter: this.props.grading![this.props.questionId].question.library.chapter
+        history.push(gradingWorkspacePath + `/${(questionId - 1).toString()}`),
+      sourceChapter: this.props.grading![questionId].question.library.chapter
     }
   }
 }

--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -106,7 +106,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
 
   /** Pre-condition: Grading has been loaded */
   private sideContentProps: (p: GradingWorkspaceProps, q: number) => SideContentProps = (
-    props: GradingWorkspaceProps, questionId: number
+    props: GradingWorkspaceProps,
+    questionId: number
   ) => ({
     activeTab: props.activeTab,
     handleChangeActiveTab: props.handleChangeActiveTab,
@@ -127,7 +128,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
 
   /** Pre-condition: Grading has been loaded */
   private controlBarProps: (p: GradingWorkspaceProps, q: number) => ControlBarProps = (
-    props: GradingWorkspaceProps, questionId: number
+    props: GradingWorkspaceProps,
+    questionId: number
   ) => {
     const listingPath = `/academy/grading`
     const gradingWorkspacePath = listingPath + `/${this.props.submissionId}`
@@ -145,10 +147,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       hasShareButton: false,
       isRunning: this.props.isRunning,
       onClickDone: () => history.push(listingPath),
-      onClickNext: () =>
-        history.push(gradingWorkspacePath + `/${(questionId + 1).toString()}`),
-      onClickPrevious: () =>
-        history.push(gradingWorkspacePath + `/${(questionId - 1).toString()}`),
+      onClickNext: () => history.push(gradingWorkspacePath + `/${(questionId + 1).toString()}`),
+      onClickPrevious: () => history.push(gradingWorkspacePath + `/${(questionId - 1).toString()}`),
       sourceChapter: this.props.grading![questionId].question.library.chapter
     }
   }

--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -137,13 +137,13 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       hasPreviousButton: this.props.questionId > 0,
       hasSaveButton: false,
       hasShareButton: false,
-      hasSubmitButton: this.props.questionId === this.props.grading!.length - 1,
+      hasDoneButton: this.props.questionId === this.props.grading!.length - 1,
       isRunning: this.props.isRunning,
       onClickNext: () =>
         history.push(gradingWorkspacePath + `/${(this.props.questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(gradingWorkspacePath + `/${(this.props.questionId - 1).toString()}`),
-      onClickSubmit: () => history.push(listingPath),
+      onClickDone: () => history.push(listingPath),
       sourceChapter: 2 // TODO dynamic library changing
     }
   }

--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -133,17 +133,17 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       handleReplEval: this.props.handleReplEval,
       handleReplOutputClear: this.props.handleReplOutputClear,
       hasChapterSelect: false,
+      hasDoneButton: this.props.questionId === this.props.grading!.length - 1,
       hasNextButton: this.props.questionId < this.props.grading!.length - 1,
       hasPreviousButton: this.props.questionId > 0,
       hasSaveButton: false,
       hasShareButton: false,
-      hasDoneButton: this.props.questionId === this.props.grading!.length - 1,
       isRunning: this.props.isRunning,
+      onClickDone: () => history.push(listingPath),
       onClickNext: () =>
         history.push(gradingWorkspacePath + `/${(this.props.questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(gradingWorkspacePath + `/${(this.props.questionId - 1).toString()}`),
-      onClickDone: () => history.push(listingPath),
       sourceChapter: 2 // TODO dynamic library changing
     }
   }

--- a/src/components/academy/grading/gradingShape.ts
+++ b/src/components/academy/grading/gradingShape.ts
@@ -1,4 +1,4 @@
-import { AssessmentCategory, IQuestion, Library, MCQChoice } from '../../assessment/assessmentShape'
+import { AssessmentCategory, IQuestion, MCQChoice } from '../../assessment/assessmentShape'
 
 /**
  * Information on a Grading, for a particular student submission
@@ -44,7 +44,6 @@ export type GradingQuestion = {
 interface IAnsweredQuestion extends IQuestion {
   solution?: number
   answer?: string | number
-  library?: Library
   solutionTemplate?: string
   choices?: MCQChoice[]
 }

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -163,12 +163,12 @@ class AssessmentWorkspace extends React.Component<
       hasPreviousButton: questionId > 0,
       hasSaveButton: true,
       hasShareButton: false,
-      hasSubmitButton: questionId === this.props.assessment!.questions.length - 1,
+      hasDoneButton: questionId === this.props.assessment!.questions.length - 1,
       isRunning: this.props.isRunning,
       onClickNext: () => history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(assessmentWorkspacePath + `/${(questionId - 1).toString()}`),
-      onClickSubmit: () => history.push(listingPath),
+      onClickDone: () => history.push(listingPath),
       sourceChapter: 2 // TODO dynamic library changing
     }
   }

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -165,10 +165,10 @@ class AssessmentWorkspace extends React.Component<
       hasSaveButton: true,
       hasShareButton: false,
       isRunning: this.props.isRunning,
+      onClickDone: () => history.push(listingPath),
       onClickNext: () => history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(assessmentWorkspacePath + `/${(questionId - 1).toString()}`),
-      onClickDone: () => history.push(listingPath),
       sourceChapter: 2 // TODO dynamic library changing
     }
   }

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -159,11 +159,11 @@ class AssessmentWorkspace extends React.Component<
       handleReplEval: this.props.handleReplEval,
       handleReplOutputClear: this.props.handleReplOutputClear,
       hasChapterSelect: false,
+      hasDoneButton: questionId === this.props.assessment!.questions.length - 1,
       hasNextButton: questionId < this.props.assessment!.questions.length - 1,
       hasPreviousButton: questionId > 0,
       hasSaveButton: true,
       hasShareButton: false,
-      hasDoneButton: questionId === this.props.assessment!.questions.length - 1,
       isRunning: this.props.isRunning,
       onClickNext: () => history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`),
       onClickPrevious: () =>

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -169,7 +169,7 @@ class AssessmentWorkspace extends React.Component<
       onClickNext: () => history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`),
       onClickPrevious: () =>
         history.push(assessmentWorkspacePath + `/${(questionId - 1).toString()}`),
-      sourceChapter: 2 // TODO dynamic library changing
+      sourceChapter: this.props.assessment!.questions[questionId].library.chapter
     }
   }
 }

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -34,7 +34,6 @@ export enum AssessmentCategories {
 export type AssessmentCategory = keyof typeof AssessmentCategories
 
 export interface IProgrammingQuestion extends IQuestion {
-  library: Library
   solutionTemplate: string
   type: 'programming'
 }
@@ -47,6 +46,7 @@ export interface IMCQQuestion extends IQuestion {
 export interface IQuestion {
   content: string
   id: number
+  library: Library
   type: QuestionType
 }
 

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -13,7 +13,7 @@ export type ControlBarProps = {
   hasPreviousButton?: boolean
   hasSaveButton?: boolean
   hasShareButton?: boolean
-  hasSubmitButton?: boolean
+  hasDoneButton?: boolean
   isRunning: boolean
   queryString?: string
   sourceChapter: number
@@ -26,7 +26,7 @@ export type ControlBarProps = {
   onClickNext?(): any
   onClickPrevious?(): any
   onClickSave?(): any
-  onClickSubmit?(): any
+  onClickDone?(): any
 }
 
 interface IChapter {
@@ -120,8 +120,8 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
     const nextButton = this.props.hasNextButton
       ? controlButton('Next', IconNames.ARROW_RIGHT, this.props.onClickNext, { iconOnRight: true })
       : undefined
-    const submitButton = this.props.hasSubmitButton
-      ? controlButton('Submit', IconNames.TICK_CIRCLE, this.props.onClickSubmit, {
+    const submitButton = this.props.hasDoneButton
+      ? controlButton('Done', IconNames.TICK_CIRCLE, this.props.onClickDone, {
           iconOnRight: true
         })
       : undefined

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -8,12 +8,12 @@ import { sourceChapters } from '../../reducers/states'
 import { controlButton } from '../commons'
 
 export type ControlBarProps = {
-  hasChapterSelect?: boolean
-  hasNextButton?: boolean
-  hasPreviousButton?: boolean
-  hasSaveButton?: boolean
-  hasShareButton?: boolean
-  hasDoneButton?: boolean
+  hasChapterSelect: boolean
+  hasNextButton: boolean
+  hasPreviousButton: boolean
+  hasSaveButton: boolean
+  hasShareButton: boolean
+  hasDoneButton: boolean
   isRunning: boolean
   queryString?: string
   sourceChapter: number

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -41,7 +41,7 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
     hasPreviousButton: false,
     hasSaveButton: false,
     hasShareButton: true,
-    hasSubmitButton: false,
+    hasDoneButton: false,
     onClickNext: () => {},
     onClickPrevious: () => {},
     onClickSave: () => {}

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -117,6 +117,7 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
       }
     ],
     id: 2,
+    library: mockLibrary,
     type: 'mcq'
   }
 ]

--- a/src/mocks/gradingAPI.ts
+++ b/src/mocks/gradingAPI.ts
@@ -111,6 +111,7 @@ const mockGrading: Grading = [
         }
       ],
       id: 2,
+      library: mockLibrary,
       type: 'mcq'
     },
     maximumXP: 100,


### PR DESCRIPTION
### Features
- 'Done' is shown instead of 'Submit'
- Control Bar `hasXXX` props are now compulsory (to prevent type checking misses)
- Redefine `IQuestion` to have library, instead of only `IProgrammingQuestion` having it
- Fix #153 for GradingWorkspace (missed it out in #173 )

### Issues fixed 
- Fixes #177 
- Fixes #153  (Re-fix)