### PR TITLE
Contributors page new

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -9,6 +9,7 @@ import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import { Role, sourceChapters } from '../reducers/states';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
+import Contributors from './contributors';
 import NavigationBar from './NavigationBar';
 import NotFound from './NotFound';
 
@@ -54,6 +55,7 @@ class Application extends React.Component<IApplicationProps, {}> {
             <Route path={`/mission-control/${assessmentRegExp}`} render={toIncubator} />
             <Route path="/playground" component={Playground} />
             <Route path="/login" render={toLogin(this.props)} />
+            <Route path="/contributors" component={Contributors} />
             <Route exact={true} path="/" render={this.redirectToAcademy} />
             <Route component={NotFound} />
           </Switch>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -52,6 +52,15 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
         <Icon icon={IconNames.CHAT} />
         <div className="navbar-button-text hidden-xs">Forum</div>
       </NavLink>
+
+      <NavLink
+        activeClassName="pt-active"
+        className="NavigationBar__link pt-button pt-minimal"
+        to="/playground"
+      >
+        <Icon icon={IconNames.CODE} />
+        <div className="navbar-button-text hidden-xs">Playground</div>
+      </NavLink>
     </NavbarGroup>
 
     <NavbarGroup align={Alignment.RIGHT}>
@@ -67,10 +76,10 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
       <NavLink
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
-        to="/playground"
+        to="/contributors"
       >
-        <Icon icon={IconNames.CODE} />
-        <div className="navbar-button-text hidden-xs">Playground</div>
+        <Icon icon={IconNames.HEART} />
+        <div className="navbar-button-text hidden-xs">Contributors</div>
       </NavLink>
 
       <div className="visible-xs">

--- a/src/components/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Application.tsx.snap
@@ -9,6 +9,7 @@ exports[`Application renders correctly 1`] = `
       <Route path=\\"/mission-control/:assessmentId(-?\\\\\\\\d+)?/:questionId(\\\\\\\\d+)?\\" render={[Function: toIncubator]} />
       <Route path=\\"/playground\\" component={[Function: C]} />
       <Route path=\\"/login\\" render={[Function]} />
+      <Route path=\\"/contributors\\" component={[function]} />
       <Route exact={true} path=\\"/\\" render={[Function]} />
       <Route component={[Function: NotFound]} />
     </Switch>

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -21,6 +21,12 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
         Forum
       </div>
     </NavLink>
+    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/playground\\" aria-current=\\"page\\">
+      <Blueprint2.Icon icon=\\"code\\" />
+      <div className=\\"navbar-button-text hidden-xs\\">
+        Playground
+      </div>
+    </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/mission-control\\" aria-current=\\"page\\">
@@ -29,10 +35,10 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
         Mission-Control
       </div>
     </NavLink>
-    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/playground\\" aria-current=\\"page\\">
-      <Blueprint2.Icon icon=\\"code\\" />
+    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/contributors\\" aria-current=\\"page\\">
+      <Blueprint2.Icon icon=\\"heart\\" />
       <div className=\\"navbar-button-text hidden-xs\\">
-        Playground
+        Contributors
       </div>
     </NavLink>
     <div className=\\"visible-xs\\">
@@ -67,6 +73,12 @@ exports[`NavigationBar renders correctly with username 1`] = `
         Forum
       </div>
     </NavLink>
+    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/playground\\" aria-current=\\"page\\">
+      <Blueprint2.Icon icon=\\"code\\" />
+      <div className=\\"navbar-button-text hidden-xs\\">
+        Playground
+      </div>
+    </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
     <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/mission-control\\" aria-current=\\"page\\">
@@ -75,10 +87,10 @@ exports[`NavigationBar renders correctly with username 1`] = `
         Mission-Control
       </div>
     </NavLink>
-    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/playground\\" aria-current=\\"page\\">
-      <Blueprint2.Icon icon=\\"code\\" />
+    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/contributors\\" aria-current=\\"page\\">
+      <Blueprint2.Icon icon=\\"heart\\" />
       <div className=\\"navbar-button-text hidden-xs\\">
-        Playground
+        Contributors
       </div>
     </NavLink>
     <div className=\\"visible-xs\\">

--- a/src/components/contributors/ContributorsDetails.tsx
+++ b/src/components/contributors/ContributorsDetails.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+const dot = <span className="dot">&bull;</span>;
+
+class ContributorsDetails extends React.Component {
+  public render() {
+    return (
+      <div className="outsideDetails">
+        <div className="contributorsDetails">
+          <h3>The people behind Source Academy</h3>
+          <p>
+            The <i>Source Academy</i> is designed by and for students of the National University of
+            Singapore. Students who completed the CS1101S module come back to coach their juniors as
+            "Avengers" or to further develop and improve the Academy. This page includes all
+            developers who contributed to the Source Academy <i>Cadet</i> (2018), a re-development
+            of its precursors, the original Source Academy (2016) and Source Academy 2 (2017).
+          </p>
+          <div className="leadership">
+            <h5>
+              <strong>
+                <u>2019 Leadership</u>
+              </strong>
+            </h5>
+            <p>
+              Liow Jia Chen
+              <br />
+              <strong>(Backend)</strong>
+            </p>
+            {dot}
+            <p>
+              Ge Shuming
+              <br />
+              <strong>(Frontend)</strong>
+            </p>
+            {dot}
+            <p>
+              Rahul Rajesh
+              <br />
+              <strong>(DevOps)</strong>
+            </p>
+            {dot}
+            <p>
+              Daryl Tan
+              <br />
+              <strong>(Source)</strong>
+            </p>
+            {dot}
+            <p>
+              Martin Henz
+              <br />
+              <strong>(Coordination)</strong>
+            </p>
+          </div>
+          <div className="hallOfFame">
+            <h5>
+              <strong>
+                <u>Hall of Fame</u>
+              </strong>
+            </h5>
+            <p>
+              <strong>Cadet architect</strong>
+            </p>
+            <p>Evan Sebastian</p>
+            <p>
+              <strong>Cadet core team</strong>
+            </p>
+            <p>
+              Julius Putra Tanu Setiaji {dot} Lee Ning Yuan {dot} Vignesh Shankar {dot} Thomas Tan{' '}
+              {dot} Chen Shaowei
+            </p>
+            <p>
+              <strong>Graphic design</strong>
+            </p>
+            <p>
+              Ng Tse Pei {dot} Joey Yeo {dot} Tan Yu Wei
+            </p>
+          </div>
+          <div className="contributors">
+            <h5>
+              <strong>
+                <u>All Contributors</u>
+              </strong>
+            </h5>
+            <p>
+              Here goes the full list of contributors to the Source Academy with their pull requests
+              in the repos: cadet, cadet-frontend, grader, js-slang, sharedb-ace-backend
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ContributorsDetails;

--- a/src/components/contributors/ContributorsList.tsx
+++ b/src/components/contributors/ContributorsList.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import { Contributor, ContributorsState, Repo } from './ContributorsTypes';
+import { fetchContributors, fetchRepos } from './GithubApi';
+
+class ContributorsList extends React.Component<{}, ContributorsState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      repos: [],
+      contributors: []
+    };
+  }
+
+  public componentDidMount() {
+    fetchRepos()
+      .then((repos: Repo[]) => {
+        this.setState({
+          repos
+        });
+        return repos;
+      })
+      .then((repos: Repo[]) => {
+        fetchContributors(repos).then((contributors: Contributor[][]) => {
+          this.setState({
+            contributors
+          });
+        });
+      });
+  }
+
+  public render() {
+    const { contributors, repos } = this.state;
+    const contributorList = contributors.length ? (
+      contributors.map((array: Contributor[], index: number) => {
+        const repo = repos[index];
+        const arrayMapped = array.map((contributor: Contributor) => {
+          return (
+            <div key={contributor.key}>
+              <img src={contributor.photo} alt="Image" />
+              <p>
+                <a href={contributor.githubPage} target="_blank">
+                  {contributor.githubName}
+                </a>
+              </p>
+              <p>Commits: {contributor.commits}</p>
+            </div>
+          );
+        });
+        return (
+          <div key={repo.key} className="containerPermalink">
+            <div className="repoDetailsPermalink">
+              <h3>{repo.name}</h3>
+              <h5>{repo.description}</h5>
+            </div>
+            <div className="inPermalink">{arrayMapped}</div>
+          </div>
+        );
+      })
+    ) : (
+      <h2>Loading...</h2>
+    );
+    return <div>{contributorList}</div>;
+  }
+}
+
+export default ContributorsList;

--- a/src/components/contributors/ContributorsTypes.ts
+++ b/src/components/contributors/ContributorsTypes.ts
@@ -82,7 +82,7 @@ export type ReposInApi = {
   has_wiki: boolean;
   has_pages: boolean;
   forks_count: number;
-  mirror_url: null; 
+  mirror_url: null;
   archived: boolean;
   disabled: boolean;
   open_issues_count: number;

--- a/src/components/contributors/ContributorsTypes.ts
+++ b/src/components/contributors/ContributorsTypes.ts
@@ -1,0 +1,154 @@
+export type ReposInApi = {
+  id: number;
+  node_id: string;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: {
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    site_admin: boolean;
+  };
+  html_url: string;
+  description: string;
+  fork: boolean;
+  url: string;
+  forks_url: string;
+  keys_url: string;
+  collaborators_url: string;
+  teams_url: string;
+  hooks_url: string;
+  issue_events_url: string;
+  events_url: string;
+  assignees_url: string;
+  branches_url: string;
+  tags_url: string;
+  blobs_url: string;
+  git_tags_url: string;
+  git_refs_url: string;
+  trees_url: string;
+  statuses_url: string;
+  languages_url: string;
+  stargazers_url: string;
+  contributors_url: string;
+  subscribers_url: string;
+  subscription_url: string;
+  commits_url: string;
+  git_commits_url: string;
+  comments_url: string;
+  issue_comment_url: string;
+  contents_url: string;
+  compare_url: string;
+  merges_url: string;
+  archive_url: string;
+  downloads_url: string;
+  issues_url: string;
+  pulls_url: string;
+  milestones_url: string;
+  notifications_url: string;
+  labels_url: string;
+  releases_url: string;
+  deployments_url: string;
+  created_at: string;
+  updated_at: string;
+  pushed_at: string;
+  git_url: string;
+  ssh_url: string;
+  clone_url: string;
+  svn_url: string;
+  homepage: string;
+  size: number;
+  stargazers_count: number;
+  watchers_count: number;
+  language: string;
+  has_issues: boolean;
+  has_projects: boolean;
+  has_downloads: boolean;
+  has_wiki: boolean;
+  has_pages: boolean;
+  forks_count: number;
+  mirror_url: null; 
+  archived: boolean;
+  disabled: boolean;
+  open_issues_count: number;
+  license: {
+    key: string;
+    name: string;
+    spdx_id: string;
+    url: string;
+    node_id: string;
+  };
+  forks: number;
+  open_issues: number;
+  watchers: number;
+  default_branch: string;
+  permissions: {
+    admin: boolean;
+    push: boolean;
+    pull: boolean;
+  };
+};
+
+export type ContributorsInApi = {
+  login: string;
+  id: number;
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: string;
+  site_admin: boolean;
+  contributions: number;
+};
+
+export type Repo = {
+  key: number;
+  name: string;
+  description: string;
+  link: string;
+};
+
+export type Contributor = {
+  key: number;
+  photo: string;
+  githubPage: string;
+  githubName: string;
+  commits: number;
+};
+
+export type ContributorsProps = {
+  repos: Repo[];
+  contributors: Contributor[][];
+  handleFetchRepos: () => Repo[];
+  handleFetchContributors: (repos: Repo[]) => Contributor[][];
+};
+
+export type ContributorsState = {
+  repos: Repo[];
+  contributors: Contributor[][];
+};

--- a/src/components/contributors/GithubApi.ts
+++ b/src/components/contributors/GithubApi.ts
@@ -1,7 +1,7 @@
 import { ContributorsInApi, Repo, ReposInApi } from './ContributorsTypes';
 
 const apiRepoDetails: string = 'https://api.github.com/orgs/source-academy/repos';
-const ignoreRepos: string[] = ['sicp', 'assessments', 'tools', 'source-academy2'];
+const ignoreRepos: string[] = ['assessments', 'tools', 'source-academy2'];
 const ignoreContributors: string[] = ['dependabot[bot]', 'dependabot-preview[bot]'];
 
 export const fetchRepos = async () => {

--- a/src/components/contributors/GithubApi.ts
+++ b/src/components/contributors/GithubApi.ts
@@ -1,0 +1,54 @@
+import { ContributorsInApi, Repo, ReposInApi } from './ContributorsTypes';
+
+const apiRepoDetails: string = 'https://api.github.com/orgs/source-academy/repos';
+const ignoreRepos: string[] = ['sicp', 'assessments', 'tools', 'source-academy2'];
+const ignoreContributors: string[] = ['dependabot[bot]', 'dependabot-preview[bot]'];
+
+export const fetchRepos = async () => {
+  const response = await fetch(apiRepoDetails);
+  const results = await response.json();
+  const repos = await results
+    .filter((repo: ReposInApi) => {
+      return !ignoreRepos.includes(repo.name);
+    })
+    .map((repo: ReposInApi) => {
+      return {
+        key: repo.id,
+        name: repo.name,
+        description: repo.description,
+        link: repo.contributors_url
+      };
+    });
+  return repos;
+};
+
+export const fetchContributors = async (endpoints: Repo[]) => {
+  const responses = await Promise.all(
+    endpoints.map((endpoint: Repo) => {
+      return fetch(endpoint.link);
+    })
+  );
+  const results = await Promise.all(
+    responses.map((res: any) => {
+      return res.json();
+    })
+  );
+  const contributorsByRepo = await Promise.all(
+    results.map((contributors: ContributorsInApi[]) => {
+      return contributors
+        .filter((contributor: ContributorsInApi) => {
+          return !ignoreContributors.includes(contributor.login);
+        })
+        .map((contributor: ContributorsInApi) => {
+          return {
+            key: contributor.id,
+            photo: contributor.avatar_url,
+            githubPage: contributor.html_url,
+            githubName: contributor.login,
+            commits: contributor.contributions
+          };
+        });
+    })
+  );
+  return contributorsByRepo;
+};

--- a/src/components/contributors/index.tsx
+++ b/src/components/contributors/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import ContributorsDetails from './ContributorsDetails';
+import ContributorsList from './ContributorsList';
+
+export class Contributors extends React.Component {
+  public render() {
+    return (
+      <div>
+        <ContributorsDetails />
+        <ContributorsList />
+      </div>
+    );
+  }
+}
+
+export default Contributors;

--- a/src/components/dropdown/About.tsx
+++ b/src/components/dropdown/About.tsx
@@ -19,31 +19,25 @@ const About: React.SFC<DialogProps> = props => (
     title="About"
   >
     <div className={Classes.DIALOG_BODY}>
-    <div className="abt">
+      <div className="abt">
         <p>
-          The <i>Source Academy</i> is a computer-mediated learning environment for studying the structure and 
-          interpretation of computer programs. Students write and run their programs in their web browser, 
-          using sublanguages of JavaScript called{' '}
-          <a href={LINKS.SOURCE_DOCS}>
-            Source §1, Source §2, Source §3 and Source §4
-          </a>,
-          designed for the first four chapters of the textbook{' '}
+          The <i>Source Academy</i> is a computer-mediated learning environment for studying the
+          structure and interpretation of computer programs. Students write and run their programs
+          in their web browser, using sublanguages of JavaScript called{' '}
+          <a href={LINKS.SOURCE_DOCS}>Source §1, Source §2, Source §3 and Source §4</a>, designed
+          for the first four chapters of the textbook{' '}
           <a href={LINKS.TEXTBOOK}>
             Structure and Interpretation of Computer Programs, JavaScript Adaptation
-          </a>.
+          </a>
+          .
         </p>
         <p>
           The Source Academy is available under the MIT License at our GitHub organisation,{' '}
-          <a href={LINKS.GITHUB_ORG}>
-            Source Academy
-          </a>. 
-          The National University of Singapore uses the Source Academy for teaching Programming Methodology
-          to freshmen Computer Science students in the course{' '}
-          <a href={LINKS.MODULE_DETAILS}>
-            CS1101S
-          </a>.
+          <a href={LINKS.GITHUB_ORG}>Source Academy</a>. The National University of Singapore uses
+          the Source Academy for teaching Programming Methodology to freshmen Computer Science
+          students in the course <a href={LINKS.MODULE_DETAILS}>CS1101S</a>.
         </p>
-      </div> 
+      </div>
     </div>
   </Dialog>
 );

--- a/src/components/dropdown/About.tsx
+++ b/src/components/dropdown/About.tsx
@@ -1,4 +1,4 @@
-import { Classes, Dialog, Tab, Tabs } from '@blueprintjs/core';
+import { Classes, Dialog } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
@@ -19,69 +19,33 @@ const About: React.SFC<DialogProps> = props => (
     title="About"
   >
     <div className={Classes.DIALOG_BODY}>
-      <Tabs id="about">
-        <Tab id="abt" panel={panelAbout}>
-          About
-        </Tab>
-        <Tab id="devs" panel={panelDevs()}>
-          Developers
-        </Tab>
-      </Tabs>
+    <div className="abt">
+        <p>
+          The <i>Source Academy</i> is a computer-mediated learning environment for studying the structure and 
+          interpretation of computer programs. Students write and run their programs in their web browser, 
+          using sublanguages of JavaScript called{' '}
+          <a href={LINKS.SOURCE_DOCS}>
+            Source §1, Source §2, Source §3 and Source §4
+          </a>,
+          designed for the first four chapters of the textbook{' '}
+          <a href={LINKS.TEXTBOOK}>
+            Structure and Interpretation of Computer Programs, JavaScript Adaptation
+          </a>.
+        </p>
+        <p>
+          The Source Academy is available under the MIT License at our GitHub organisation,{' '}
+          <a href={LINKS.GITHUB_ORG}>
+            Source Academy
+          </a>. 
+          The National University of Singapore uses the Source Academy for teaching Programming Methodology
+          to freshmen Computer Science students in the course{' '}
+          <a href={LINKS.MODULE_DETAILS}>
+            CS1101S
+          </a>.
+        </p>
+      </div> 
     </div>
   </Dialog>
-);
-
-const panelAbout = (
-  <>
-    <p>
-      The <i>Source Academy</i> is an experimental environment for learning programming in the
-      CS1101S module at the National University of Singapore.
-    </p>
-    <p>
-      This iteration of Source Academy, code-named <i>Cadet</i>, is available under the MIT License.
-      You may find the source code for Cadet at our GitHub organisation,{' '}
-      <a href={LINKS.GITHUB_ORG}>Source Academy</a>.
-    </p>
-  </>
-);
-
-const dot = <span className="dot">&bull;</span>;
-
-const panelDevs = () => (
-  <div className="devs">
-    <p>
-      <strong>Project Managers</strong>
-    </p>
-    <p>Martin Henz {dot} Evan Sebastian</p>
-    <p>
-      <strong>Frontend Team</strong>
-    </p>
-    {Math.round(Math.random()) === 0 ? (
-      <p>
-        Lee Ning Yuan {dot} Vignesh Shankar {dot} Rahul Rajesh
-      </p>
-    ) : (
-      <p>
-        Vignesh Shankar {dot} Lee Ning Yuan {dot} Rahul Rajesh
-      </p>
-    )}
-    <p>
-      <strong>Backend Team</strong>
-    </p>
-    <p>
-      Julius Putra Tanu Setiaji {dot} Chen Shaowei {dot} Liow Jia Chen
-    </p>
-    <p>
-      <strong>Source Team</strong>
-    </p>
-    <p>Tan Chee Kun, Thomas</p>
-    <p>
-      <strong>Artistic Team</strong>
-    </p>
-    <p>
-      Ng Tse Pei {dot} Joey Yeo {dot} Tan Yu Wei
-    </p>
-  </div>
 );
 
 export default About;

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import Profile from '../../containers/ProfileContainer';
 import { controlButton } from '../commons/controlButton';
 import About from './About';
-// import Contributors from '../Contributors'
 import Help from './Help';
 
 type DropdownProps = {
@@ -63,7 +62,6 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
       <Menu>
         {profile}
         <MenuItem icon={IconNames.HELP} onClick={this.toggleAboutOpen} text="About" />
-        <MenuItem icon={IconNames.HELP} onClick={this.toggleAboutOpen} text="Contributors" />
         <MenuItem icon={IconNames.ERROR} onClick={this.toggleHelpOpen} text="Help" />
         {logout}
       </Menu>

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import Profile from '../../containers/ProfileContainer';
 import { controlButton } from '../commons/controlButton';
 import About from './About';
+// import Contributors from '../Contributors'
 import Help from './Help';
 
 type DropdownProps = {
@@ -62,6 +63,7 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
       <Menu>
         {profile}
         <MenuItem icon={IconNames.HELP} onClick={this.toggleAboutOpen} text="About" />
+        <MenuItem icon={IconNames.HELP} onClick={this.toggleAboutOpen} text="Contributors" />
         <MenuItem icon={IconNames.ERROR} onClick={this.toggleHelpOpen} text="Help" />
         {logout}
       </Menu>

--- a/src/styles/_contributors.scss
+++ b/src/styles/_contributors.scss
@@ -1,0 +1,138 @@
+// Mixins
+
+@mixin mQ($arg) {
+  @media screen and (max-width: $arg) {
+    @content;
+  }
+}
+
+// Styling components of the ContributorsDetails
+
+.outsideDetails {
+  background-color: $cadet-color-1;
+  text-align: center;
+
+  .contributorsDetails {
+    background-color: $cadet-color-4;
+    border-radius: 10px;
+    width: 96%;
+    height: 95%;
+    display: inline-block;
+    margin-top: 2%;
+    padding: 1% 1% 1% 1%;
+
+    h3 {
+      text-transform: capitalize;
+      font-weight: bold;
+      font-style: oblique;
+    }
+
+    p {
+        text-align: justify;
+        text-align-last: center;
+        margin-right: 0.5%;
+        margin-left: 0.5%;
+    }
+
+    span.dot {
+      padding: 0 0.2rem 0 0.2rem;
+    }
+
+    div.leadership {
+      margin-top: 10px;
+      text-align: center;
+
+      p {
+        vertical-align: top;
+        display: inline-block;
+        width: 120px;
+      }
+    }
+
+    div.hallOfFame {
+      margin-top: 10px;
+      text-align: center;
+    }
+
+    div.contributors {
+      margin-top: 10px;
+      text-align: center;
+
+      h5 {
+        text-align: center;
+      }
+    }
+  }
+}
+
+// Styling components of the ContributorsList
+
+.containerPermalink {
+  background-color: $cadet-color-1;
+  padding-bottom: 1%;
+}
+
+div.inPermalink {
+  margin-inline-start: 2%;
+  margin-inline-end: 2%;
+  text-align: justify;
+  background-color: $cadet-color-3;
+  border-radius: 10px;
+
+  div {
+    text-align: center;
+    vertical-align: top;
+    display: inline-block;
+    width: (100% / 6);
+    height: (100% / 6);
+    margin-top: 1%;
+    margin-bottom: 0.5%;
+    @include mQ(800px) {
+      width: 25%;
+      height: 25%;
+    }
+  }
+
+  img {
+    width: 90%;
+    height: 90%;
+  }
+
+  p {
+    margin-bottom: 0.2rem;
+    color: $cadet-color-5;
+  }
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+    color: $cadet-color-4;
+    &:hover {
+      color: $cadet-color-5;
+    }
+  }
+}
+
+div.repoDetailsPermalink {
+  text-align: center;
+
+  h3 {
+    line-height: 175%;
+    margin-right: 2%;
+    margin-left: 2%;
+    margin-bottom: 0%;
+    color: $cadet-color-4;
+  }
+
+  h3::first-letter {
+    text-transform: uppercase;
+  }
+
+  h5 {
+    margin-right: 2%;
+    margin-left: 2%;
+    margin-bottom: 1%;
+    font-style: italic;
+    color: $cadet-color-5;
+  }
+}

--- a/src/styles/_contributors.scss
+++ b/src/styles/_contributors.scss
@@ -28,10 +28,10 @@
     }
 
     p {
-        text-align: justify;
-        text-align-last: center;
-        margin-right: 0.5%;
-        margin-left: 0.5%;
+      text-align: justify;
+      text-align-last: center;
+      margin-right: 0.5%;
+      margin-left: 0.5%;
     }
 
     span.dot {

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -5,22 +5,9 @@ div.pt-dialog.about {
     margin-top: 10px;
   }
 
-  div#pt-tab-panel_about_abt {
+  div.abt {
     margin-top: 10px;
     text-align: justify;
-  }
-
-  div#pt-tab-panel_about_devs {
-    margin-top: 10px;
-    text-align: center;
-  }
-
-  span.dot {
-    padding: 0 0.2rem 0 0.2rem;
-  }
-
-  div.pt-tab {
-    outline: 0;
   }
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -10,6 +10,7 @@
 @import 'academy';
 @import 'application';
 @import 'commons';
+@import 'contributors';
 @import 'dropdown';
 @import 'game';
 @import 'login';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export enum LINKS {
   GITHUB_ISSUES = 'https://github.com/source-academy/cadet-frontend/issues',
   GITHUB_ORG = 'https://github.com/source-academy',
 
+  MODULE_DETAILS = 'https://www.comp.nus.edu.sg/~cs1101s',
   LUMINUS = 'https://luminus.nus.edu.sg/modules/57290e55-335a-4c09-b904-a795572d6cda',
   PIAZZA = 'https://piazza.com/nus.edu.sg/fall2019/cs1101s',
   SHAREDB_SERVER = 'api2.sourceacademy.nus.edu.sg/',


### PR DESCRIPTION
Part of #609:

- Reorganized code from #612 - split fetching, types, rendering of list of contributors, and extra details about contributors into different files
- Contributors now displayed on a page with route `/contributors`, accessed from Contributors button on the Navbar
- Content of About popup in the dropdown updated
- Required snapshots updated