### PR TITLE
Fix actual canvas element not maintaining aspect ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "cadet-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "scripts-info": {
     "format": "Format source code",
     "start": "Start the Webpack development server",

--- a/src/styles/_game.scss
+++ b/src/styles/_game.scss
@@ -7,6 +7,7 @@
   width: 100%;
 
   canvas {
+    margin: auto;
     height: 100%;
     object-fit: contain;
   }


### PR DESCRIPTION
Resolves #241.

The canvas element was not maintaining its aspect ratio, but the visuals of the canvas element were. Resulted in the visuals and their hover areas being 'out of sync'. Fixed with the oldest css trick in the book.