### PR TITLE
starting to use jsdoc for our libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+# emacs backup copies
+*~
+
 # dependencies
 /node_modules
 
@@ -22,3 +25,6 @@ terraform*
 .env.production.local
 
 npm-debug.log*
+
+# generated docs ignored
+/doc/jsdoc

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "update-ui-snapshots": "jest --updateSnapshot",
     "watch-css": "node-sass-chokidar src/ -o src/ --watch --recursive",
     "tslint": "tslint -p .",
-    "cors-proxy": "lcp --proxyUrl http://localhost:4000 --port 4001 --proxyPartial \"\""
+    "cors-proxy": "lcp --proxyUrl http://localhost:4000 --port 4001 --proxyPartial \"\"",
+    "jsdoc": "./scripts/jsdoc.sh"
   },
   "husky": {
     "hooks": {

--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+SOURCEFOLDERS="public/externalLibs/sound"
+JSDOC="node_modules/.bin/jsdoc"
+
+main() {
+    # make sure we are in the git root
+    if [[ $(git rev-parse --show-toplevel 2> /dev/null) = "$PWD" ]]; then
+        run
+    else
+        echo "Please run this command from the git root directory."
+        false  # exit 1
+    fi
+}
+
+run() {
+
+    ${JSDOC} -r -d doc/jsdoc ${SOURCEFOLDERS} 
+
+}
+
+main $1


### PR DESCRIPTION
How to use:

npm run jsdoc

The files are placed in a folder doc/jsdoc

The script jsdoc.sh controls which files are examined for jsdoc annotations. Currently, we use the sound library.