### PR TITLE
Fix workspaceLocation for saveSourcecastData

### DIFF
--- a/src/containers/sourcecast/SourcereelContainer.ts
+++ b/src/containers/sourcecast/SourcereelContainer.ts
@@ -81,7 +81,7 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
         description: string,
         audio: Blob,
         playbackData: IPlaybackData
-      ) => saveSourcecastData(title, description, audio, playbackData, location),
+      ) => saveSourcecastData(title, description, audio, playbackData, 'sourcecast'),
       handleSetEditorReadonly: (readonly: boolean) => setEditorReadonly(location, readonly),
       handleRecordEditorInitValue: (editorValue: string) =>
         recordEditorInitValue(editorValue, location),

--- a/src/reducers/__tests__/sourcecast.ts
+++ b/src/reducers/__tests__/sourcecast.ts
@@ -61,7 +61,7 @@ describe('SAVE_SOURCECAST_DATA', () => {
     const action: IAction = generateAction(SAVE_SOURCECAST_DATA, payload);
     const result = reducer(defaultWorkspaceManager.sourcecast, action);
     expect(result).toEqual({
-      ...defaultWorkspaceManager.sourcereel,
+      ...defaultWorkspaceManager.sourcecast,
       ...payload
     });
   });

--- a/src/reducers/__tests__/sourcecast.ts
+++ b/src/reducers/__tests__/sourcecast.ts
@@ -1,5 +1,6 @@
 import {
   IAction,
+  SAVE_SOURCECAST_DATA,
   SET_CODE_DELTAS_TO_APPLY,
   SET_INPUT_TO_APPLY,
   SET_SOURCECAST_DATA,
@@ -23,6 +24,48 @@ function generateAction(type: string, payload: any = {}): IAction {
     payload
   };
 }
+
+describe('SAVE_SOURCECAST_DATA', () => {
+  test('saves sourcecastData correctly', () => {
+    const codeDelta: ICodeDelta = {
+      start: {
+        row: 0,
+        column: 1
+      },
+      end: {
+        row: 0,
+        column: 2
+      },
+      action: 'insert',
+      lines: ['a']
+    };
+    const input: Input = {
+      time: 1,
+      type: 'codeDelta',
+      data: codeDelta
+    };
+    const playbackData: IPlaybackData = {
+      init: {
+        editorValue: ''
+      },
+      inputs: [input]
+    };
+
+    const payload = {
+      title: 'Test Title',
+      description: 'Test Description',
+      audioUrl: 'someUrl.com',
+      playbackData
+    };
+
+    const action: IAction = generateAction(SAVE_SOURCECAST_DATA, payload);
+    const result = reducer(defaultWorkspaceManager.sourcecast, action);
+    expect(result).toEqual({
+      ...defaultWorkspaceManager.sourcereel,
+      ...payload
+    });
+  });
+});
 
 describe('SET_CODE_DELTAS_TO_APPLY', () => {
   test('sets codeDeltasToApply correctly', () => {

--- a/src/reducers/__tests__/sourcereel.ts
+++ b/src/reducers/__tests__/sourcereel.ts
@@ -2,19 +2,13 @@ import {
   IAction,
   RECORD_EDITOR_INIT_VALUE,
   RECORD_INPUT,
-  SAVE_SOURCECAST_DATA,
   TIMER_PAUSE,
   TIMER_RESET,
   TIMER_RESUME,
   TIMER_START,
   TIMER_STOP
 } from '../../actions/actionTypes';
-import {
-  ICodeDelta,
-  Input,
-  IPlaybackData,
-  RecordingStatus
-} from '../../components/sourcecast/sourcecastShape';
+import { ICodeDelta, Input, RecordingStatus } from '../../components/sourcecast/sourcecastShape';
 import { reducer } from '../sourcereel';
 import { defaultWorkspaceManager } from '../states';
 
@@ -72,48 +66,6 @@ describe('RECORD_INPUT', () => {
         ...defaultWorkspaceManager.sourcereel.playbackData,
         inputs: [...defaultWorkspaceManager.sourcereel.playbackData.inputs, input]
       }
-    });
-  });
-});
-
-describe('SAVE_SOURCECAST_DATA', () => {
-  test('saves sourcecastData correctly', () => {
-    const codeDelta: ICodeDelta = {
-      start: {
-        row: 0,
-        column: 1
-      },
-      end: {
-        row: 0,
-        column: 2
-      },
-      action: 'insert',
-      lines: ['a']
-    };
-    const input: Input = {
-      time: 1,
-      type: 'codeDelta',
-      data: codeDelta
-    };
-    const playbackData: IPlaybackData = {
-      init: {
-        editorValue: ''
-      },
-      inputs: [input]
-    };
-
-    const payload = {
-      title: 'Test Title',
-      description: 'Test Description',
-      audioUrl: 'someUrl.com',
-      playbackData
-    };
-
-    const action: IAction = generateAction(SAVE_SOURCECAST_DATA, payload);
-    const result = reducer(defaultWorkspaceManager.sourcereel, action);
-    expect(result).toEqual({
-      ...defaultWorkspaceManager.sourcereel,
-      ...payload
     });
   });
 });

--- a/src/reducers/sourcecast.ts
+++ b/src/reducers/sourcecast.ts
@@ -3,6 +3,7 @@ import { ISourcecastWorkspace } from './states';
 
 import {
   IAction,
+  SAVE_SOURCECAST_DATA,
   SET_CODE_DELTAS_TO_APPLY,
   SET_INPUT_TO_APPLY,
   SET_SOURCECAST_DATA,
@@ -16,18 +17,24 @@ export const reducer: Reducer<ISourcecastWorkspace> = (
   action: IAction
 ) => {
   switch (action.type) {
+    case SAVE_SOURCECAST_DATA:
+      return {
+        ...state,
+        title: action.payload.title,
+        description: action.payload.description,
+        audioUrl: action.payload.audioUrl,
+        playbackData: action.payload.playbackData
+      };
     case SET_CODE_DELTAS_TO_APPLY:
       return {
         ...state,
         codeDeltasToApply: action.payload.deltas
       };
-
     case SET_INPUT_TO_APPLY:
       return {
         ...state,
         inputToApply: action.payload.inputToApply
       };
-
     case SET_SOURCECAST_DATA:
       return {
         ...state,

--- a/src/reducers/sourcereel.ts
+++ b/src/reducers/sourcereel.ts
@@ -5,7 +5,6 @@ import {
   IAction,
   RECORD_EDITOR_INIT_VALUE,
   RECORD_INPUT,
-  SAVE_SOURCECAST_DATA,
   TIMER_PAUSE,
   TIMER_RESET,
   TIMER_RESUME,
@@ -36,14 +35,6 @@ export const reducer: Reducer<ISourcereelWorkspace> = (
           ...state.playbackData,
           inputs: [...state.playbackData.inputs, action.payload.input]
         }
-      };
-    case SAVE_SOURCECAST_DATA:
-      return {
-        ...state,
-        title: action.payload.title,
-        description: action.payload.description,
-        audioUrl: action.payload.audioUrl,
-        playbackData: action.payload.playbackData
       };
     case TIMER_PAUSE:
       return {


### PR DESCRIPTION
- Recorded sourcecast entry should be ready for preview after saving into database.
- Broken due to extraction of sourcereel/sourcecast reducers from workspace reducer.