### PR TITLE
Bump Dependancies : redux-saga -> 1.0.0 , typescript -> 3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -379,6 +379,53 @@
       "resolved": "https://registry.npmjs.org/@pixi/filter-zoom-blur/-/filter-zoom-blur-2.6.0.tgz",
       "integrity": "sha1-Stlmowk3K3MeD8Rp2X3VG/edG9Y="
     },
+    "@redux-saga/core": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.0.3.tgz",
+      "integrity": "sha512-zf8h5N0oTzaNeSMxOWH9GJMB9IRSM8JubDsrZVsvVltXjzFFSR8DNt7tbPoRJUK0hFfQB1it+bL+dEMWpD7wXA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@redux-saga/deferred": "^1.0.1",
+        "@redux-saga/delay-p": "^1.0.1",
+        "@redux-saga/is": "^1.0.2",
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2",
+        "redux": ">=0.10 <5",
+        "typescript-tuple": "^2.1.0"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.0.1.tgz",
+      "integrity": "sha512-+gW5xQ93QXOOmRLAmX8x2Hx1HpbTG6CM6+HcdTSbJovh4uMWaGyeDECnqXSt8QqA/ja3s2nqYXLqXFKepIQ1hw=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.0.1.tgz",
+      "integrity": "sha512-0SnNDyDLUyB4NThtptAwiprNOnbCNhoed/Rp5JwS7SB+a/AdWynVgg/E6BmjsggLFNr07KW0bzn05tsPRBuU7Q==",
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.0.2.tgz",
+      "integrity": "sha512-WnaUOwYvPK2waWjzebT4uhL8zY76XNkzzpJ2EQJe8bN1tByvAjvT7MuJZTSshOhdHL5PsRO0MsH224XIXBJidQ==",
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.0.1.tgz",
+      "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg=="
+    },
+    "@redux-saga/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
+    },
     "@semantic-release/commit-analyzer": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
@@ -8969,8 +9016,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8988,13 +9034,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9006,18 +9050,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9119,8 +9160,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9130,7 +9170,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9143,7 +9182,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9156,7 +9194,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9245,8 +9282,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9256,7 +9292,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9332,8 +9367,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9363,7 +9397,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9381,7 +9414,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9406,13 +9438,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -19885,9 +19915,12 @@
       }
     },
     "redux-saga": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.15.6.tgz",
-      "integrity": "sha1-hjjcUi3mxsCklv6LK1RmKHrC3E0="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.0.0.tgz",
+      "integrity": "sha512-GvJWs/SzMvEQgeaw6sRMXnS2FghlvEGsHiEtTLpJqc/FHF3I5EE/B+Hq5lyHZ8LSoT2r/X/46uWvkdCnK9WgHA==",
+      "requires": {
+        "@redux-saga/core": "^1.0.0"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -22420,10 +22453,31 @@
       "integrity": "sha512-hvhuNqsai6LzXQ+Hl6vajC9bGd/kHHL1hJvI4GQ0Rs6Fax1cjbNEsuFGy/RbfLPhBAL10n6DECEHUa+Q9E+MxQ=="
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
     "redux-mock-store": "^1.5.1",
-    "redux-saga": "^0.15.6",
+    "redux-saga": "^1.0.0",
     "sharedb-ace": "^1.0.9",
     "showdown": "^1.9.0",
     "typesafe-actions": "^3.2.1",
@@ -116,6 +116,6 @@
     "prettier": "^1.12.0",
     "react-scripts-ts": "^2.16.0",
     "react-test-renderer": "^16.3.1",
-    "typescript": "^2.8.1"
+    "typescript": "^3.5.2"
   }
 }

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -3,8 +3,8 @@ import { InterruptedError } from 'js-slang/dist/interpreter-errors';
 import { manualToggleDebugger } from 'js-slang/dist/stdlib/inspector';
 import { compressToEncodedURIComponent } from 'lz-string';
 import * as qs from 'query-string';
-import { delay, SagaIterator } from 'redux-saga';
-import { call, put, race, select, take, takeEvery } from 'redux-saga/effects';
+import { SagaIterator } from 'redux-saga';
+import { call, delay, put, race, select, take, takeEvery } from 'redux-saga/effects';
 import * as actions from '../actions';
 import * as actionTypes from '../actions/actionTypes';
 import { WorkspaceLocation } from '../actions/workspaces';
@@ -267,14 +267,14 @@ function* workspaceSaga(): SagaIterator {
         if ((window as any).getReadyWebGLForCanvas !== undefined) {
           break;
         }
-        yield call(delay, 250);
+        yield delay(250);
       }
       return true;
     }
     /** Create a race condition between the js files being loaded and a timeout. */
     const { loadedScripts, timeout } = yield race({
       loadedScripts: call(helper),
-      timeout: call(delay, 4000)
+      timeout: delay(4000)
     });
     if (timeout !== undefined && loadedScripts === undefined) {
       yield call(showWarningMessage, 'Error loading libraries', 750);


### PR DESCRIPTION
Reason for upgrade: Need to upgrade typescript to upgrade redux-saga. Need to update redux-saga to use redux-saga-test-plan. 
- Changed call(delay, time) to delay(time) for redux-saga@1.0.0 bump.
- Import delay from 'redux-saga/effects' from 'redux-saga' for redux-saga@1.0.0 bump.