### PR TITLE
Fix display builtin not working in playground

### DIFF
--- a/src/actions/interpreter.ts
+++ b/src/actions/interpreter.ts
@@ -7,7 +7,7 @@ import { WorkspaceLocation } from './workspaces'
 // is implemented completely
 export const handleConsoleLog = (
   logString: string,
-  workspaceLocation: WorkspaceLocation = 'assessment'
+  workspaceLocation: WorkspaceLocation
 ) => ({
   type: actionTypes.HANDLE_CONSOLE_LOG,
   payload: { logString, workspaceLocation }

--- a/src/actions/interpreter.ts
+++ b/src/actions/interpreter.ts
@@ -5,10 +5,7 @@ import { WorkspaceLocation } from './workspaces'
 
 // TODO fix this immediately after location
 // is implemented completely
-export const handleConsoleLog = (
-  logString: string,
-  workspaceLocation: WorkspaceLocation
-) => ({
+export const handleConsoleLog = (logString: string, workspaceLocation: WorkspaceLocation) => ({
   type: actionTypes.HANDLE_CONSOLE_LOG,
   payload: { logString, workspaceLocation }
 })

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -187,7 +187,8 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
           ...state[location],
           context: createContext<WorkspaceLocation>(
             action.payload.chapter,
-            action.payload.externals
+            action.payload.externals,
+            location
           ),
           externals: action.payload.externals
         }

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -78,7 +78,7 @@ function visualiseList(list: any) {}
  * provides the original function with the required
  * externalBuiltIns, such as display and prompt.
  */
-export function createContext<T>(chapter = 1, externals: string[] = [], externalContext?: T) {
+export function createContext<T>(chapter = 1, externals: string[] = [], externalContext: T) {
   const externalBuiltIns = {
     display,
     prompt: cadetPrompt,


### PR DESCRIPTION
### Features
- Made the `externalContext` argument for `createContext` mandatory
- Removed a default argument from an action creator (missed out from a rebase)

### Issues fixed
- Fixes #222 