### PR TITLE
Clicking on Diamond Logo - Broken Link

### DIFF
--- a/src/components/academy/game/create-initializer.js
+++ b/src/components/academy/game/create-initializer.js
@@ -48,7 +48,7 @@ export default function (StoryXMLPlayer, story, username, attemptedAll) {
   };
 
   function openWristDevice() {
-    history.push(LINKS.IVLE)
+    window.open(LINKS.IVLE);
   }
 
   function startGame(div, canvas, saveData) {


### PR DESCRIPTION
Reference to issue #305 

PR #308 changes openWristDevice() to history.push(). However, this is a relative change and window.open() is required to change URL to IVLE. 
 