### PR TITLE
Bump Cadet-Frontend Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "cadet-frontend",
-  "version": "1.0.21",
+  "version": "1.2.0",
   "scripts-info": {
     "format": "Format source code",
     "start": "Start the Webpack development server",


### PR DESCRIPTION
It has been awhile. Let's keep our versioning going! (also our `releases` - https://github.com/source-academy/cadet-frontend/releases)

This PR bumps `cadet-frontend` to version 1.2.0.

Changes include (edit this description to add in any more changes - this will be used in the release documentation) :

----
Contributors Page (#655)
LumiNUS Authentication (#534)

Frontend-Testing: Added tests for actions/reducers/sagas (#581)

Grading Improvements: Format changed + Test runners (#568)

Clean up of libraries
Un-Submit Feature for Assessments (#598)
Sessions in Playground
Debugger + Environment Visualiser

