### PR TITLE
Frontend testing: Add tests for actions folder

### DIFF
--- a/src/actions/__tests__/commons.ts
+++ b/src/actions/__tests__/commons.ts
@@ -1,0 +1,9 @@
+import * as actionTypes from '../actionTypes';
+import { logOut } from '../commons';
+
+test('logOut generates correct action object', () => {
+  const action = logOut();
+  expect(action).toEqual({
+    type: actionTypes.LOG_OUT
+  });
+});

--- a/src/actions/__tests__/game.ts
+++ b/src/actions/__tests__/game.ts
@@ -1,0 +1,11 @@
+import * as actionTypes from '../actionTypes';
+import { saveCanvas } from '../game';
+
+test('saveCanvas generates correct action object', () => {
+  const canvas: HTMLCanvasElement = document.createElement('canvas');
+  const action = saveCanvas(canvas);
+  expect(action).toEqual({
+    type: actionTypes.SAVE_CANVAS,
+    payload: canvas
+  });
+});

--- a/src/actions/__tests__/interpreter.ts
+++ b/src/actions/__tests__/interpreter.ts
@@ -1,0 +1,131 @@
+import { WorkspaceLocation, WorkspaceLocations } from '../../actions/workspaces';
+import * as actionTypes from '../actionTypes';
+import {
+  beginDebuggerPause,
+  beginInterruptExecution,
+  debuggerReset,
+  debuggerResume,
+  endDebuggerPause,
+  endInterruptExecution,
+  evalInterpreterError,
+  evalInterpreterSuccess,
+  evalTestcaseSuccess,
+  handleConsoleLog
+} from '../interpreter';
+
+const assessmentWorkspace: WorkspaceLocation = WorkspaceLocations.assessment;
+const gradingWorkspace: WorkspaceLocation = WorkspaceLocations.grading;
+const playgroundWorkspace: WorkspaceLocation = WorkspaceLocations.playground;
+
+test('handleConsoleLog generates correct action object', () => {
+  const logString = 'test-log-string';
+  const action = handleConsoleLog(logString, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.HANDLE_CONSOLE_LOG,
+    payload: {
+      logString,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('evalInterpreterSuccess generates correct action object', () => {
+  const value = 'value';
+  const action = evalInterpreterSuccess(value, gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_INTERPRETER_SUCCESS,
+    payload: {
+      type: 'result',
+      value,
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('evalTestcaseSuccess generates correct action object', () => {
+  const value = 'another value';
+  const index = 3;
+  const action = evalTestcaseSuccess(value, playgroundWorkspace, index);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_TESTCASE_SUCCESS,
+    payload: {
+      type: 'result',
+      value,
+      workspaceLocation: playgroundWorkspace,
+      index
+    }
+  });
+});
+
+test('evalInterpreterError generates correct action object', () => {
+  const errors: any = [];
+  const action = evalInterpreterError(errors, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_INTERPRETER_ERROR,
+    payload: {
+      type: 'errors',
+      errors,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('beginInterruptExecution generates correct action object', () => {
+  const action = beginInterruptExecution(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.BEGIN_INTERRUPT_EXECUTION,
+    payload: {
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('endInterruptExecution generates correct action object', () => {
+  const action = endInterruptExecution(playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.END_INTERRUPT_EXECUTION,
+    payload: {
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('beginDebuggerPause generates correct action object', () => {
+  const action = beginDebuggerPause(assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.BEGIN_DEBUG_PAUSE,
+    payload: {
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('endDebuggerPause generates correct action object', () => {
+  const action = endDebuggerPause(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.END_DEBUG_PAUSE,
+    payload: {
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('debuggerResume generates correct action object', () => {
+  const action = debuggerResume(playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.DEBUG_RESUME,
+    payload: {
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('debuggerReset generates correct action object', () => {
+  const action = debuggerReset(assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.DEBUG_RESET,
+    payload: {
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});

--- a/src/actions/__tests__/playground.ts
+++ b/src/actions/__tests__/playground.ts
@@ -1,0 +1,18 @@
+import * as actionTypes from '../actionTypes';
+import { changeQueryString, generateLzString } from '../playground';
+
+test('generateLzString generates correct action object', () => {
+  const action = generateLzString();
+  expect(action).toEqual({
+    type: actionTypes.GENERATE_LZ_STRING
+  });
+});
+
+test('changeQueryString generates correct action object', () => {
+  const queryString = 'test-query-string';
+  const action = changeQueryString(queryString);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_QUERY_STRING,
+    payload: queryString
+  });
+});

--- a/src/actions/__tests__/session.ts
+++ b/src/actions/__tests__/session.ts
@@ -1,0 +1,285 @@
+import { Grading, GradingOverview } from '../../components/academy/grading/gradingShape';
+import { IAssessment, IAssessmentOverview } from '../../components/assessment/assessmentShape';
+import * as actionTypes from '../actionTypes';
+import {
+  fetchAnnouncements,
+  fetchAssessment,
+  fetchAssessmentOverviews,
+  fetchAuth,
+  fetchGrading,
+  fetchGradingOverviews,
+  login,
+  setTokens,
+  setUser,
+  submitAnswer,
+  submitAssessment,
+  submitGrading,
+  updateAssessment,
+  updateAssessmentOverviews,
+  updateGrading,
+  updateGradingOverviews,
+  updateHistoryHelpers
+} from '../session';
+
+test('fetchAuth generates correct action object', () => {
+  const luminusCode = 'luminus-code-test';
+  const action = fetchAuth(luminusCode);
+  expect(action).toEqual({
+    type: actionTypes.FETCH_AUTH,
+    payload: luminusCode
+  });
+});
+
+test('fetchAnnouncements generates correct action object', () => {
+  const action = fetchAnnouncements();
+  expect(action).toEqual({
+    type: actionTypes.FETCH_ANNOUNCEMENTS
+  });
+});
+
+test('fetchAssessment generates correct action object', () => {
+  const id = 3;
+  const action = fetchAssessment(id);
+  expect(action).toEqual({
+    type: actionTypes.FETCH_ASSESSMENT,
+    payload: id
+  });
+});
+
+test('fetchAssessmentOverviews generates correct action object', () => {
+  const action = fetchAssessmentOverviews();
+  expect(action).toEqual({
+    type: actionTypes.FETCH_ASSESSMENT_OVERVIEWS
+  });
+});
+
+test('fetchGrading generates correct action object', () => {
+  const submissionId = 5;
+  const action = fetchGrading(submissionId);
+  expect(action).toEqual({
+    type: actionTypes.FETCH_GRADING,
+    payload: submissionId
+  });
+});
+
+test('fetchGradingOverviews generates correct default action object', () => {
+  const action = fetchGradingOverviews();
+  expect(action).toEqual({
+    type: actionTypes.FETCH_GRADING_OVERVIEWS,
+    payload: true
+  });
+});
+
+test('fetchGradingOverviews generates correct action object', () => {
+  const filterToGroup = false;
+  const action = fetchGradingOverviews(filterToGroup);
+  expect(action).toEqual({
+    type: actionTypes.FETCH_GRADING_OVERVIEWS,
+    payload: filterToGroup
+  });
+});
+
+test('login action generates correct action object', () => {
+  const action = login();
+  expect(action).toEqual({
+    type: actionTypes.LOGIN
+  });
+});
+
+test('setTokens generates correct action object', () => {
+  const accessToken = 'access-token-test';
+  const refreshToken = 'refresh-token-test';
+  const action = setTokens({ accessToken, refreshToken });
+  expect(action).toEqual({
+    type: actionTypes.SET_TOKENS,
+    payload: {
+      accessToken,
+      refreshToken
+    }
+  });
+});
+
+test('setUser generates correct action object', () => {
+  const user = {
+    name: 'test student',
+    role: 'student',
+    grade: 150,
+    story: {}
+  };
+  const action = setUser(user);
+  expect(action).toEqual({
+    type: actionTypes.SET_USER,
+    payload: user
+  });
+});
+
+test('submitAnswer generates correct action object', () => {
+  const id = 3;
+  const answer = 'test-answer-here';
+  const action = submitAnswer(id, answer);
+  expect(action).toEqual({
+    type: actionTypes.SUBMIT_ANSWER,
+    payload: {
+      id,
+      answer
+    }
+  });
+});
+
+test('submitAssessment generates correct action object', () => {
+  const id = 7;
+  const action = submitAssessment(id);
+  expect(action).toEqual({
+    type: actionTypes.SUBMIT_ASSESSMENT,
+    payload: id
+  });
+});
+
+test('submitGrading generates correct action object with default values', () => {
+  const submissionId = 8;
+  const questionId = 2;
+  const comment = 'test comment here';
+
+  const action = submitGrading(submissionId, questionId, comment);
+  expect(action).toEqual({
+    type: actionTypes.SUBMIT_GRADING,
+    payload: {
+      submissionId,
+      questionId,
+      comment,
+      gradeAdjustment: 0,
+      xpAdjustment: 0
+    }
+  });
+});
+
+test('submitGrading generates correct action object', () => {
+  const submissionId = 10;
+  const questionId = 3;
+  const comment = 'another test comment here';
+  const gradeAdjustment = 10;
+  const xpAdjustment = 100;
+  const action = submitGrading(submissionId, questionId, comment, gradeAdjustment, xpAdjustment);
+  expect(action).toEqual({
+    type: actionTypes.SUBMIT_GRADING,
+    payload: {
+      submissionId,
+      questionId,
+      comment,
+      gradeAdjustment,
+      xpAdjustment
+    }
+  });
+});
+
+test('updateHistoryHelpers generates correct action object', () => {
+  const loc = 'location';
+  const action = updateHistoryHelpers(loc);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_HISTORY_HELPERS,
+    payload: loc
+  });
+});
+
+test('updateAssessmentOverviews generates correct action object', () => {
+  const overviews: IAssessmentOverview[] = [
+    {
+      category: 'Mission',
+      closeAt: 'test_string',
+      coverImage: 'test_string',
+      grade: 0,
+      id: 0,
+      maxGrade: 0,
+      maxXp: 0,
+      openAt: 'test_string',
+      title: 'test_string',
+      shortSummary: 'test_string',
+      status: 'not_attempted',
+      story: null,
+      xp: 0,
+      gradingStatus: 'none'
+    }
+  ];
+  const action = updateAssessmentOverviews(overviews);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_ASSESSMENT_OVERVIEWS,
+    payload: overviews
+  });
+});
+
+test('updateAssessment generates correct action object', () => {
+  const assessment: IAssessment = {
+    category: 'Mission',
+    globalDeployment: undefined,
+    graderDeployment: undefined,
+    id: 1,
+    longSummary: 'long summary here',
+    missionPDF: 'www.google.com',
+    questions: [],
+    title: 'first assessment'
+  };
+
+  const action = updateAssessment(assessment);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_ASSESSMENT,
+    payload: assessment
+  });
+});
+
+test('updateGradingOverviews generates correct action object', () => {
+  const overviews: GradingOverview[] = [
+    {
+      assessmentId: 1,
+      assessmentName: 'test assessment',
+      assessmentCategory: 'Contest',
+      initialGrade: 0,
+      gradeAdjustment: 0,
+      currentGrade: 10,
+      maxGrade: 20,
+      initialXp: 0,
+      xpBonus: 100,
+      xpAdjustment: 50,
+      currentXp: 50,
+      maxXp: 500,
+      studentId: 100,
+      studentName: 'test student',
+      submissionId: 1,
+      groupName: 'group'
+    }
+  ];
+
+  const action = updateGradingOverviews(overviews);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_GRADING_OVERVIEWS,
+    payload: overviews
+  });
+});
+
+test('updateGrading generates correct action object', () => {
+  const submissionId = 3;
+  const grading: Grading = [
+    {
+      question: jest.genMockFromModule('../../components/academy/grading/gradingShape'),
+      student: {
+        name: 'test student',
+        id: 234
+      },
+      grade: {
+        comment: 'test comment',
+        grade: 10,
+        gradeAdjustment: 0,
+        xp: 100,
+        xpAdjustment: 0
+      }
+    }
+  ];
+
+  const action = updateGrading(submissionId, grading);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_GRADING,
+    payload: {
+      submissionId,
+      grading
+    }
+  });
+});

--- a/src/actions/__tests__/workspaces.ts
+++ b/src/actions/__tests__/workspaces.ts
@@ -1,0 +1,400 @@
+import { WorkspaceLocation, WorkspaceLocations } from '../../actions/workspaces';
+import { Library } from '../../components/assessment/assessmentShape';
+import { createDefaultWorkspace } from '../../reducers/states';
+import * as actionTypes from '../actionTypes';
+import {
+  beginClearContext,
+  browseReplHistoryDown,
+  browseReplHistoryUp,
+  changeActiveTab,
+  changeEditorHeight,
+  changeEditorWidth,
+  changePlaygroundExternal,
+  changeSideContentHeight,
+  chapterSelect,
+  clearReplInput,
+  clearReplOutput,
+  endClearContext,
+  ensureLibrariesLoaded,
+  evalEditor,
+  evalRepl,
+  evalTestcase,
+  highlightEditorLine,
+  invalidEditorSessionId,
+  playgroundExternalSelect,
+  resetWorkspace,
+  sendReplInputToOutput,
+  setEditorBreakpoint,
+  setEditorSessionId,
+  setWebsocketStatus,
+  toggleEditorAutorun,
+  updateCurrentAssessmentId,
+  updateCurrentSubmissionId,
+  updateEditorValue,
+  updateHasUnsavedChanges,
+  updateReplValue
+} from '../workspaces';
+
+const assessmentWorkspace: WorkspaceLocation = WorkspaceLocations.assessment;
+const gradingWorkspace: WorkspaceLocation = WorkspaceLocations.grading;
+const playgroundWorkspace: WorkspaceLocation = WorkspaceLocations.playground;
+
+test('browseReplHistoryDown generates correct action object', () => {
+  const action = browseReplHistoryDown(assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.BROWSE_REPL_HISTORY_DOWN,
+    payload: { workspaceLocation: assessmentWorkspace }
+  });
+});
+
+test('browseReplHistoryUp generates correct action object', () => {
+  const action = browseReplHistoryUp(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.BROWSE_REPL_HISTORY_UP,
+    payload: { workspaceLocation: gradingWorkspace }
+  });
+});
+
+test('changeActiveTab generates correct action object', () => {
+  const activeTab = 3;
+  const action = changeActiveTab(activeTab, playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_ACTIVE_TAB,
+    payload: {
+      activeTab,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('changePlaygroundExternal generates correct action object', () => {
+  const newExternal = 'new-external-test';
+  const action = changePlaygroundExternal(newExternal);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_PLAYGROUND_EXTERNAL,
+    payload: {
+      newExternal
+    }
+  });
+});
+
+test('changeEditorHeight generates correct action object', () => {
+  const height = 120;
+  const action = changeEditorHeight(height, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_EDITOR_HEIGHT,
+    payload: {
+      height,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('changeEditorWidth generates correct action object', () => {
+  const widthChange = '120';
+  const action = changeEditorWidth(widthChange, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_EDITOR_WIDTH,
+    payload: {
+      widthChange,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('changeSideContentHeight generates correct action object', () => {
+  const height = 100;
+  const action = changeSideContentHeight(height, gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CHANGE_SIDE_CONTENT_HEIGHT,
+    payload: {
+      height,
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('chapterSelect generates correct action object', () => {
+  const chapter = 3;
+  const action = chapterSelect(chapter, playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CHAPTER_SELECT,
+    payload: {
+      chapter,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('playgroundExternalSelect generates correct action object', () => {
+  const externalLibraryName = 'STREAMS';
+  const action = playgroundExternalSelect(externalLibraryName, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.PLAYGROUND_EXTERNAL_SELECT,
+    payload: {
+      externalLibraryName,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('toggleEditorAutorun generates correct action object', () => {
+  const action = toggleEditorAutorun(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.TOGGLE_EDITOR_AUTORUN,
+    payload: {
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('beginClearContext generates correct action object', () => {
+  const library: Library = {
+    chapter: 4,
+    external: {
+      name: 'STREAMS',
+      symbols: []
+    },
+    globals: []
+  };
+
+  const action = beginClearContext(library, playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.BEGIN_CLEAR_CONTEXT,
+    payload: {
+      library,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('clearReplInput generates correct action object', () => {
+  const action = clearReplInput(assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CLEAR_REPL_INPUT,
+    payload: {
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('clearReplOutput generates correct action object', () => {
+  const action = clearReplOutput(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.CLEAR_REPL_OUTPUT,
+    payload: {
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('endClearContext generates correct action object', () => {
+  const library: Library = {
+    chapter: 4,
+    external: {
+      name: 'STREAMS',
+      symbols: []
+    },
+    globals: []
+  };
+
+  const action = endClearContext(library, playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.END_CLEAR_CONTEXT,
+    payload: {
+      library,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('ensureLibrariesLoaded generates correct action object', () => {
+  const action = ensureLibrariesLoaded();
+  expect(action).toEqual({
+    type: actionTypes.ENSURE_LIBRARIES_LOADED
+  });
+});
+
+test('evalEditor generates correct action object', () => {
+  const action = evalEditor(assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_EDITOR,
+    payload: {
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('evalRepl generates correct action object', () => {
+  const action = evalRepl(gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_REPL,
+    payload: {
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('evalTestcase generates correct action object', () => {
+  const testcaseId = 3;
+  const action = evalTestcase(playgroundWorkspace, testcaseId);
+  expect(action).toEqual({
+    type: actionTypes.EVAL_TESTCASE,
+    payload: {
+      testcaseId,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('invalidEditorSessionId generates correct action object', () => {
+  const action = invalidEditorSessionId();
+  expect(action).toEqual({
+    type: actionTypes.INVALID_EDITOR_SESSION_ID
+  });
+});
+
+test('updateEditorValue generates correct action object', () => {
+  const newEditorValue = 'new_editor_value';
+  const action = updateEditorValue(newEditorValue, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_EDITOR_VALUE,
+    payload: {
+      newEditorValue,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('setEditorBreakpoint generates correct action object', () => {
+  const breakpoints = ['1', '2', '5'];
+  const action = setEditorBreakpoint(breakpoints, gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_EDITOR_BREAKPOINTS,
+    payload: {
+      breakpoints,
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('highlightEditorLine generates correct action object', () => {
+  const highlightedLines = [1, 2, 5];
+  const action = highlightEditorLine(highlightedLines, playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.HIGHLIGHT_LINE,
+    payload: {
+      highlightedLines,
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('updateReplValue generates correct action object', () => {
+  const newReplValue = 'new_repl_value';
+  const action = updateReplValue(newReplValue, assessmentWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_REPL_VALUE,
+    payload: {
+      newReplValue,
+      workspaceLocation: assessmentWorkspace
+    }
+  });
+});
+
+test('sendReplInputToOutput generates correct action object', () => {
+  const newOutput = 'new_output';
+  const action = sendReplInputToOutput(newOutput, gradingWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.SEND_REPL_INPUT_TO_OUTPUT,
+    payload: {
+      type: 'code',
+      value: newOutput,
+      workspaceLocation: gradingWorkspace
+    }
+  });
+});
+
+test('resetWorkspace generates correct default action object', () => {
+  const action = resetWorkspace(playgroundWorkspace);
+  expect(action).toEqual({
+    type: actionTypes.RESET_WORKSPACE,
+    payload: {
+      workspaceLocation: playgroundWorkspace
+    }
+  });
+});
+
+test('resetWorkspace generates correct action object with provided workspace', () => {
+  const workspaceOptions = createDefaultWorkspace(assessmentWorkspace);
+  const action = resetWorkspace(assessmentWorkspace, workspaceOptions);
+  expect(action).toEqual({
+    type: actionTypes.RESET_WORKSPACE,
+    payload: {
+      workspaceLocation: assessmentWorkspace,
+      workspaceOptions
+    }
+  });
+});
+
+test('setEditorSessionId generates correct action object', () => {
+  const editorSessionId = 'test-editor-session-id';
+  const action = setEditorSessionId(gradingWorkspace, editorSessionId);
+  expect(action).toEqual({
+    type: actionTypes.SET_EDITOR_SESSION_ID,
+    payload: {
+      workspaceLocation: gradingWorkspace,
+      editorSessionId
+    }
+  });
+});
+
+test('setWebsocketStatus generates correct action object', () => {
+  const websocketStatus = 0;
+  const action = setWebsocketStatus(playgroundWorkspace, websocketStatus);
+  expect(action).toEqual({
+    type: actionTypes.SET_WEBSOCKET_STATUS,
+    payload: {
+      workspaceLocation: playgroundWorkspace,
+      websocketStatus
+    }
+  });
+});
+
+test('updateCurrentAssessmentId generates correct action object', () => {
+  const assessmentId = 2;
+  const questionId = 4;
+  const action = updateCurrentAssessmentId(assessmentId, questionId);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_CURRENT_ASSESSMENT_ID,
+    payload: {
+      assessmentId,
+      questionId
+    }
+  });
+});
+
+test('updateCurrentSubmissionId generates correct action object', () => {
+  const submissionId = 3;
+  const questionId = 6;
+  const action = updateCurrentSubmissionId(submissionId, questionId);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_CURRENT_SUBMISSION_ID,
+    payload: {
+      submissionId,
+      questionId
+    }
+  });
+});
+
+test('updateHasUnsavedChanges generates correct action object', () => {
+  const hasUnsavedChanges = true;
+  const action = updateHasUnsavedChanges(assessmentWorkspace, hasUnsavedChanges);
+  expect(action).toEqual({
+    type: actionTypes.UPDATE_HAS_UNSAVED_CHANGES,
+    payload: {
+      workspaceLocation: assessmentWorkspace,
+      hasUnsavedChanges
+    }
+  });
+});


### PR DESCRIPTION
Part of #581 

Added tests for the files below:
- actions/commons.ts
- actions/game.ts
- actions/interpreter.ts
- actions/playground.ts
- actions/session.ts
- actions/workspaces.ts