### PR TITLE
bumping js-slang

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "draft-js": "^0.10.5",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.2.3",
+    "js-slang": "^0.2.4",
     "lodash": "^4.17.11",
     "lz-string": "^1.4.4",
     "moment": "^2.22.2",


### PR DESCRIPTION
latest is now 1.2.4, the version with the nested scope of REPL