### PR TITLE
Use externalSymbols stored in js-slang

### DIFF
--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -66,7 +66,6 @@ export interface IWorkspaceState {
   readonly replValue: string
   readonly sideContentActiveTab: number
   readonly sideContentHeight?: number
-  readonly externalSymbols: string[]
   readonly globals: Array<[string, any]>
 }
 
@@ -203,7 +202,6 @@ export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceS
   },
   replValue: '',
   sideContentActiveTab: 0,
-  externalSymbols: [],
   globals: [],
   isRunning: false
 })

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -192,7 +192,7 @@ export const defaultEditorValue = '// Type your program in here!'
  * @param location the location of the workspace, used for context
  */
 export const createDefaultWorkspace = (location: WorkspaceLocation): IWorkspaceState => ({
-  context: createContext<WorkspaceLocation>(latestSourceChapter, undefined, location),
+  context: createContext<WorkspaceLocation>(latestSourceChapter, [], location),
   editorValue: location === WorkspaceLocations.playground ? defaultEditorValue : null,
   editorWidth: '50%',
   output: [],

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -189,7 +189,6 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
             action.payload.library.external.symbols,
             location
           ),
-          externalSymbols: action.payload.library.external.symbols,
           globals: action.payload.library.globals
         }
       }

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -35,7 +35,7 @@ function* workspaceSaga(): SagaIterator {
       (state: IState) => (state.workspaces[location] as IWorkspaceState).context.chapter
     )
     const symbols: string[] = yield select(
-      (state: IState) => (state.workspaces[location] as IWorkspaceState).externalSymbols
+      (state: IState) => (state.workspaces[location] as IWorkspaceState).context.externalSymbols
     )
     const globals: Array<[string, any]> = yield select(
       (state: IState) => (state.workspaces[location] as IWorkspaceState).globals
@@ -80,7 +80,7 @@ function* workspaceSaga(): SagaIterator {
       (state: IState) => (state.workspaces[location] as IWorkspaceState).context.chapter
     )
     const symbols: string[] = yield select(
-      (state: IState) => (state.workspaces[location] as IWorkspaceState).externalSymbols
+      (state: IState) => (state.workspaces[location] as IWorkspaceState).context.externalSymbols
     )
     const globals: Array<[string, any]> = yield select(
       (state: IState) => (state.workspaces[location] as IWorkspaceState).globals

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -86,7 +86,7 @@ visualiseList.__SOURCE__ = 'draw_list(a)'
  * provides the original function with the required
  * externalBuiltIns, such as display and prompt.
  */
-export function createContext<T>(chapter = 1, externals: string[] = [], externalContext: T) {
+export function createContext<T>(chapter: number, externals: string[], externalContext: T) {
   const externalBuiltIns = {
     display,
     prompt: cadetPrompt,


### PR DESCRIPTION
### Features
- `externalSymbols` removed from the state
- Symbols are retrieved from js-slang instead, where they are stored (master uses 0.1.5, that does store it already)

I'm putting a waiting tag on this because **it affects a critical part of the website** and should be certain to contain no bugs before being merged.

Fixes #276 