### PR TITLE
Fix null crashing interpreter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "cadet-frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts-info": {
     "format": "Format source code",
     "start": "Start the Webpack development server",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "draft-js": "^0.10.5",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "0.1.5",
+    "js-slang": "0.1.6",
     "lodash": "^4.17.10",
     "lz-string": "^1.4.4",
     "moment": "^2.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5135,9 +5135,9 @@ js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
-js-slang@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.5.tgz#15ba048bfe8129b94ec868734337df0a65049d8b"
+js-slang@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.6.tgz#cfd5b663af57bb6d185e9c5397f9c38e4f5ac21a"
   dependencies:
     "@types/acorn" "^4.0.3"
     "@types/estree" "0.0.39"


### PR DESCRIPTION
### Features
- Bumped js-slang to 0.1.6, that fixes this issue

Resolves #307