### PR TITLE
Disable mission control for the time being

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -64,14 +64,15 @@ const NavigationBar: React.SFC<INavigationBarProps> = props => (
     </NavbarGroup>
 
     <NavbarGroup align={Alignment.RIGHT}>
-      <NavLink
+      {/* To be reintroduced in the future */}
+      {/* <NavLink
         activeClassName="pt-active"
         className="NavigationBar__link pt-button pt-minimal"
         to="/mission-control"
       >
         <Icon icon={IconNames.CODE} />
         <div className="navbar-button-text hidden-xs">Mission-Control</div>
-      </NavLink>
+      </NavLink> */}
 
       <NavLink
         activeClassName="pt-active"

--- a/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/components/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -29,12 +29,6 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
     </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
-    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/mission-control\\" aria-current=\\"page\\">
-      <Blueprint2.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button-text hidden-xs\\">
-        Mission-Control
-      </div>
-    </NavLink>
     <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/contributors\\" aria-current=\\"page\\">
       <Blueprint2.Icon icon=\\"heart\\" />
       <div className=\\"navbar-button-text hidden-xs\\">
@@ -81,12 +75,6 @@ exports[`NavigationBar renders correctly with username 1`] = `
     </NavLink>
   </Blueprint2.NavbarGroup>
   <Blueprint2.NavbarGroup align=\\"right\\">
-    <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/mission-control\\" aria-current=\\"page\\">
-      <Blueprint2.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button-text hidden-xs\\">
-        Mission-Control
-      </div>
-    </NavLink>
     <NavLink activeClassName=\\"pt-active\\" className=\\"NavigationBar__link pt-button pt-minimal\\" to=\\"/contributors\\" aria-current=\\"page\\">
       <Blueprint2.Icon icon=\\"heart\\" />
       <div className=\\"navbar-button-text hidden-xs\\">


### PR DESCRIPTION
The button will be removed. However, users can still manually navigate to mission-control via `/mission-control`