### PR TITLE
Fix interpreter error in environments where Inspector is not available

### DIFF
--- a/public/externalLibs/inspector/inspector.js
+++ b/public/externalLibs/inspector/inspector.js
@@ -129,7 +129,7 @@
     // icon to blink
     const icon = document.getElementById("Inspector-icon");
 
-    if (!context) {
+    if (!context && !!icon) {
       icon.classList.remove("side-content-header-button-alert");
       container.innerHTML = "";
       return
@@ -150,7 +150,9 @@
         tbody.innerHTML = "</br><caption><strong> " + frames[i].name + "</strong></caption>" + envtoString;
         newtable.appendChild(tbody);
         container.appendChild(newtable);
-        icon.classList.add("side-content-header-button-alert");
+        if (!!icon) {
+          icon.classList.add("side-content-header-button-alert");
+        }
       }
     } catch (e) {
         container.innerHTML = e;

--- a/public/externalLibs/inspector/inspector.js
+++ b/public/externalLibs/inspector/inspector.js
@@ -129,7 +129,7 @@
     // icon to blink
     const icon = document.getElementById("Inspector-icon");
 
-    if (!context && !!icon) {
+    if (!context && icon) {
       icon.classList.remove("side-content-header-button-alert");
       container.innerHTML = "";
       return
@@ -150,7 +150,7 @@
         tbody.innerHTML = "</br><caption><strong> " + frames[i].name + "</strong></caption>" + envtoString;
         newtable.appendChild(tbody);
         container.appendChild(newtable);
-        if (!!icon) {
+        if (icon) {
           icon.classList.add("side-content-header-button-alert");
         }
       }


### PR DESCRIPTION
## [Bugfix] Fix interpreter error in environments where Inspector is not available
Resolves #772.

### Bug description
The interpreter (`interpreter.js` script) is loaded in both assessment and playground environments. The script has the line

https://github.com/source-academy/cadet-frontend/blob/0dc69f3c15fa73f335a3994bcd29c8934d5cea38/public/externalLibs/inspector/inspector.js#L130

which retrieves the HTML element with ID `Inspector-icon`, then later on accesses and modifies the HTML attribute `classList` here

https://github.com/source-academy/cadet-frontend/blob/0dc69f3c15fa73f335a3994bcd29c8934d5cea38/public/externalLibs/inspector/inspector.js#L133

and here

https://github.com/source-academy/cadet-frontend/blob/0dc69f3c15fa73f335a3994bcd29c8934d5cea38/public/externalLibs/inspector/inspector.js#L153

to apply CSS animation styling (for use with breakpoints in the playground). 

In the playground environment, the Inspector component is loaded along with the tab button (which has the id `Inspector-icon` - hence `icon` is defined. However, in the assessment environment, the Source Inspector component is not loaded - hence the above line returns `null` and attempting to access `classList` throws a fatal error that stalls the interpreter, requiring the page to be refreshed.

### Fix
  - Add `null` check for `icon` to prevent the script from accessing the `classList` attribute when the Inspector is not loaded.

#### Personal Comments
Regarding loading the Debugger and Inspector in assessments, that decision should be left to the teaching team as a whole.

Last updated 19 Jul 2019, 11:45PM