### PR TITLE
Fix tokens not being refreshed and auto-logout 

### DIFF
--- a/src/sagas/backend.ts
+++ b/src/sagas/backend.ts
@@ -22,6 +22,7 @@ import {
   QuestionType,
   QuestionTypes
 } from '../components/assessment/assessmentShape';
+import { store } from '../createStore';
 import { IState, Role } from '../reducers/states';
 import { castLibrary } from '../utils/castBackend';
 import { BACKEND_URL } from '../utils/constants';
@@ -611,7 +612,7 @@ async function request(
       return response;
     } else if (opts.shouldRefresh && response.status === 401) {
       const newTokens = await postRefresh(opts.refreshToken!);
-      put(actions.setTokens(newTokens));
+      store.dispatch(actions.setTokens(newTokens));
       const newOpts = {
         ...opts,
         accessToken: newTokens!.accessToken,
@@ -627,7 +628,7 @@ async function request(
       throw new Error('API call failed or got non-OK response');
     }
   } catch (e) {
-    put(actions.logOut());
+    store.dispatch(actions.logOut());
     showWarningMessage(opts.errorMessage ? opts.errorMessage : 'Please login again.');
     return null;
   }


### PR DESCRIPTION
Fixes #721 

This is a regression bug from the testing. The issue is that saga's `put` will not work inside a function like  `request` (since it is not a generator). We just have to manually call the store here to dispatch the action.

In the long run though, we need to relook at how handle our HTTP requests and come up with a better design. It is a little messy at the moment. Perhaps, #713 can improve it.