### PR TITLE
Add List Visualiser

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "draft-js": "^0.10.5",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "0.1.3",
+    "js-slang": "0.1.5",
     "lodash": "^4.17.10",
     "lz-string": "^1.4.4",
     "node-sass-chokidar": "^1.3.0",

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -148,7 +148,7 @@ const playgroundIntroductionTab: SideContentTab = {
 }
 const listVisualizerTab: SideContentTab = {
   label: 'List Visualizer',
-  icon: IconNames.COMPASS,
+  icon: IconNames.EYE_OPEN,
   body: <ListVisualizer />
 }
 

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -8,6 +8,7 @@ import { InterpreterOutput } from '../reducers/states'
 import { ExternalLibraryName } from './assessment/assessmentShape'
 import Workspace, { WorkspaceProps } from './workspace'
 import { SideContentTab } from './workspace/side-content'
+import ListVisualizer from './workspace/side-content/ListVisualizer'
 
 export interface IPlaygroundProps extends IDispatchProps, IStateProps, RouteComponentProps<{}> {}
 
@@ -99,7 +100,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
       sideContentProps: {
         activeTab: this.props.activeTab,
         handleChangeActiveTab: this.props.handleChangeActiveTab,
-        tabs: [playgroundIntroduction]
+        tabs: [playgroundIntroductionTab, listVisualizerTab]
       }
     }
     return (
@@ -120,7 +121,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
 
 const SICP_SITE = 'https://www.comp.nus.edu.sg/~cs1101s/source/'
 const CHAP = '\xa7'
-const playgroundIntroduction: SideContentTab = {
+const playgroundIntroductionTab: SideContentTab = {
   label: 'Introduction',
   icon: IconNames.COMPASS,
   body: (
@@ -144,6 +145,11 @@ const playgroundIntroduction: SideContentTab = {
       right border of the editor, or the top border of the REPL.
     </Text>
   )
+}
+const listVisualizerTab: SideContentTab = {
+  label: 'List Visualizer',
+  icon: IconNames.COMPASS,
+  body: <ListVisualizer />
 }
 
 export default Playground

--- a/src/components/workspace/side-content/ListVisualizer.tsx
+++ b/src/components/workspace/side-content/ListVisualizer.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@blueprintjs/core'
 import * as React from 'react'
 
 class ListVisualizer extends React.Component<{}, {}> {
@@ -12,28 +11,8 @@ class ListVisualizer extends React.Component<{}, {}> {
 
   public render() {
     return (
-      <div ref={r => this.$parent = r} className="sa-list-visualizer pt-dark">
-        <div className="row">
-          <div className="pt-button-group col-xs-12">
-            <Button id="next" onClick={this.handleNext}>Next</Button>
-            <Button id="previous" onClick={this.handlePrevious}>Previous</Button>
-            <Button id="clear" onClick={this.handleClear}>Clear</Button>
-          </div>
-        </div>
-      </div>
+      <div ref={r => this.$parent = r} className="sa-list-visualizer pt-dark" />
     )
-  }
-
-  private handleClear() {
-    (window as any).ListVisualizer.clear()
-  }
-
-  private handleNext() {
-    (window as any).ListVisualizer.next()
-  }
-
-  private handlePrevious() {
-    (window as any).ListVisualizer.previous()
   }
 }
 

--- a/src/components/workspace/side-content/ListVisualizer.tsx
+++ b/src/components/workspace/side-content/ListVisualizer.tsx
@@ -5,14 +5,12 @@ class ListVisualizer extends React.Component<{}, {}> {
 
   public componentDidMount() {
     if (this.$parent) {
-      (window as any).ListVisualizer.init(this.$parent)
+      ;(window as any).ListVisualizer.init(this.$parent)
     }
   }
 
   public render() {
-    return (
-      <div ref={r => this.$parent = r} className="sa-list-visualizer pt-dark" />
-    )
+    return <div ref={r => (this.$parent = r)} className="sa-list-visualizer pt-dark" />
   }
 }
 

--- a/src/components/workspace/side-content/ListVisualizer.tsx
+++ b/src/components/workspace/side-content/ListVisualizer.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@blueprintjs/core'
+import * as React from 'react'
+
+class ListVisualizer extends React.Component<{}, {}> {
+  private $parent: HTMLElement | null
+
+  public componentDidMount() {
+    if (this.$parent) {
+      (window as any).ListVisualizer.init(this.$parent)
+    }
+  }
+
+  public render() {
+    return (
+      <div ref={r => this.$parent = r} className="sa-list-visualizer pt-dark">
+        <div className="row">
+          <div className="pt-button-group col-xs-12">
+            <Button id="next" onClick={this.handleNext}>Next</Button>
+            <Button id="previous" onClick={this.handlePrevious}>Previous</Button>
+            <Button id="clear" onClick={this.handleClear}>Clear</Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  private handleClear() {
+    (window as any).ListVisualizer.clear()
+  }
+
+  private handleNext() {
+    (window as any).ListVisualizer.next()
+  }
+
+  private handlePrevious() {
+    (window as any).ListVisualizer.previous()
+  }
+}
+
+export default ListVisualizer

--- a/src/styles/_playground.scss
+++ b/src/styles/_playground.scss
@@ -12,5 +12,5 @@
    */
   width: 100% !important;
   height: 40vh !important; // 100% results in 0 height, 100vh is too big.
-  overflow: scroll;
+  overflow: auto;
 }

--- a/src/styles/_playground.scss
+++ b/src/styles/_playground.scss
@@ -4,3 +4,13 @@
   flex-direction: column;
   flex: 1 1 100%;
 }
+
+.kineticjs-content {
+  /** 
+   * Fixes a bug where the 1000x1000 canvas does not overflow
+   * when it's container is too small.
+   */
+  width: 100% !important;
+  height: 40vh !important; // 100% results in 0 height, 100vh is too big.
+  overflow: scroll;
+}

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -79,23 +79,29 @@ $code-color-error: #ff4444;
     flex: 1 1;
     margin: 0 0.5rem 0 0.5rem;
     overflow: hidden;
+
     .mcq-content-parent {
       height: 100%;
       overflow: auto;
       padding: 20px;
+
       .mcq-options-parent {
         height: 100%;
+
         .mcq-option {
           padding: 20px;
         }
+
         .mcq-option:focus {
           outline: 0;
         }
       }
     }
+
     .pt-card {
       background-color: $cadet-color-2;
     }
+
     .Text {
       word-break: break-word;
       word-wrap: break-word;

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -78,6 +78,8 @@ function visualiseList(list: any) {
     throw new Error('List visualizer is not enabled') 
   }
 }
+/** Follow the js-slang specification of the visualiseList symbol. */
+visualiseList.__SOURCE__ = 'draw(a)'
 
 /**
  * A wrapper around js-slang's createContext. This

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -71,7 +71,13 @@ cadetAlert.__SOURCE__ = 'alert(a)'
  *
  * @param list the list to be visualised.
  */
-function visualiseList(list: any) {}
+function visualiseList(list: any) {
+  if ((window as any).ListVisualizer) {
+    (window as any).ListVisualizer.draw(list)
+  } else {
+    throw new Error('List visualizer is not enabled') 
+  }
+}
 
 /**
  * A wrapper around js-slang's createContext. This

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -73,9 +73,9 @@ cadetAlert.__SOURCE__ = 'alert(a)'
  */
 function visualiseList(list: any) {
   if ((window as any).ListVisualizer) {
-    (window as any).ListVisualizer.draw(list)
+    ;(window as any).ListVisualizer.draw(list)
   } else {
-    throw new Error('List visualizer is not enabled') 
+    throw new Error('List visualizer is not enabled')
   }
 }
 /** Follow the js-slang specification of the visualiseList symbol. */

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -79,7 +79,7 @@ function visualiseList(list: any) {
   }
 }
 /** Follow the js-slang specification of the visualiseList symbol. */
-visualiseList.__SOURCE__ = 'draw(a)'
+visualiseList.__SOURCE__ = 'draw_list(a)'
 
 /**
  * A wrapper around js-slang's createContext. This

--- a/yarn.lock
+++ b/yarn.lock
@@ -5135,9 +5135,9 @@ js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
-js-slang@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.3.tgz#ff95065aad01d0f6f54f169ae0691f4796f493bc"
+js-slang@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.5.tgz#15ba048bfe8129b94ec868734337df0a65049d8b"
   dependencies:
     "@types/acorn" "^4.0.3"
     "@types/estree" "0.0.39"


### PR DESCRIPTION
### Requirements
- [x] js-slang must specify the `draw` function to be available (not exactly necessary, but is essential for testing)

### Features
- calling `draw` on a list visualises it in a side content tab
- The visualiser is only available on the playground
- The "Next", "Previous" and "Clear" buttons have been scrapped, as that introduces a two-way interaction between the application (that calls the external functions) and the library (that manipulates the dom and refers to the buttons by class and id). Either ways, I don't see the use case for visualising multiple lists in quick succession.
