### PR TITLE
Markdown table styling fix

### DIFF
--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -122,7 +122,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -216,7 +216,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -312,7 +312,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -408,7 +408,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -612,7 +612,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -730,7 +730,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -826,7 +826,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">
@@ -922,7 +922,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                 </div>
                                 <div className=\\"row listing-description\\">
                                   <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                    <div className={[undefined]} dangerouslySetInnerHTML={{...}} />
+                                    <div className=\\"md\\" dangerouslySetInnerHTML={{...}} />
                                   </Markdown>
                                 </div>
                                 <div className=\\"listing-controls\\">

--- a/src/components/commons/Markdown.tsx
+++ b/src/components/commons/Markdown.tsx
@@ -8,7 +8,7 @@ type MarkdownProps = {
 
 const Markdown: React.SFC<MarkdownProps> = props => (
   <div
-    className={props.className}
+    className={props.className ? props.className : 'md'}
     dangerouslySetInnerHTML={{ __html: converter.makeHtml(props.content) }}
   />
 )


### PR DESCRIPTION
Right now the styling affects all the tables (not just markdown related):

<img width="700" alt="screen shot 2018-10-10 at 12 40 55 pm" src="https://user-images.githubusercontent.com/10579415/46713560-e9ce5700-cc89-11e8-9b41-0f45827672be.png">

I have made the css specific to only point to Markdown components (made a `md` class if no class defined).

Updated tests also!

