### PR TITLE
fixes #407

### DIFF
--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import AceEditor from 'react-ace'
 import { HotKeys } from 'react-hotkeys'
 
+import 'brace/ext/searchbox'
 import 'brace/mode/javascript'
 import 'brace/theme/cobalt'
 


### PR DESCRIPTION
Ctrl + F now works in editor due to missing import for the searchbox.