### PR TITLE
Disable MCQ selection in Grading workspace

### DIFF
--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -114,6 +114,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       handleEditorWidthChange: this.props.handleEditorWidthChange,
       handleSideContentHeightChange: this.props.handleSideContentHeightChange,
       mcqProps: {
+        disableSelection: true,
         mcq: question as IMCQQuestion,
         handleMCQSubmit: (i: number) => {}
       },

--- a/src/components/workspace/MCQChooser.tsx
+++ b/src/components/workspace/MCQChooser.tsx
@@ -6,6 +6,7 @@ import { IMCQQuestion } from '../assessment/assessmentShape'
 import Markdown from '../commons/Markdown'
 
 export interface IMCQChooserProps {
+  disableSelection?: boolean
   mcq: IMCQQuestion
   handleMCQSubmit: (choiceId: number) => void
 }
@@ -15,6 +16,10 @@ type State = {
 }
 
 class MCQChooser extends React.PureComponent<IMCQChooserProps, State> {
+  public static defaultProps: Partial<IMCQChooserProps> = {
+    disableSelection: false
+  }
+
   constructor(props: IMCQChooserProps) {
     super(props)
     this.state = {
@@ -54,7 +59,7 @@ class MCQChooser extends React.PureComponent<IMCQChooserProps, State> {
    * @param i the id of the answer
    */
   private onButtonClickFactory = (i: number) => (e: any) => {
-    if (i !== this.state.mcqOption) {
+    if (i !== this.state.mcqOption && !this.props.disableSelection) {
       this.props.handleMCQSubmit(i)
       this.setState({
         mcqOption: i


### PR DESCRIPTION
### Features
- Buttons are clickable (to show hints), but the option does not get highlighted.
- An optional prop is used (like in ControlBar) as it is not an expected default behaviour