### PR TITLE
Patch issue with Grading in production

### DIFF
--- a/src/actions/__tests__/session.ts
+++ b/src/actions/__tests__/session.ts
@@ -139,15 +139,13 @@ test('submitAssessment generates correct action object', () => {
 test('submitGrading generates correct action object with default values', () => {
   const submissionId = 8;
   const questionId = 2;
-  const comment = 'test comment here';
 
-  const action = submitGrading(submissionId, questionId, comment);
+  const action = submitGrading(submissionId, questionId);
   expect(action).toEqual({
     type: actionTypes.SUBMIT_GRADING,
     payload: {
       submissionId,
       questionId,
-      comment,
       gradeAdjustment: 0,
       xpAdjustment: 0
     }
@@ -157,16 +155,14 @@ test('submitGrading generates correct action object with default values', () => 
 test('submitGrading generates correct action object', () => {
   const submissionId = 10;
   const questionId = 3;
-  const comment = 'another test comment here';
   const gradeAdjustment = 10;
   const xpAdjustment = 100;
-  const action = submitGrading(submissionId, questionId, comment, gradeAdjustment, xpAdjustment);
+  const action = submitGrading(submissionId, questionId, gradeAdjustment, xpAdjustment);
   expect(action).toEqual({
     type: actionTypes.SUBMIT_GRADING,
     payload: {
       submissionId,
       questionId,
-      comment,
       gradeAdjustment,
       xpAdjustment
     }

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -80,7 +80,6 @@ export const submitAssessment: ActionCreator<actionTypes.IAction> = (id: number)
 export const submitGrading: ActionCreator<actionTypes.IAction> = (
   submissionId: number,
   questionId: number,
-  comment: string,
   gradeAdjustment: number = 0,
   xpAdjustment: number = 0
 ) => ({
@@ -88,7 +87,6 @@ export const submitGrading: ActionCreator<actionTypes.IAction> = (
   payload: {
     submissionId,
     questionId,
-    comment,
     gradeAdjustment,
     xpAdjustment
   }

--- a/src/sagas/backend.ts
+++ b/src/sagas/backend.ts
@@ -238,7 +238,6 @@ function* backendSaga(): SagaIterator {
     const {
       submissionId,
       questionId,
-      comment,
       gradeAdjustment,
       xpAdjustment
     } = (action as actionTypes.IAction).payload;
@@ -249,7 +248,7 @@ function* backendSaga(): SagaIterator {
     const resp = yield postGrading(
       submissionId,
       questionId,
-      comment,
+      '',
       gradeAdjustment,
       xpAdjustment,
       tokens


### PR DESCRIPTION
There was a regression bug in production which caused grading to fail. This was due to a mismatch of the fields passed into the backend API.

This bug has been patched. This PR updates the current master to be in sync with the deployed version.

#### Changes
- Removed comment from `SUBMIT_GRADING` action
- Send empty string as comment to backend 
