### PR TITLE
Fixing prompt

### DIFF
--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -54,7 +54,7 @@ function rawDisplay(value: Value, str: string, workspaceLocation: any) {
  * @param value the value to be displayed as a prompt
  */
 function cadetPrompt(value: any) {
-  return prompt(stringify(value));
+  return prompt(value);
 }
 
 /**


### PR DESCRIPTION
prompt was over-eagerly stringifying, too much for getting a nice REPL in the meta-circular evaluator. We had:

<img width="434" alt="Screenshot 2019-07-04 at 6 49 36 PM" src="https://user-images.githubusercontent.com/30220768/60661651-00a68080-9e8d-11e9-9172-27f50817a55c.png">

With this fix, we get:

<img width="434" alt="Screenshot 2019-07-04 at 6 50 29 PM" src="https://user-images.githubusercontent.com/30220768/60661668-0a2fe880-9e8d-11e9-864e-8286d7405479.png">
