### PR TITLE
Change "Skip Story & Attempt" on buttons to just "Attempt"

### DIFF
--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -494,19 +494,19 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                           <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}}>
                                             <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                               <Blueprint3.Icon icon={{...}}>
-                                                <Blueprint3.Icon icon=\\"step-forward\\" color={[undefined]}>
-                                                  <span icon=\\"step-forward\\" className=\\"bp3-icon bp3-icon-step-forward\\" title={[undefined]}>
-                                                    <svg fill={[undefined]} data-icon=\\"step-forward\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                                  <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                    <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                       <desc>
-                                                        step-forward
+                                                        play
                                                       </desc>
-                                                      <path d=\\"M12 3h-1c-.55 0-1 .45-1 1v2.72l-4.38-3.5v.01A.987.987 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .24 0 .44-.09.62-.23l.01.01L10 9.28V12c0 .55.45 1 1 1h1c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                                      <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
                                                     </svg>
                                                   </span>
                                                 </Blueprint3.Icon>
                                               </Blueprint3.Icon>
                                               <span className=\\"bp3-button-text\\">
-                                                Skip Story &amp; Attempt
+                                                Attempt
                                               </span>
                                               <Blueprint3.Icon icon={[undefined]} />
                                             </button>
@@ -725,19 +725,19 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                           <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}}>
                                             <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                               <Blueprint3.Icon icon={{...}}>
-                                                <Blueprint3.Icon icon=\\"step-forward\\" color={[undefined]}>
-                                                  <span icon=\\"step-forward\\" className=\\"bp3-icon bp3-icon-step-forward\\" title={[undefined]}>
-                                                    <svg fill={[undefined]} data-icon=\\"step-forward\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                                  <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                    <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                       <desc>
-                                                        step-forward
+                                                        play
                                                       </desc>
-                                                      <path d=\\"M12 3h-1c-.55 0-1 .45-1 1v2.72l-4.38-3.5v.01A.987.987 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .24 0 .44-.09.62-.23l.01.01L10 9.28V12c0 .55.45 1 1 1h1c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                                      <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
                                                     </svg>
                                                   </span>
                                                 </Blueprint3.Icon>
                                               </Blueprint3.Icon>
                                               <span className=\\"bp3-button-text\\">
-                                                Skip Story &amp; Attempt
+                                                Attempt
                                               </span>
                                               <Blueprint3.Icon icon={[undefined]} />
                                             </button>
@@ -1084,19 +1084,19 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                           <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}}>
                                             <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                               <Blueprint3.Icon icon={{...}}>
-                                                <Blueprint3.Icon icon=\\"step-forward\\" color={[undefined]}>
-                                                  <span icon=\\"step-forward\\" className=\\"bp3-icon bp3-icon-step-forward\\" title={[undefined]}>
-                                                    <svg fill={[undefined]} data-icon=\\"step-forward\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                                  <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                    <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                       <desc>
-                                                        step-forward
+                                                        play
                                                       </desc>
-                                                      <path d=\\"M12 3h-1c-.55 0-1 .45-1 1v2.72l-4.38-3.5v.01A.987.987 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .24 0 .44-.09.62-.23l.01.01L10 9.28V12c0 .55.45 1 1 1h1c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                                      <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
                                                     </svg>
                                                   </span>
                                                 </Blueprint3.Icon>
                                               </Blueprint3.Icon>
                                               <span className=\\"bp3-button-text\\">
-                                                Skip Story &amp; Attempt
+                                                Attempt
                                               </span>
                                               <Blueprint3.Icon icon={[undefined]} />
                                             </button>

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -410,8 +410,8 @@ const makeOverviewCardButton = (overview: IAssessmentOverview) => {
   let label: string;
   switch (overview.status) {
     case AssessmentStatuses.not_attempted:
-      icon = IconNames.STEP_FORWARD;
-      label = overview.story ? 'Skip Story & Attempt' : 'Attempt';
+      icon = IconNames.PLAY;
+      label = 'Attempt';
       break;
     case AssessmentStatuses.attempting:
       icon = IconNames.PLAY;


### PR DESCRIPTION
Simple change to remove "Skip Story" on the buttons displayed when trying to access an assessment for the first time. I took the opportunity to modify the icon used as well, from "step-forward" (similar to a 'skip' icon on videos) to "play".

<img width="947" alt="only-attempt" src="https://user-images.githubusercontent.com/49450743/61255717-5a1b8300-a79c-11e9-9bf5-0404d79bf135.png">

This change is meant to resolve issue #725.