### PR TITLE
Make Workspace testable and add a test for it

### DIFF
--- a/src/components/commons/Resizable.tsx
+++ b/src/components/commons/Resizable.tsx
@@ -1,0 +1,7 @@
+import * as ResizableOriginal from 're-resizable'
+
+export { default as ResizableElement } from 're-resizable'
+export * from 're-resizable'
+export default (ResizableOriginal instanceof Function
+  ? ResizableOriginal
+  : (ResizableOriginal as any).default)

--- a/src/components/workspace/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Workspace renders correctly 1`] = `
+"<div className=\\"workspace\\">
+  <ControlBar externalLibraryName=\\"\\" handleChapterSelect={[Function: handleChapterSelect]} handleExternalSelect={[Function: handleExternalSelect]} handleEditorEval={[Function: handleEditorEval]} handleGenerateLz={[Function: handleGenerateLz]} handleInterruptEval={[Function: handleInterruptEval]} handleReplEval={[Function: handleReplEval]} handleReplOutputClear={[Function: handleReplOutputClear]} hasChapterSelect={true} hasSaveButton={false} hasShareButton={true} isRunning={true} queryString=\\"/playground\\" questionProgress={{...}} sourceChapter={3} hasUnsavedChanges={[undefined]} onClickNext={[Function: onClickNext]} onClickPrevious={[Function: onClickPrevious]} onClickSave={[Function: onClickSave]} />
+  <div className=\\"row workspace-parent\\">
+    <div className=\\"editor-divider\\" />
+    <Resizable className=\\"resize-editor left-parent\\" enable={{...}} minWidth={0} onResize={[Function]} onResizeStop={[Function: onResizeStop]} size={{...}} onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0}>
+      <Editor editorValue=\\"\\" handleEditorEval={[Function: handleEditorEval]} handleEditorValueChange={[Function: handleEditorValueChange]} />
+    </Resizable>
+    <div className=\\"right-parent\\">
+      <Resizable bounds=\\"parent\\" className=\\"resize-side-content\\" enable={{...}} minHeight={0} onResize={[Function]} onResizeStop={[Function: onResizeStop]} size={{...}} onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0}>
+        <SideContent activeTab={0} handleChangeActiveTab={[Function: handleChangeActiveTab]} tabs={{...}} />
+        <div className=\\"side-content-divider\\" />
+      </Resizable>
+      <Repl output={{...}} replValue=\\"\\" handleBrowseHistoryDown={[Function: handleBrowseHistoryDown]} handleBrowseHistoryUp={[Function: handleBrowseHistoryUp]} handleReplEval={[Function: handleReplEval]} handleReplValueChange={[Function: handleReplValueChange]} />
+    </div>
+  </div>
+</div>"
+`;

--- a/src/components/workspace/__tests__/index.tsx
+++ b/src/components/workspace/__tests__/index.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+
+import { shallow } from 'enzyme'
+
+import Workspace, { WorkspaceProps } from '..'
+import { SideContentTab } from '../side-content'
+
+const playgroundIntroductionTab: SideContentTab = {
+  label: 'Introduction',
+  icon: '',
+  body: <p />
+}
+
+const listVisualizerTab: SideContentTab = {
+  label: 'List Visualizer',
+  icon: '',
+  body: <p />
+}
+
+test('Workspace renders correctly', () => {
+  const props: WorkspaceProps = {
+    controlBarProps: {
+      externalLibraryName: '',
+      handleChapterSelect: () => {},
+      handleExternalSelect: () => {},
+      handleEditorEval: () => {},
+      handleGenerateLz: () => {},
+      handleInterruptEval: () => {},
+      handleReplEval: () => {},
+      handleReplOutputClear: () => {},
+      hasChapterSelect: true,
+      hasSaveButton: false,
+      hasShareButton: true,
+      isRunning: true,
+      queryString: '/playground',
+      questionProgress: null,
+      sourceChapter: 3
+    },
+    editorProps: {
+      editorValue: '',
+      handleEditorEval: () => {},
+      handleEditorValueChange: () => {}
+    },
+    editorWidth: '100%',
+    handleEditorWidthChange: () => {},
+    handleSideContentHeightChange: () => {},
+    replProps: {
+      output: [],
+      replValue: '',
+      handleBrowseHistoryDown: () => {},
+      handleBrowseHistoryUp: () => {},
+      handleReplEval: () => {},
+      handleReplValueChange: () => {}
+    },
+    sideContentHeight: 10,
+    sideContentProps: {
+      activeTab: 0,
+      handleChangeActiveTab: () => {},
+      tabs: [playgroundIntroductionTab, listVisualizerTab]
+    }
+  }
+
+  const app = <Workspace {...props} />
+  const tree = shallow(app)
+  expect(tree.debug()).toMatchSnapshot()
+})


### PR DESCRIPTION
There's a bug (with react-scripts-ts?) that causes yarn test to load a
different version of `re-resizable` compared to yarn start, so in order
to work around that I've added a commons component that just wraps
around re-resizable and makes it work no matter which version is loaded.
Ugly though.