### PR TITLE
Make MCQ Hint messages show up only when hint is non-null

### DIFF
--- a/src/components/workspace/MCQChooser.tsx
+++ b/src/components/workspace/MCQChooser.tsx
@@ -54,10 +54,13 @@ class MCQChooser extends React.PureComponent<IMCQChooserProps, State> {
    */
   private onButtonClickFactory = (i: number) => (e: any) => {
     this.props.handleMCQSubmit(i)
-    if (this.props.mcq.solution && i === this.props.mcq.solution) {
-      showSuccessMessage(this.props.mcq.choices[i].hint!, 4000)
-    } else if (this.props.mcq.solution && i !== this.props.mcq.solution) {
-      showWarningMessage(this.props.mcq.choices[i].hint!, 4000)
+    const shouldDisplayMessage = this.props.mcq.solution && this.props.mcq.choices[i].hint
+    if (shouldDisplayMessage) {
+      if (i === this.props.mcq.solution) {
+        showSuccessMessage(this.props.mcq.choices[i].hint!, 4000)
+      } else {
+        showWarningMessage(this.props.mcq.choices[i].hint!, 4000)
+      }
     }
     this.setState({
       mcqOption: i

--- a/src/components/workspace/MCQChooser.tsx
+++ b/src/components/workspace/MCQChooser.tsx
@@ -53,7 +53,12 @@ class MCQChooser extends React.PureComponent<IMCQChooserProps, State> {
    * @param i the id of the answer
    */
   private onButtonClickFactory = (i: number) => (e: any) => {
-    this.props.handleMCQSubmit(i)
+    if (i !== this.state.mcqOption) {
+      this.props.handleMCQSubmit(i)
+      this.setState({
+        mcqOption: i
+      })
+    }
     const shouldDisplayMessage = this.props.mcq.solution && this.props.mcq.choices[i].hint
     if (shouldDisplayMessage) {
       if (i === this.props.mcq.solution) {
@@ -62,9 +67,6 @@ class MCQChooser extends React.PureComponent<IMCQChooserProps, State> {
         showWarningMessage(this.props.mcq.choices[i].hint!, 4000)
       }
     }
-    this.setState({
-      mcqOption: i
-    })
   }
 
   /**

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -171,7 +171,7 @@ What's your favourite dinner food?
   {
     answer: 3,
     content:
-      'This is the 3rd question. Oddly enough, it is an ungraded MCQ question that uses the curves library!',
+      'This is the 3rd question. Oddly enough, it is an ungraded MCQ question that uses the curves library! Option C has a null hint!',
     choices: [
       {
         content: 'A',
@@ -183,7 +183,7 @@ What's your favourite dinner food?
       },
       {
         content: 'C',
-        hint: 'hint C'
+        hint: null
       },
       {
         content: 'D',


### PR DESCRIPTION
### Features
- No message is shown for `null` hints
- MCQ is not submitted if the selected option is the same as the current option. This prevents unnecessary POST requests (imagine someone auto-clicking the mcq buttons to throw requests at the backend)

### Issues fixes
- Fixes #281 