### PR TITLE
SWS3012: Change game component to load a default wallpaper

### DIFF
--- a/src/components/academy/game/create-initializer.js
+++ b/src/components/academy/game/create-initializer.js
@@ -71,23 +71,7 @@ export default function (StoryXMLPlayer, story, username, attemptedAll) {
 
   function initialize(div, canvas) {
     startGame(div, canvas);
-    var willPlayOpening = !attemptedAll;
-    var savedLocation;
-    if (typeof Storage !== 'undefined') {
-      // Code for localStorage/sessionStorage.
-      savedLocation = localStorage.cs1101s_source_academy_location;
-    }
-    if (story === 'contest-3.3') {
-      alert('Next contest: 3D Rune')
-    } else if (story === 'mission-1') {
-      StoryXMLPlayer.loadStory('spaceship', function () {
-        StoryXMLPlayer.loadStory('mission-1', function () { })
-      })
-    } else if (willPlayOpening) {
-      StoryXMLPlayer.loadStory(story, function () { }, savedLocation);
-    } else {
-      StoryXMLPlayer.loadStoryWithoutFirstQuest(story, function () { }, savedLocation)
-    }
+    StoryXMLPlayer.loadStory('default', function () { });
   }
 
   return initialize;


### PR DESCRIPTION
Simplifies the game for SWS3012. Instead of loading the usual 'spaceship' story, the academy will look for a 'default' story. Currently, the 'default' story is intended to be a simple galaxy background/wallpaper.

This requires `default.story.xml` to be deployed in the AWS first before it can show anything. In particular, it should exist in https://s3-ap-southeast-1.amazonaws.com/source-academy-assets/stories/default.story.xml
If it is not deployed in the AWS, it will show a default black screen. 