### PR TITLE
Move max grade and max xp into question

### DIFF
--- a/src/components/academy/grading/GradingWorkspace.tsx
+++ b/src/components/academy/grading/GradingWorkspace.tsx
@@ -190,10 +190,10 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
             submissionId={props.submissionId}
             initialGrade={props.grading![questionId].grade.grade}
             gradeAdjustment={props.grading![questionId].grade.gradeAdjustment}
-            maxGrade={props.grading![questionId].maxGrade}
+            maxGrade={props.grading![questionId].question.maxGrade}
             initialXp={props.grading![questionId].grade.xp}
             xpAdjustment={props.grading![questionId].grade.xpAdjustment}
-            maxXp={props.grading![questionId].maxXp}
+            maxXp={props.grading![questionId].question.maxXp}
           />
         )
       },

--- a/src/components/academy/grading/gradingShape.ts
+++ b/src/components/academy/grading/gradingShape.ts
@@ -35,8 +35,6 @@ export type Grading = GradingQuestion[]
  */
 export type GradingQuestion = {
   question: IAnsweredQuestion
-  maxGrade: number
-  maxXp: number
   grade: {
     comment: string
     grade: number
@@ -61,6 +59,8 @@ interface IAnsweredQuestion extends IQuestion {
   comment: null
   solution: number | string | null
   answer: string | number | null
+  maxGrade: number
+  maxXp: number
   solutionTemplate?: string
   choices?: MCQChoice[]
 }

--- a/src/mocks/gradingAPI.ts
+++ b/src/mocks/gradingAPI.ts
@@ -96,10 +96,10 @@ Hello and welcome to this assessment! This is the *0th question*.
       library: mockLibrary,
       solutionTemplate: '0th question mock solution template',
       solution: 'This is how the 0th question is `solved`',
-      type: 'programming'
+      type: 'programming',
+      maxGrade: 1000,
+      maxXp: 1000
     },
-    maxGrade: 1000,
-    maxXp: 1000,
     grade: {
       gradeAdjustment: 0,
       xpAdjustment: 0,
@@ -117,10 +117,10 @@ Hello and welcome to this assessment! This is the *0th question*.
       library: mockLibrary,
       solutionTemplate: '1st question mock solution template',
       solution: null,
-      type: 'programming'
+      type: 'programming',
+      maxGrade: 200,
+      maxXp: 200
     },
-    maxGrade: 200,
-    maxXp: 200,
     grade: {
       gradeAdjustment: 0,
       xpAdjustment: 0,
@@ -157,10 +157,10 @@ Hello and welcome to this assessment! This is the *0th question*.
       ],
       id: 2,
       library: mockLibrary,
-      type: 'mcq'
+      type: 'mcq',
+      maxGrade: 100,
+      maxXp: 100
     },
-    maxGrade: 100,
-    maxXp: 100,
     grade: {
       gradeAdjustment: 0,
       xpAdjustment: 0,

--- a/src/sagas/backend.ts
+++ b/src/sagas/backend.ts
@@ -462,7 +462,8 @@ async function getGrading(submissionId: number, tokens: Tokens): Promise<Grading
   if (response) {
     const gradingResult = await response.json()
     const grading: Grading = gradingResult.map((gradingQuestion: any) => {
-      const { question, maxGrade, maxXp, grade } = gradingQuestion
+      const { question, grade } = gradingQuestion
+
       return {
         question: {
           answer: question.answer,
@@ -477,10 +478,10 @@ async function getGrading(submissionId: number, tokens: Tokens): Promise<Grading
               ? question.solution
               : null,
           solutionTemplate: question.solutionTemplate,
-          type: question.type as QuestionType
+          type: question.type as QuestionType,
+          maxGrade: question.maxGrade,
+          maxXp: question.maxXp
         },
-        maxGrade,
-        maxXp,
         grade: {
           grade: grade.grade,
           xp: grade.xp,


### PR DESCRIPTION
This is the accompanying frontend fix.

Now, max grade and xp will be available in the assessment workspace.
Which #420 will require.

To merge only after this backend pr has been merged.
source-academy/cadet#320