### PR TITLE
[WIP] Store library externals in state

### DIFF
--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -81,9 +81,13 @@ export const librarySelect: ActionCreator<actionTypes.IAction> = (
   }
 })
 
-export const clearContext = (workspaceLocation: WorkspaceLocation, chapter: number, externals: string[]) => ({
+export const clearContext = (
+  workspaceLocation: WorkspaceLocation,
+  chapter: number,
+  externals: string[]
+) => ({
   type: actionTypes.CLEAR_CONTEXT,
-  payload: { 
+  payload: {
     workspaceLocation,
     chapter,
     externals

--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -134,12 +134,8 @@ export const sendReplInputToOutput: ActionCreator<actionTypes.IAction> = (
   }
 })
 
-export const resetAssessmentWorkspace = (chapter: number, externals: string[]) => ({
-  type: actionTypes.RESET_ASSESSMENT_WORKSPACE,
-  payload: {
-    chapter,
-    externals
-  }
+export const resetAssessmentWorkspace = () => ({
+  type: actionTypes.RESET_ASSESSMENT_WORKSPACE
 })
 
 export const updateCurrentAssessmentId = (assessmentId: number, questionId: number) => ({

--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -81,9 +81,13 @@ export const librarySelect: ActionCreator<actionTypes.IAction> = (
   }
 })
 
-export const clearContext = (workspaceLocation: WorkspaceLocation) => ({
+export const clearContext = (workspaceLocation: WorkspaceLocation, chapter: number, externals: string[]) => ({
   type: actionTypes.CLEAR_CONTEXT,
-  payload: { workspaceLocation }
+  payload: { 
+    workspaceLocation,
+    chapter,
+    externals
+  }
 })
 
 export const clearReplInput = (workspaceLocation: WorkspaceLocation) => ({

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core'
-import { IconNames } from '@blueprintjs/icons'
+import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core' import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 
 import { InterpreterOutput } from '../../reducers/states'
@@ -159,6 +158,7 @@ class AssessmentWorkspace extends React.Component<
       const chapter = this.props.assessment.questions[questionId].library.chapter
       const externals = this.props.assessment.questions[questionId].library.externals
       this.props.handleUpdateCurrentAssessmentId(assessmentId, questionId)
+      // TODO clear context here using chapter and externals
       this.props.handleResetAssessmentWorkspace(chapter, externals)
     }
   }

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core' import { IconNames } from '@blueprintjs/icons'
+import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core' 
+import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 
 import { InterpreterOutput } from '../../reducers/states'
@@ -13,7 +14,7 @@ import {
   IMCQQuestion,
   IProgrammingQuestion,
   IQuestion,
-  QuestionTypes
+  QuestionTypes,
 } from './assessmentShape'
 
 export type AssessmentWorkspaceProps = DispatchProps & OwnProps & StateProps
@@ -41,6 +42,7 @@ export type DispatchProps = {
   handleAssessmentFetch: (assessmentId: number) => void
   handleChangeActiveTab: (activeTab: number) => void
   handleChapterSelect: (chapter: any, changeEvent: any) => void
+  handleClearContext: (chapter: number, externals: string[]) => void
   handleEditorEval: () => void
   handleEditorValueChange: (val: string) => void
   handleEditorWidthChange: (widthChange: number) => void
@@ -48,7 +50,7 @@ export type DispatchProps = {
   handleReplEval: () => void
   handleReplOutputClear: () => void
   handleReplValueChange: (newValue: string) => void
-  handleResetAssessmentWorkspace: (chapter: number, externals: string[]) => void
+  handleResetAssessmentWorkspace: () => void
   handleSideContentHeightChange: (heightChange: number) => void
   handleUpdateCurrentAssessmentId: (assessmentId: number, questionId: number) => void
 }
@@ -158,8 +160,8 @@ class AssessmentWorkspace extends React.Component<
       const chapter = this.props.assessment.questions[questionId].library.chapter
       const externals = this.props.assessment.questions[questionId].library.externals
       this.props.handleUpdateCurrentAssessmentId(assessmentId, questionId)
-      // TODO clear context here using chapter and externals
-      this.props.handleResetAssessmentWorkspace(chapter, externals)
+      this.props.handleResetAssessmentWorkspace()
+      this.props.handleClearContext(chapter, externals)
     }
   }
 

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core' 
+import { Button, Card, Dialog, NonIdealState, Spinner, Text } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import * as React from 'react'
 
@@ -14,7 +14,7 @@ import {
   IMCQQuestion,
   IProgrammingQuestion,
   IQuestion,
-  QuestionTypes,
+  QuestionTypes
 } from './assessmentShape'
 
 export type AssessmentWorkspaceProps = DispatchProps & OwnProps & StateProps

--- a/src/components/assessment/__tests__/AssessmentWorkspace.tsx
+++ b/src/components/assessment/__tests__/AssessmentWorkspace.tsx
@@ -23,7 +23,8 @@ const defaultProps: AssessmentWorkspaceProps = {
   handleResetAssessmentWorkspace: () => {},
   handleSideContentHeightChange: (heightChange: number) => {},
   handleUpdateCurrentAssessmentId: (a: number, q: number) => {},
-  isRunning: false, output: [],
+  isRunning: false,
+  output: [],
   questionId: 0,
   replValue: ''
 }

--- a/src/components/assessment/__tests__/AssessmentWorkspace.tsx
+++ b/src/components/assessment/__tests__/AssessmentWorkspace.tsx
@@ -12,6 +12,7 @@ const defaultProps: AssessmentWorkspaceProps = {
   handleAssessmentFetch: (assessmentId: number) => {},
   handleChangeActiveTab: (activeTab: number) => {},
   handleChapterSelect: (chapter: any, changeEvent: any) => {},
+  handleClearContext: (chapter: number, externals: string[]) => {},
   handleEditorEval: () => {},
   handleEditorValueChange: (val: string) => {},
   handleEditorWidthChange: (widthChange: number) => {},
@@ -22,8 +23,7 @@ const defaultProps: AssessmentWorkspaceProps = {
   handleResetAssessmentWorkspace: () => {},
   handleSideContentHeightChange: (heightChange: number) => {},
   handleUpdateCurrentAssessmentId: (a: number, q: number) => {},
-  isRunning: false,
-  output: [],
+  isRunning: false, output: [],
   questionId: 0,
   replValue: ''
 }

--- a/src/containers/assessment/AssessmentWorkspaceContainer.ts
+++ b/src/containers/assessment/AssessmentWorkspaceContainer.ts
@@ -13,9 +13,13 @@ import {
   evalRepl,
   fetchAssessment,
   updateEditorValue,
-  updateReplValue,
+  updateReplValue
 } from '../../actions'
-import { resetAssessmentWorkspace, WorkspaceLocation, updateCurrentAssessmentId } from '../../actions/workspaces'
+import {
+  resetAssessmentWorkspace,
+  updateCurrentAssessmentId,
+  WorkspaceLocation
+} from '../../actions/workspaces'
 import AssessmentWorkspace, {
   DispatchProps,
   OwnProps,
@@ -47,7 +51,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleChangeActiveTab: (activeTab: number) => changeActiveTab(activeTab, location),
       handleChapterSelect: (chapter: any, changeEvent: any) =>
         chapterSelect(chapter, changeEvent, location),
-      handleClearContext: (chapter: number, externals: string[]) => clearContext(location, chapter, externals),
+      handleClearContext: (chapter: number, externals: string[]) =>
+        clearContext(location, chapter, externals),
       handleEditorEval: () => evalEditor(location),
       handleEditorValueChange: (val: string) => updateEditorValue(val, location),
       handleEditorWidthChange: (widthChange: number) => changeEditorWidth(widthChange, location),

--- a/src/containers/assessment/AssessmentWorkspaceContainer.ts
+++ b/src/containers/assessment/AssessmentWorkspaceContainer.ts
@@ -7,15 +7,15 @@ import {
   changeEditorWidth,
   changeSideContentHeight,
   chapterSelect,
+  clearContext,
   clearReplOutput,
   evalEditor,
   evalRepl,
   fetchAssessment,
   updateEditorValue,
   updateReplValue,
-  WorkspaceLocation
 } from '../../actions'
-import { resetAssessmentWorkspace, updateCurrentAssessmentId } from '../../actions/workspaces'
+import { resetAssessmentWorkspace, WorkspaceLocation, updateCurrentAssessmentId } from '../../actions/workspaces'
 import AssessmentWorkspace, {
   DispatchProps,
   OwnProps,
@@ -47,6 +47,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleChangeActiveTab: (activeTab: number) => changeActiveTab(activeTab, location),
       handleChapterSelect: (chapter: any, changeEvent: any) =>
         chapterSelect(chapter, changeEvent, location),
+      handleClearContext: (chapter: number, externals: string[]) => clearContext(location, chapter, externals),
       handleEditorEval: () => evalEditor(location),
       handleEditorValueChange: (val: string) => updateEditorValue(val, location),
       handleEditorWidthChange: (widthChange: number) => changeEditorWidth(widthChange, location),
@@ -54,7 +55,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleReplEval: () => evalRepl(location),
       handleReplOutputClear: () => clearReplOutput(location),
       handleReplValueChange: (newValue: string) => updateReplValue(newValue, location),
-      handleResetAssessmentWorkspace: resetAssessmentWorkspace,
+      handleResetAssessmentWorkspace: () => resetAssessmentWorkspace,
       handleSideContentHeightChange: (heightChange: number) =>
         changeSideContentHeight(heightChange, location),
       handleUpdateCurrentAssessmentId: updateCurrentAssessmentId

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -132,7 +132,26 @@ const latestSourceChapter = sourceChapters.slice(-1)[0]
  * TODO use constants
  * TODO move this to a file closer to the libraries
  */
-const libEntries: Array<[string, string[]]> = [['none', []], ['sound', ['make_sourcesound']]]
+const libEntries: Array<[string, string[]]> = [
+  ['none', []],
+  [
+    'sound',
+    [
+      'make_sourcesound',
+      'get_wave',
+      'get_duration',
+      'is_sound',
+      'play',
+      'stop',
+      'cut_sourcesound',
+      'cut',
+      'sourcesound_to_sound',
+      'autocut_sourcesound',
+      'consecutively',
+      'simultaneously'
+    ]
+  ]
+]
 export const externalLibraries: Map<string, string[]> = new Map(libEntries)
 
 const currentEnvironment = (): ApplicationEnvironment => {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -49,6 +49,7 @@ interface IWorkspaceState {
   readonly replValue: string
   readonly sideContentActiveTab: number
   readonly sideContentHeight?: number
+  readonly externals: string[]
 }
 
 export interface ISessionState {
@@ -183,20 +184,15 @@ export const defaultEditorValue = '// Type your program in here!'
  * Takes in parameters to set the js-slang library and chapter.
  *
  * @param location the location of the workspace, used for context
- * @param chapter the chapter number for the js-slang interpreter
- * @param externals any external library exposed symbols
  */
-export const createDefaultWorkspace = (
-  location: WorkspaceLocation,
-  chapter: number = latestSourceChapter,
-  externals?: string[]
-): IWorkspaceState => ({
-  context: createContext<WorkspaceLocation>(chapter, externals, location),
+export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceState => ({
+  context: createContext<WorkspaceLocation>(latestSourceChapter, undefined, location),
   editorValue: defaultEditorValue,
   editorWidth: '50%',
   output: [],
   replValue: '',
-  sideContentActiveTab: 0
+  sideContentActiveTab: 0,
+  externals: []
 })
 
 export const defaultComments = 'Comments **here**. Use `markdown` if you ~~are cool~~ want!'

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -259,11 +259,9 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
      * Resets the assessment workspace (under state.workspaces.assessment).
      */
     case RESET_ASSESSMENT_WORKSPACE:
-      chapter = action.payload.chapter
-      externals = action.payload.externals
       return {
         ...state,
-        assessment: createDefaultWorkspace(WorkspaceLocations.assessment, chapter, externals),
+        assessment: createDefaultWorkspace(WorkspaceLocations.assessment),
         gradingCommentsValue: defaultComments,
         gradingXP: undefined
       }

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -65,8 +65,12 @@ function* workspaceSaga(): SagaIterator {
   yield takeEvery(actionTypes.EVAL_EDITOR, function*(action) {
     const location = (action as actionTypes.IAction).payload.workspaceLocation
     const code: string = yield select((state: IState) => state.workspaces[location].editorValue)
-    const chapter: number = yield select((state: IState) => state.workspaces[location].context.chapter)
-    const externals: string[] = yield select((state: IState) => state.workspaces[location].externals)
+    const chapter: number = yield select(
+      (state: IState) => state.workspaces[location].context.chapter
+    )
+    const externals: string[] = yield select(
+      (state: IState) => state.workspaces[location].externals
+    )
     /** End any code that is running right now. */
     yield put(actions.beginInterruptExecution(location))
     /** Clear the context, with the same chapter and externals as before. */

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -65,8 +65,12 @@ function* workspaceSaga(): SagaIterator {
   yield takeEvery(actionTypes.EVAL_EDITOR, function*(action) {
     const location = (action as actionTypes.IAction).payload.workspaceLocation
     const code: string = yield select((state: IState) => state.workspaces[location].editorValue)
+    const chapter: number = yield select((state: IState) => state.workspaces[location].context.chapter)
+    const externals: string[] = yield select((state: IState) => state.workspaces[location].externals)
+    /** End any code that is running right now. */
     yield put(actions.beginInterruptExecution(location))
-    yield put(actions.clearContext(location))
+    /** Clear the context, with the same chapter and externals as before. */
+    yield put(actions.clearContext(location, chapter, externals))
     yield put(actions.clearReplOutput(location))
     context = yield select((state: IState) => state.workspaces[location].context)
     yield* evalCode(code, context, location)


### PR DESCRIPTION
### Features
- [ ] Store externals in state, to ensure a single source of truth for the externals used by `js-slang`.
- [ ] Removal of `changeChapter` and `changeLibrary` actions, now `clearContext` is used to reset the context **and** set chapter and externals (previously library). This is because changing chapter or library will require the context to be cleared.