### PR TITLE
Hotfix overflowing game width

### DIFF
--- a/src/styles/_game.scss
+++ b/src/styles/_game.scss
@@ -8,6 +8,8 @@
 
   canvas {
     margin: auto;
+    max-height: 100%;
+    max-width: 100%;
     height: 100%;
     object-fit: contain;
   }


### PR DESCRIPTION
Fix a bug where if the aspect ratio of the browser was more narrow than the aspect ratio of the game, the game would overflow horizontally.