### PR TITLE
Remove exports from list.js file

### DIFF
--- a/public/externalLibs/list.js
+++ b/public/externalLibs/list.js
@@ -348,5 +348,3 @@ function set_tail(xs, x) {
     throw new Error('set_tail(xs,x) expects a pair as argument xs, but encountered ' + xs)
   }
 }
-
-exports.set_tail = set_tail


### PR DESCRIPTION
Fixes #487 

Right now, when we run Source Academy and open the console, we will see this error:
<img width="1440" alt="Screenshot 2019-06-24 at 10 16 55 PM" src="https://user-images.githubusercontent.com/10579415/60026290-dfe06d00-96cd-11e9-801b-cae1f0ef37d0.png">

This is because of the `exports` in the `list.js` file. This PR removes it as it is not needed.