### PR TITLE
Frontend Testing : Add tests for localStorage and createStore

### DIFF
--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -1,6 +1,6 @@
 import { compressToUTF16 } from 'lz-string';
 import { createStore } from './createStore';
-import { ISavedState, loadStoredState } from './localStorage';
+import { ISavedState } from './localStorage';
 import { defaultState, IState } from './reducers/states';
 import { history } from './utils/history';
 
@@ -34,14 +34,13 @@ const mockChangedState: IState = {
   }
 };
 
-describe('CREATESTORE', () => {
+describe('createStore() function', () => {
   test('has defaultState when initialised', () => {
-    expect(loadStoredState()).toEqual(undefined);
+    localStorage.removeItem('storedState');
     expect(createStore(history).getState()).toEqual({
       ...defaultState,
       router: { location: null }
     });
-    expect(loadStoredState()).toEqual(undefined);
   });
   test('has correct getState() when called with storedState', () => {
     localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockChangedStoredState)));

--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -34,8 +34,8 @@ const mockChangedState: IState = {
   }
 };
 
-describe('createStore', () => {
-  test('createStore initialised states are correct', () => {
+describe('CREATESTORE', () => {
+  test('has defaultState when initialised', () => {
     expect(loadStoredState()).toEqual(undefined);
     expect(createStore(history).getState()).toEqual({
       ...defaultState,
@@ -43,7 +43,7 @@ describe('createStore', () => {
     });
     expect(loadStoredState()).toEqual(undefined);
   });
-  test('when called with stored states', () => {
+  test('has correct getState() when called with storedState', () => {
     localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockChangedStoredState)));
     expect(createStore(history).getState()).toEqual({
       ...mockChangedState,

--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -1,0 +1,54 @@
+import { compressToUTF16 } from 'lz-string';
+import { createStore } from './createStore';
+import { ISavedState, loadStoredState } from './localStorage';
+import { defaultState, IState } from './reducers/states';
+import { history } from './utils/history';
+
+const mockChangedStoredState: ISavedState = {
+  session: {
+    accessToken: 'yep',
+    refreshToken: 'refresherOrb',
+    role: undefined,
+    name: 'Jeff'
+  },
+  playgroundEditorValue: 'Nihao everybody',
+  playgroundIsEditorAutorun: true
+};
+
+const mockChangedState: IState = {
+  ...defaultState,
+  session: {
+    ...defaultState.session,
+    accessToken: 'yep',
+    refreshToken: 'refresherOrb',
+    role: undefined,
+    name: 'Jeff'
+  },
+  workspaces: {
+    ...defaultState.workspaces,
+    playground: {
+      ...defaultState.workspaces.playground,
+      editorValue: 'Nihao everybody',
+      isEditorAutorun: true
+    }
+  }
+};
+
+describe('createStore', () => {
+  test('createStore initialised states are correct', () => {
+    expect(loadStoredState()).toEqual(undefined);
+    expect(createStore(history).getState()).toEqual({
+      ...defaultState,
+      router: { location: null }
+    });
+    expect(loadStoredState()).toEqual(undefined);
+  });
+  test('when called with stored states', () => {
+    localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockChangedStoredState)));
+    expect(createStore(history).getState()).toEqual({
+      ...mockChangedState,
+      router: { location: null }
+    });
+    localStorage.removeItem('storedState');
+  });
+});

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -34,7 +34,7 @@ export function createStore(history: History): Store<IState> {
   });
   const enchancers = composeEnhancers(applyMiddleware(...middleware));
   const loadedStore = loadStoredState();
-  let initialStore: IState;
+  let initialStore: IState = defaultState;
   if (loadedStore) {
     initialStore = {
       ...defaultState,
@@ -55,8 +55,6 @@ export function createStore(history: History): Store<IState> {
         }
       }
     };
-  } else {
-    initialStore = defaultState;
   }
   const createdStore = _createStore<IState>(rootReducer, initialStore, enchancers);
 

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -19,7 +19,7 @@ import { history as appHistory } from './utils/history';
 
 declare var __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: () => StoreEnhancer<IState>;
 
-function createStore(history: History): Store<IState> {
+export function createStore(history: History): Store<IState> {
   let composeEnhancers: any = compose;
   const sagaMiddleware = createSagaMiddleware();
   const middleware = [sagaMiddleware, routerMiddleware(history)];

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -1,0 +1,36 @@
+import { compressToUTF16 } from 'lz-string';
+import { ISavedState, loadStoredState, saveState } from './localStorage';
+import { defaultState } from './reducers/states';
+
+const mockShortDefaultState: ISavedState = {
+  session: {
+    accessToken: defaultState.session.accessToken,
+    refreshToken: defaultState.session.refreshToken,
+    role: defaultState.session.role,
+    name: defaultState.session.name
+  },
+  playgroundEditorValue: defaultState.workspaces.playground.editorValue,
+  playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun
+};
+
+describe('loadStoredState', () => {
+  test('Runs normally', () => {
+    localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockShortDefaultState)));
+    expect(loadStoredState()).toEqual(mockShortDefaultState);
+    localStorage.removeItem('storedState');
+  });
+  test('Returns undefined when there is no stored state', () => {
+    localStorage.removeItem('storedState');
+    expect(loadStoredState()).toBe(undefined);
+  });
+});
+
+describe('saveState', () => {
+  test('Run normally', () => {
+    localStorage.removeItem('storedState');
+    saveState(defaultState);
+    expect(localStorage.getItem('storedState')).toBe(
+      compressToUTF16(JSON.stringify(mockShortDefaultState))
+    );
+  });
+});

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -26,11 +26,11 @@ describe('loadStoredState', () => {
 });
 
 describe('saveState', () => {
-  test('Run normally', () => {
-    localStorage.removeItem('storedState');
+  test('Runs normally', () => {
     saveState(defaultState);
     expect(localStorage.getItem('storedState')).toBe(
       compressToUTF16(JSON.stringify(mockShortDefaultState))
     );
+    localStorage.removeItem('storedState');
   });
 });

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -13,7 +13,7 @@ const mockShortDefaultState: ISavedState = {
   playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun
 };
 
-describe('LOADSTOREDSTATE', () => {
+describe('loadStoredState() function', () => {
   test('runs normally', () => {
     localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockShortDefaultState)));
     expect(loadStoredState()).toEqual(mockShortDefaultState);
@@ -25,7 +25,7 @@ describe('LOADSTOREDSTATE', () => {
   });
 });
 
-describe('SAVESTATE', () => {
+describe('saveState() function', () => {
   test('Runs normally', () => {
     saveState(defaultState);
     expect(localStorage.getItem('storedState')).toBe(

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -13,19 +13,19 @@ const mockShortDefaultState: ISavedState = {
   playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun
 };
 
-describe('loadStoredState', () => {
-  test('Runs normally', () => {
+describe('LOADSTOREDSTATE', () => {
+  test('runs normally', () => {
     localStorage.setItem('storedState', compressToUTF16(JSON.stringify(mockShortDefaultState)));
     expect(loadStoredState()).toEqual(mockShortDefaultState);
     localStorage.removeItem('storedState');
   });
-  test('Returns undefined when there is no stored state', () => {
+  test('returns undefined when there is no stored state', () => {
     localStorage.removeItem('storedState');
     expect(loadStoredState()).toBe(undefined);
   });
 });
 
-describe('saveState', () => {
+describe('SAVESTATE', () => {
   test('Runs normally', () => {
     saveState(defaultState);
     expect(localStorage.getItem('storedState')).toBe(

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,6 +1,7 @@
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 
 import { ISessionState, IState } from './reducers/states';
+import { showWarningMessage } from './utils/notification';
 
 export type ISavedState = {
   session: Partial<ISessionState>;
@@ -17,7 +18,7 @@ export const loadStoredState = (): ISavedState | undefined => {
       return JSON.parse(decompressFromUTF16(serializedState)) as ISavedState;
     }
   } catch (err) {
-    // Issue #143
+    showWarningMessage('Error loading from local storage');
     return undefined;
   }
 };
@@ -37,6 +38,6 @@ export const saveState = (state: IState) => {
     const serialized = compressToUTF16(JSON.stringify(stateToBeSaved));
     localStorage.setItem('storedState', serialized);
   } catch (err) {
-    // https://github.com/source-academy/cadet-frontend/issues/143
+    showWarningMessage('Error saving to local storage');
   }
 };

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -12,11 +12,10 @@ export type ISavedState = {
 export const loadStoredState = (): ISavedState | undefined => {
   try {
     const serializedState = localStorage.getItem('storedState');
-    if (serializedState === null) {
+    if (!serializedState) {
       return undefined;
-    } else {
-      return JSON.parse(decompressFromUTF16(serializedState)) as ISavedState;
     }
+    return JSON.parse(decompressFromUTF16(serializedState)) as ISavedState;
   } catch (err) {
     showWarningMessage('Error loading from local storage');
     return undefined;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,11 +2,3 @@ import { configure } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
-
-// const localStorageMock = {
-//   getItem: jest.fn(),
-//   setItem: jest.fn(),
-//   removeItem: jest.fn(),
-//   clear: jest.fn()
-// }
-// global['localStorage'] = localStorageMock


### PR DESCRIPTION
Part of #581 

- Delete commented out lines from setupTests.ts for simplicity.
- Added tests for localStorage.ts and createStore.ts
- Added warning messages for error in loading and saving to localStorage.