### PR TITLE
Fixed missing reset button and renamed reset to resetTemplate

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -85,13 +85,13 @@ export type DispatchProps = {
 
 class AssessmentWorkspace extends React.Component<
   AssessmentWorkspaceProps,
-  { showOverlay: boolean; showResetOverlay: boolean }
+  { showOverlay: boolean; showresetTemplateOverlay: boolean }
 > {
   public constructor(props: AssessmentWorkspaceProps) {
     super(props);
     this.state = {
       showOverlay: false,
-      showResetOverlay: false
+      showresetTemplateOverlay: false
     };
     this.props.handleEditorValueChange('');
   }
@@ -154,12 +154,12 @@ class AssessmentWorkspace extends React.Component<
       </Dialog>
     );
 
-    const resetOverlay = (
+    const resetTemplateOverlay = (
       <Dialog
         className="assessment-reset"
         icon={IconNames.ERROR}
         isCloseButtonShown={false}
-        isOpen={this.state.showResetOverlay}
+        isOpen={this.state.showresetTemplateOverlay}
         title="Confirmation: Reset editor?"
       >
         <div className={Classes.DIALOG_BODY}>
@@ -168,14 +168,19 @@ class AssessmentWorkspace extends React.Component<
         </div>
         <div className={Classes.DIALOG_FOOTER}>
           <ButtonGroup>
-            {controlButton('Cancel', null, () => this.setState({ showResetOverlay: false }), {
-              minimal: false
-            })}
+            {controlButton(
+              'Cancel',
+              null,
+              () => this.setState({ showresetTemplateOverlay: false }),
+              {
+                minimal: false
+              }
+            )}
             {controlButton(
               'Confirm',
               null,
               () => {
-                this.setState({ showResetOverlay: false });
+                this.setState({ showresetTemplateOverlay: false });
                 this.props.handleEditorValueChange(
                   (this.props.assessment!.questions[questionId] as IProgrammingQuestion)
                     .solutionTemplate
@@ -233,7 +238,7 @@ class AssessmentWorkspace extends React.Component<
     return (
       <div className="WorkspaceParent pt-dark">
         {overlay}
-        {resetOverlay}
+        {resetTemplateOverlay}
         <Workspace {...workspaceProps} />
       </div>
     );
@@ -362,8 +367,8 @@ class AssessmentWorkspace extends React.Component<
           this.props.assessment!.questions[questionId].id,
           this.props.editorValue!
         ),
-      onClickReset: () => {
-        this.setState({ showResetOverlay: true });
+      onClickResetTemplate: () => {
+        this.setState({ showresetTemplateOverlay: true });
       },
       questionProgress: [questionId + 1, this.props.assessment!.questions.length],
       sourceChapter: this.props.assessment!.questions[questionId].library.chapter

--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -85,13 +85,13 @@ export type DispatchProps = {
 
 class AssessmentWorkspace extends React.Component<
   AssessmentWorkspaceProps,
-  { showOverlay: boolean; showresetTemplateOverlay: boolean }
+  { showOverlay: boolean; showResetTemplateOverlay: boolean }
 > {
   public constructor(props: AssessmentWorkspaceProps) {
     super(props);
     this.state = {
       showOverlay: false,
-      showresetTemplateOverlay: false
+      showResetTemplateOverlay: false
     };
     this.props.handleEditorValueChange('');
   }
@@ -159,7 +159,7 @@ class AssessmentWorkspace extends React.Component<
         className="assessment-reset"
         icon={IconNames.ERROR}
         isCloseButtonShown={false}
-        isOpen={this.state.showresetTemplateOverlay}
+        isOpen={this.state.showResetTemplateOverlay}
         title="Confirmation: Reset editor?"
       >
         <div className={Classes.DIALOG_BODY}>
@@ -171,7 +171,7 @@ class AssessmentWorkspace extends React.Component<
             {controlButton(
               'Cancel',
               null,
-              () => this.setState({ showresetTemplateOverlay: false }),
+              () => this.setState({ showResetTemplateOverlay: false }),
               {
                 minimal: false
               }
@@ -180,7 +180,7 @@ class AssessmentWorkspace extends React.Component<
               'Confirm',
               null,
               () => {
-                this.setState({ showresetTemplateOverlay: false });
+                this.setState({ showResetTemplateOverlay: false });
                 this.props.handleEditorValueChange(
                   (this.props.assessment!.questions[questionId] as IProgrammingQuestion)
                     .solutionTemplate
@@ -368,7 +368,7 @@ class AssessmentWorkspace extends React.Component<
           this.props.editorValue!
         ),
       onClickResetTemplate: () => {
-        this.setState({ showresetTemplateOverlay: true });
+        this.setState({ showResetTemplateOverlay: true });
       },
       questionProgress: [questionId + 1, this.props.assessment!.questions.length],
       sourceChapter: this.props.assessment!.questions[questionId].library.chapter

--- a/src/components/missionControl/EditingWorkspace.tsx
+++ b/src/components/missionControl/EditingWorkspace.tsx
@@ -90,7 +90,7 @@ interface IState {
   activeTab: number;
   editingMode: string;
   hasUnsavedChanges: boolean;
-  showResetOverlay: boolean;
+  showresetTemplateOverlay: boolean;
   originalMaxGrade: number;
   originalMaxXp: number;
 }
@@ -103,7 +103,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       activeTab: 0,
       editingMode: 'question',
       hasUnsavedChanges: false,
-      showResetOverlay: false,
+      showresetTemplateOverlay: false,
       originalMaxGrade: 0,
       originalMaxXp: 0
     };
@@ -186,7 +186,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
     };
     return (
       <div className="WorkspaceParent pt-dark">
-        {this.resetOverlay()}
+        {this.resetTemplateOverlay()}
         <Workspace {...workspaceProps} />
       </div>
     );
@@ -206,12 +206,12 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
   /**
    * Resets to last save.
    */
-  private resetOverlay = () => (
+  private resetTemplateOverlay = () => (
     <Dialog
       className="assessment-reset"
       icon={IconNames.ERROR}
       isCloseButtonShown={false}
-      isOpen={this.state.showResetOverlay}
+      isOpen={this.state.showresetTemplateOverlay}
       title="Confirmation: Reset editor?"
     >
       <div className={Classes.DIALOG_BODY}>
@@ -219,7 +219,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <ButtonGroup>
-          {controlButton('Cancel', null, () => this.setState({ showResetOverlay: false }), {
+          {controlButton('Cancel', null, () => this.setState({ showresetTemplateOverlay: false }), {
             minimal: false
           })}
           {controlButton(
@@ -230,7 +230,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
               this.setState({
                 assessment,
                 hasUnsavedChanges: false,
-                showResetOverlay: false,
+                showresetTemplateOverlay: false,
                 originalMaxGrade: this.getMaxMarks('maxGrade'),
                 originalMaxXp: this.getMaxMarks('maxXp')
               });
@@ -568,8 +568,8 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
         history.push(assessmentWorkspacePath + `/${(questionId - 1).toString()}`),
       onClickReturn: () => history.push(listingPath),
       onClickSave: this.handleSave,
-      onClickReset: () => {
-        this.setState({ showResetOverlay: this.state.hasUnsavedChanges });
+      onClickResetTemplate: () => {
+        this.setState({ showresetTemplateOverlay: this.state.hasUnsavedChanges });
       },
       questionProgress: [questionId + 1, this.state.assessment!.questions.length],
       sourceChapter: this.state.assessment!.questions[questionId].library.chapter,

--- a/src/components/missionControl/EditingWorkspace.tsx
+++ b/src/components/missionControl/EditingWorkspace.tsx
@@ -90,7 +90,7 @@ interface IState {
   activeTab: number;
   editingMode: string;
   hasUnsavedChanges: boolean;
-  showresetTemplateOverlay: boolean;
+  showResetTemplateOverlay: boolean;
   originalMaxGrade: number;
   originalMaxXp: number;
 }
@@ -103,7 +103,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       activeTab: 0,
       editingMode: 'question',
       hasUnsavedChanges: false,
-      showresetTemplateOverlay: false,
+      showResetTemplateOverlay: false,
       originalMaxGrade: 0,
       originalMaxXp: 0
     };
@@ -211,7 +211,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       className="assessment-reset"
       icon={IconNames.ERROR}
       isCloseButtonShown={false}
-      isOpen={this.state.showresetTemplateOverlay}
+      isOpen={this.state.showResetTemplateOverlay}
       title="Confirmation: Reset editor?"
     >
       <div className={Classes.DIALOG_BODY}>
@@ -219,7 +219,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <ButtonGroup>
-          {controlButton('Cancel', null, () => this.setState({ showresetTemplateOverlay: false }), {
+          {controlButton('Cancel', null, () => this.setState({ showResetTemplateOverlay: false }), {
             minimal: false
           })}
           {controlButton(
@@ -230,7 +230,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
               this.setState({
                 assessment,
                 hasUnsavedChanges: false,
-                showresetTemplateOverlay: false,
+                showResetTemplateOverlay: false,
                 originalMaxGrade: this.getMaxMarks('maxGrade'),
                 originalMaxXp: this.getMaxMarks('maxXp')
               });
@@ -569,7 +569,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
       onClickReturn: () => history.push(listingPath),
       onClickSave: this.handleSave,
       onClickResetTemplate: () => {
-        this.setState({ showresetTemplateOverlay: this.state.hasUnsavedChanges });
+        this.setState({ showResetTemplateOverlay: this.state.hasUnsavedChanges });
       },
       questionProgress: [questionId + 1, this.state.assessment!.questions.length],
       sourceChapter: this.state.assessment!.questions[questionId].library.chapter,

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -63,7 +63,7 @@ export type ControlBarProps = {
   onClickPrevious?(): any;
   onClickReturn?(): any;
   onClickSave?(): any;
-  onClickReset?(): any;
+  onClickResetTemplate?(): any;
   toggleEditMode?(): void;
 };
 
@@ -91,7 +91,7 @@ class ControlBar extends React.PureComponent<ControlBarProps, { joinElemValue: s
     onClickNext: () => {},
     onClickPrevious: () => {},
     onClickSave: () => {},
-    onClickReset: () => {}
+    onClickResetTemplate: () => {}
   };
 
   private inviteInputElem: React.RefObject<HTMLInputElement>;
@@ -253,8 +253,8 @@ class ControlBar extends React.PureComponent<ControlBarProps, { joinElemValue: s
       this.props.hasChapterSelect && this.props.externalLibraryName !== undefined
         ? externalSelect(this.props.externalLibraryName, this.props.handleExternalSelect!)
         : undefined;
-    const resetButton = this.props.hasSaveButton
-      ? controlButton('Reset', IconNames.REPEAT, this.props.onClickReset)
+    const resetTemplateButton = this.props.hasSaveButton
+      ? controlButton('Reset', IconNames.REPEAT, this.props.onClickResetTemplate)
       : undefined;
     const toggleAutorunButton = this.props.hasEditorAutorunButton ? (
       <div className="Switch">
@@ -276,7 +276,7 @@ class ControlBar extends React.PureComponent<ControlBarProps, { joinElemValue: s
           : this.props.isRunning
             ? stopButton
             : this.props.isDebugging
-              ? resetButton
+              ? null
               : runButton}
         {this.props.isRunning
           ? this.props.isDebugging
@@ -286,7 +286,7 @@ class ControlBar extends React.PureComponent<ControlBarProps, { joinElemValue: s
             ? resumeButton
             : null}
         {saveButton}
-        {shareButton} {chapterSelectButton} {externalSelectButton}
+        {shareButton} {chapterSelectButton} {externalSelectButton} {resetTemplateButton}
         {inviteButton} {this.props.editorSessionId === '' ? joinButton : leaveButton}
       </div>
     );


### PR DESCRIPTION
- Fixed missing reset button introduced in #506 
- Renamed 'reset' to 'resetTemplate' for dis-ambiguity