### PR TITLE
Fix assessment crashing on load

### DIFF
--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -54,13 +54,9 @@ export type DispatchProps = {
 }
 
 class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
-  public componentWillMount() {
+  public componentDidMount() {
+    this.checkWorkspaceReset(this.props)
     this.props.handleGradingFetch(this.props.submissionId)
-    this.checkWorkspaceReset(this.props)
-  }
-
-  public componentWillUpdate() {
-    this.checkWorkspaceReset(this.props)
   }
 
   public render() {

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -61,17 +61,13 @@ class AssessmentWorkspace extends React.Component<
 > {
   public state = { showOverlay: false }
 
-  public componentWillMount() {
+  public componentDidMount() {
+    this.checkWorkspaceReset(this.props)
     /* Load assessment if it isn't passed as a prop. */
     this.props.handleAssessmentFetch(this.props.assessmentId)
     if (this.props.questionId === 0) {
       this.setState({ showOverlay: true })
     }
-    this.checkWorkspaceReset(this.props)
-  }
-
-  public componentWillUpdate() {
-    this.checkWorkspaceReset(this.props)
   }
 
   public render() {

--- a/src/containers/assessment/AssessmentWorkspaceContainer.ts
+++ b/src/containers/assessment/AssessmentWorkspaceContainer.ts
@@ -60,7 +60,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleReplEval: () => evalRepl(location),
       handleReplOutputClear: () => clearReplOutput(location),
       handleReplValueChange: (newValue: string) => updateReplValue(newValue, location),
-      handleResetAssessmentWorkspace: () => resetAssessmentWorkspace,
+      handleResetAssessmentWorkspace: resetAssessmentWorkspace,
       handleSideContentHeightChange: (heightChange: number) =>
         changeSideContentHeight(heightChange, location),
       handleUpdateCurrentAssessmentId: updateCurrentAssessmentId


### PR DESCRIPTION
I believe this was caused by various updates in `componentWillMount` and `componentWillUpdate`. As such, they have been removed to use `componentDidMount` (as recommended by [React](https://reactjs.org/docs/react-component.html#the-component-lifecycle)). Also removed one instance of unnecessary currying (inconsequential)

Fixes #206.