### PR TITLE
Redesign Profile component to a full-fledged user profile page

### DIFF
--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -1,14 +1,16 @@
 import {
+  Callout,
   Drawer,
   Intent,
   NonIdealState,
+  ProgressBar,
   Spinner
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
 import { Role } from '../../reducers/states';
-import { AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
+import { AssessmentCategories, AssessmentCategory, AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
 
 type ProfileProps = OwnProps & StateProps;
 
@@ -52,6 +54,62 @@ class Profile extends React.Component<ProfileProps> {
                 : Intent.DANGER;
       };
 
+      const renderIcon = (category: AssessmentCategory) => {
+        switch (category) {
+          case AssessmentCategories.Mission:
+            return IconNames.FLAME;
+          case AssessmentCategories.Sidequest:
+            return IconNames.LIGHTBULB;
+          case AssessmentCategories.Path:
+            return IconNames.PREDICTIVE_ANALYSIS;
+          case AssessmentCategories.Contest:
+            return IconNames.COMPARISON;
+          default:
+            // For rendering hidden assessments not visible to the student
+            // e.g. studio participation marks
+            return IconNames.PULSE;
+          }
+      };
+
+      // Build condensed assessment cards from an array of assessments
+      const summaryCallouts = this.props.assessmentOverviews!
+        .filter( (item) => item.status === AssessmentStatuses.submitted )
+        .map( (item) => {
+          return (
+            <Callout
+                className='profile-summary-callout'
+                key={`${item.title}-${item.id}`}
+                icon={renderIcon(item.category)}
+                title={item.title}
+              >
+              {item.maxGrade <= 0 ? '' :
+                <div className='grade-details'>
+                  <div className='title'>Grade</div>
+                  <div className='value'>{item.grade} / {item.maxGrade}</div>
+                  <ProgressBar
+                    animate={false}
+                    className='value-bar'
+                    intent={parseFrac(item.grade / item.maxGrade)}
+                    stripes={false}
+                    value={item.grade / item.maxGrade} />
+                </div>
+              }
+              {item.maxXp <= 0 ? '' :
+                <div className='xp-details'>
+                  <div className='title'>XP</div>
+                  <div className='value'>{item.xp} / {item.maxXp}</div>
+                  <ProgressBar
+                    animate={false}
+                    className='value-bar'
+                    intent={parseFrac(item.xp / item.maxXp)}
+                    stripes={false}
+                    value={item.xp / item.maxXp} />
+                </div>
+              }
+            </Callout>
+          );
+        });
+
       // Compute the user's maximum total grade and XP from submitted assessments
       content = (
         <div className='profile-content'>
@@ -88,6 +146,9 @@ class Profile extends React.Component<ProfileProps> {
               </div>
               <div className="percentage">{((currentXp / maxXp) * 100).toFixed(2)}%</div>
             </div>
+          </div>
+          <div className="profile-callouts">
+              {summaryCallouts}
           </div>
         </div>
       );

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import { Role } from '../../reducers/states';
 import { AssessmentCategories, AssessmentCategory, AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
 
-type ProfileProps = OwnProps & StateProps;
+type ProfileProps = DispatchProps & OwnProps & StateProps;
 
 export type StateProps = {
   assessmentOverviews?: IAssessmentOverview[];
@@ -25,7 +25,18 @@ export type OwnProps = {
   onClose: () => void;
 };
 
+export type DispatchProps = {
+  handleAssessmentOverviewFetch: () => void;
+};
+
 class Profile extends React.Component<ProfileProps> {
+  public componentDidMount() {
+    if (!this.props.assessmentOverviews) {
+      // If assessment overviews are not loaded, fetch them
+      this.props.handleAssessmentOverviewFetch();
+    }
+  }
+
   public render() {
     const isLoaded = this.props.name && this.props.role && this.props.assessmentOverviews;
     let content: JSX.Element;

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -71,7 +71,14 @@ class Profile extends React.Component<ProfileProps, {}> {
         const [currentGrade, currentXp, maxGrade, maxXp] = this.props.assessmentOverviews!.reduce(
           (acc, item) =>
             item.status === AssessmentStatuses.submitted
-              ? [acc[0] + item.grade, acc[1] + item.xp, acc[2] + item.maxGrade, acc[3] + item.maxXp]
+              ? item.category === AssessmentCategories.Mission
+                ? [
+                    acc[0] + item.grade,
+                    acc[1] + item.xp,
+                    acc[2] + item.maxGrade,
+                    acc[3] + item.maxXp
+                  ]
+                : [acc[0], acc[1] + item.xp, acc[2], acc[3] + item.maxXp]
               : acc,
           [0, 0, 0, 0]
         );

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -1,16 +1,15 @@
-import { Callout, Drawer, Intent, NonIdealState, ProgressBar, Spinner } from '@blueprintjs/core';
+import { Drawer, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
-import { NavLink } from 'react-router-dom';
 import { Role } from '../../reducers/states';
-import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
 import {
   AssessmentCategories,
   AssessmentCategory,
   AssessmentStatuses,
   IAssessmentOverview
 } from '../assessment/assessmentShape';
+import ProfileCard from './ProfileCard';
 
 type ProfileProps = DispatchProps & OwnProps & StateProps;
 
@@ -29,7 +28,7 @@ export type DispatchProps = {
   handleAssessmentOverviewFetch: () => void;
 };
 
-class Profile extends React.Component<ProfileProps> {
+class Profile extends React.Component<ProfileProps, {}> {
   public componentDidMount() {
     if (!this.props.assessmentOverviews) {
       // If assessment overviews are not loaded, fetch them
@@ -116,58 +115,15 @@ class Profile extends React.Component<ProfileProps> {
         // Build condensed assessment cards from an array of assessments
         const summaryCallouts = this.props
           .assessmentOverviews!.filter(item => item.status === AssessmentStatuses.submitted)
-          .map(item => {
+          .map((assessment, index) => {
             return (
-              // Make each card navigate the user to the respective assessment
-              <NavLink
-                className="profile-summary-navlink"
-                key={`${item.title}-${item.id}`}
-                target="_blank"
-                to={`/academy/${assessmentCategoryLink(item.category)}/${item.id}/0`}
-                activeClassName="profile-summary-navlink"
-              >
-                <Callout
-                  className="profile-summary-callout"
-                  key={`${item.title}-${item.id}`}
-                  icon={renderIcon(item.category)}
-                  title={item.title}
-                >
-                  {item.maxGrade <= 0 && item.grade === 0 ? (
-                    ''
-                  ) : (
-                    <div className="grade-details">
-                      <div className="title">Grade</div>
-                      <div className="value">
-                        {item.grade} / {item.maxGrade}
-                      </div>
-                      <ProgressBar
-                        animate={false}
-                        className="value-bar"
-                        intent={parseFrac(getFrac(item.grade, item.maxGrade))}
-                        stripes={false}
-                        value={getFrac(item.grade, item.maxGrade)}
-                      />
-                    </div>
-                  )}
-                  {item.maxXp <= 0 && item.xp === 0 ? (
-                    ''
-                  ) : (
-                    <div className="xp-details">
-                      <div className="title">XP</div>
-                      <div className="value">
-                        {item.xp} / {item.maxXp}
-                      </div>
-                      <ProgressBar
-                        animate={false}
-                        className="value-bar"
-                        intent={parseFrac(getFrac(item.xp, item.maxXp))}
-                        stripes={false}
-                        value={getFrac(item.xp, item.maxXp)}
-                      />
-                    </div>
-                  )}
-                </Callout>
-              </NavLink>
+              <ProfileCard
+                key={index}
+                item={assessment}
+                getFrac={getFrac}
+                parseFrac={parseFrac}
+                renderIcon={renderIcon}
+              />
             );
           });
 

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -44,151 +44,171 @@ class Profile extends React.Component<ProfileProps> {
     if (!isLoaded) {
       content = <NonIdealState description="Loading..." icon={<Spinner />} />;
     } else {
-      // Compute the user's current total grade and XP from submitted assessments
-      const [currentGrade, currentXp, maxGrade, maxXp] = this.props.assessmentOverviews!.reduce(
-        (acc, item) =>
-          item.status === AssessmentStatuses.submitted
-            ? [acc[0] + item.grade, acc[1] + item.xp, acc[2] + item.maxGrade, acc[3] + item.maxXp]
-            : acc,
-        [0, 0, 0, 0]
-      );
+      // Check if there are any closed assessments, else render a placeholder <div>
+      const numClosed = this.props.assessmentOverviews!.filter(
+        item => item.status === AssessmentStatuses.submitted
+      ).length;
 
-      // Performs boundary checks if denominator is 0 or if it exceeds 1 (100%)
-      const getFrac = (num: number, den: number): number => {
-        return den <= 0 || num / den > 1 ? 1 : num / den;
-      };
-
-      // Given a fraction between 0 and 1 inclusive, returns the corresponding Intent (colour)
-      const parseFrac = (frac: number): Intent => {
-        return frac < 0
-          ? Intent.NONE
-          : frac >= 0.9
-          ? Intent.PRIMARY
-          : frac >= 0.8
-          ? Intent.SUCCESS
-          : frac >= 0.6
-          ? Intent.WARNING
-          : Intent.DANGER;
-      };
-
-      // Given an assessment category, return its icon
-      const renderIcon = (category: AssessmentCategory) => {
-        switch (category) {
-          case AssessmentCategories.Mission:
-            return IconNames.FLAME;
-          case AssessmentCategories.Sidequest:
-            return IconNames.LIGHTBULB;
-          case AssessmentCategories.Path:
-            return IconNames.PREDICTIVE_ANALYSIS;
-          case AssessmentCategories.Contest:
-            return IconNames.COMPARISON;
-          default:
-            // For rendering hidden assessments not visible to the student
-            // e.g. studio participation marks
-            return IconNames.PULSE;
-        }
-      };
-
-      // Build condensed assessment cards from an array of assessments
-      const summaryCallouts = this.props
-        .assessmentOverviews!.filter(item => item.status === AssessmentStatuses.submitted)
-        .map(item => {
-          return (
-            // Make each card navigate the user to the respective assessment
-            <NavLink
-              className="profile-summary-navlink"
-              key={`${item.title}-${item.id}`}
-              target="_blank"
-              to={`/academy/${assessmentCategoryLink(item.category)}/${item.id}/0`}
-              activeClassName="profile-summary-navlink"
-            >
-              <Callout
-                className="profile-summary-callout"
-                key={`${item.title}-${item.id}`}
-                icon={renderIcon(item.category)}
-                title={item.title}
-              >
-                {item.maxGrade <= 0 && item.grade === 0 ? (
-                  ''
-                ) : (
-                  <div className="grade-details">
-                    <div className="title">Grade</div>
-                    <div className="value">
-                      {item.grade} / {item.maxGrade}
-                    </div>
-                    <ProgressBar
-                      animate={false}
-                      className="value-bar"
-                      intent={parseFrac(getFrac(item.grade, item.maxGrade))}
-                      stripes={false}
-                      value={getFrac(item.grade, item.maxGrade)}
-                    />
-                  </div>
-                )}
-                {item.maxXp <= 0 && item.xp === 0 ? (
-                  ''
-                ) : (
-                  <div className="xp-details">
-                    <div className="title">XP</div>
-                    <div className="value">
-                      {item.xp} / {item.maxXp}
-                    </div>
-                    <ProgressBar
-                      animate={false}
-                      className="value-bar"
-                      intent={parseFrac(getFrac(item.xp, item.maxXp))}
-                      stripes={false}
-                      value={getFrac(item.xp, item.maxXp)}
-                    />
-                  </div>
-                )}
-              </Callout>
-            </NavLink>
-          );
-        });
-
-      // Compute the user's maximum total grade and XP from submitted assessments
-      content = (
-        <div className="profile-content">
-          <div className="profile-header">
-            <div className="profile-username">
-              <div className="name">{this.props.name}</div>
-              <div className="role">{this.props.role}</div>
-            </div>
+      const userDetails = (
+        <div className="profile-header">
+          <div className="profile-username">
+            <div className="name">{this.props.name}</div>
+            <div className="role">{this.props.role}</div>
           </div>
-          <div className="profile-progress">
-            <div className="profile-grade">
-              <Spinner
-                className="grade-spinner"
-                intent={parseFrac(getFrac(currentGrade, maxGrade))}
-                size={144}
-                value={getFrac(currentGrade, maxGrade)}
-              />
-              <div className="type">Grade</div>
-              <div className="total-value">
-                {currentGrade} / {maxGrade}
-              </div>
-              <div className="percentage">
-                {(getFrac(currentGrade, maxGrade) * 100).toFixed(2)}%
-              </div>
-            </div>
-            <div className="profile-xp">
-              <Spinner
-                className="xp-spinner"
-                intent={parseFrac(getFrac(currentXp, maxXp))}
-                size={144}
-                value={getFrac(currentXp, maxXp)}
-              />
-              <div className="type">XP</div>
-              <div className="total-value">
-                {currentXp} / {maxXp}
-              </div>
-              <div className="percentage">{(getFrac(currentXp, maxXp) * 100).toFixed(2)}%</div>
-            </div>
-          </div>
-          <div className="profile-callouts">{summaryCallouts}</div>
         </div>
       );
+
+      if (numClosed === 0) {
+        content = (
+          <div className="profile-content">
+            {userDetails}
+            <div className="profile-placeholder">
+              There are no closed assessments to render grade and XP of.
+            </div>
+          </div>
+        );
+      } else {
+        // Compute the user's current total grade and XP from submitted assessments
+        const [currentGrade, currentXp, maxGrade, maxXp] = this.props.assessmentOverviews!.reduce(
+          (acc, item) =>
+            item.status === AssessmentStatuses.submitted
+              ? [acc[0] + item.grade, acc[1] + item.xp, acc[2] + item.maxGrade, acc[3] + item.maxXp]
+              : acc,
+          [0, 0, 0, 0]
+        );
+
+        // Performs boundary checks if denominator is 0 or if it exceeds 1 (100%)
+        const getFrac = (num: number, den: number): number => {
+          return den <= 0 || num / den > 1 ? 1 : num / den;
+        };
+
+        // Given a fraction between 0 and 1 inclusive, returns the corresponding Intent (colour)
+        const parseFrac = (frac: number): Intent => {
+          return frac < 0
+            ? Intent.NONE
+            : frac >= 0.9
+            ? Intent.PRIMARY
+            : frac >= 0.8
+            ? Intent.SUCCESS
+            : frac >= 0.6
+            ? Intent.WARNING
+            : Intent.DANGER;
+        };
+
+        // Given an assessment category, return its icon
+        const renderIcon = (category: AssessmentCategory) => {
+          switch (category) {
+            case AssessmentCategories.Mission:
+              return IconNames.FLAME;
+            case AssessmentCategories.Sidequest:
+              return IconNames.LIGHTBULB;
+            case AssessmentCategories.Path:
+              return IconNames.PREDICTIVE_ANALYSIS;
+            case AssessmentCategories.Contest:
+              return IconNames.COMPARISON;
+            default:
+              // For rendering hidden assessments not visible to the student
+              // e.g. studio participation marks
+              return IconNames.PULSE;
+          }
+        };
+
+        // Build condensed assessment cards from an array of assessments
+        const summaryCallouts = this.props
+          .assessmentOverviews!.filter(item => item.status === AssessmentStatuses.submitted)
+          .map(item => {
+            return (
+              // Make each card navigate the user to the respective assessment
+              <NavLink
+                className="profile-summary-navlink"
+                key={`${item.title}-${item.id}`}
+                target="_blank"
+                to={`/academy/${assessmentCategoryLink(item.category)}/${item.id}/0`}
+                activeClassName="profile-summary-navlink"
+              >
+                <Callout
+                  className="profile-summary-callout"
+                  key={`${item.title}-${item.id}`}
+                  icon={renderIcon(item.category)}
+                  title={item.title}
+                >
+                  {item.maxGrade <= 0 && item.grade === 0 ? (
+                    ''
+                  ) : (
+                    <div className="grade-details">
+                      <div className="title">Grade</div>
+                      <div className="value">
+                        {item.grade} / {item.maxGrade}
+                      </div>
+                      <ProgressBar
+                        animate={false}
+                        className="value-bar"
+                        intent={parseFrac(getFrac(item.grade, item.maxGrade))}
+                        stripes={false}
+                        value={getFrac(item.grade, item.maxGrade)}
+                      />
+                    </div>
+                  )}
+                  {item.maxXp <= 0 && item.xp === 0 ? (
+                    ''
+                  ) : (
+                    <div className="xp-details">
+                      <div className="title">XP</div>
+                      <div className="value">
+                        {item.xp} / {item.maxXp}
+                      </div>
+                      <ProgressBar
+                        animate={false}
+                        className="value-bar"
+                        intent={parseFrac(getFrac(item.xp, item.maxXp))}
+                        stripes={false}
+                        value={getFrac(item.xp, item.maxXp)}
+                      />
+                    </div>
+                  )}
+                </Callout>
+              </NavLink>
+            );
+          });
+
+        // Compute the user's maximum total grade and XP from submitted assessments
+        content = (
+          <div className="profile-content">
+            {userDetails}
+            <div className="profile-progress">
+              <div className="profile-grade">
+                <Spinner
+                  className="grade-spinner"
+                  intent={parseFrac(getFrac(currentGrade, maxGrade))}
+                  size={144}
+                  value={getFrac(currentGrade, maxGrade)}
+                />
+                <div className="type">Grade</div>
+                <div className="total-value">
+                  {currentGrade} / {maxGrade}
+                </div>
+                <div className="percentage">
+                  {(getFrac(currentGrade, maxGrade) * 100).toFixed(2)}%
+                </div>
+              </div>
+              <div className="profile-xp">
+                <Spinner
+                  className="xp-spinner"
+                  intent={parseFrac(getFrac(currentXp, maxXp))}
+                  size={144}
+                  value={getFrac(currentXp, maxXp)}
+                />
+                <div className="type">XP</div>
+                <div className="total-value">
+                  {currentXp} / {maxXp}
+                </div>
+                <div className="percentage">{(getFrac(currentXp, maxXp) * 100).toFixed(2)}%</div>
+              </div>
+            </div>
+            <div className="profile-callouts">{summaryCallouts}</div>
+          </div>
+        );
+      }
     }
 
     return (

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -9,7 +9,9 @@ import {
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
+import { NavLink } from 'react-router-dom';
 import { Role } from '../../reducers/states';
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
 import { AssessmentCategories, AssessmentCategory, AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
 
 type ProfileProps = DispatchProps & OwnProps & StateProps;
@@ -87,7 +89,15 @@ class Profile extends React.Component<ProfileProps> {
         .filter( (item) => item.status === AssessmentStatuses.submitted )
         .map( (item) => {
           return (
-            <Callout
+            // Make each card navigate the user to the respective assessment
+            <NavLink
+              className='profile-summary-navlink'
+              key={`${item.title}-${item.id}`}
+              target="_blank"
+              to={`/academy/${assessmentCategoryLink(item.category)}/${item.id}/0`}
+              activeClassName='profile-summary-navlink'
+            >
+              <Callout
                 className='profile-summary-callout'
                 key={`${item.title}-${item.id}`}
                 icon={renderIcon(item.category)}
@@ -117,7 +127,8 @@ class Profile extends React.Component<ProfileProps> {
                     value={item.xp / item.maxXp} />
                 </div>
               }
-            </Callout>
+              </Callout>
+            </NavLink>
           );
         });
 

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -1,4 +1,4 @@
-import { Drawer, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
+import { Drawer, NonIdealState, Spinner } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
@@ -81,17 +81,15 @@ class Profile extends React.Component<ProfileProps, {}> {
           return den <= 0 || num / den > 1 ? 1 : num / den;
         };
 
-        // Given a fraction between 0 and 1 inclusive, returns the corresponding Intent (colour)
-        const parseFrac = (frac: number): Intent => {
+        // Given a fraction between 0 and 1 inclusive, returns a className to apply colour with CSS
+        const parseColour = (frac: number): string => {
           return frac < 0
-            ? Intent.NONE
-            : frac >= 0.9
-            ? Intent.PRIMARY
+            ? ''
             : frac >= 0.8
-            ? Intent.SUCCESS
-            : frac >= 0.6
-            ? Intent.WARNING
-            : Intent.DANGER;
+            ? ' progress-steelblue'
+            : frac >= 0.45
+            ? ' progress-deepskyblue'
+            : ' progress-skyblue';
         };
 
         // Given an assessment category, return its icon
@@ -121,7 +119,7 @@ class Profile extends React.Component<ProfileProps, {}> {
                 key={index}
                 item={assessment}
                 getFrac={getFrac}
-                parseFrac={parseFrac}
+                parseColour={parseColour}
                 renderIcon={renderIcon}
               />
             );
@@ -134,8 +132,7 @@ class Profile extends React.Component<ProfileProps, {}> {
             <div className="profile-progress">
               <div className="profile-grade">
                 <Spinner
-                  className="profile-spinner"
-                  intent={parseFrac(getFrac(currentGrade, maxGrade))}
+                  className={'profile-spinner' + parseColour(getFrac(currentGrade, maxGrade))}
                   size={144}
                   value={getFrac(currentGrade, maxGrade)}
                 />
@@ -149,8 +146,7 @@ class Profile extends React.Component<ProfileProps, {}> {
               </div>
               <div className="profile-xp">
                 <Spinner
-                  className="profile-spinner"
-                  intent={parseFrac(getFrac(currentXp, maxXp))}
+                  className={'profile-spinner' + parseColour(getFrac(currentXp, maxXp))}
                   size={144}
                   value={getFrac(currentXp, maxXp)}
                 />

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -1,66 +1,113 @@
-import { Classes, Dialog, NonIdealState, ProgressBar, Spinner } from '@blueprintjs/core';
+import {
+  Drawer,
+  Intent,
+  NonIdealState,
+  Spinner
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
 import { Role } from '../../reducers/states';
+import { AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
 
 type ProfileProps = OwnProps & StateProps;
 
 export type StateProps = {
-  grade: number;
-  maxGrade: number;
-  maxXp: number;
+  assessmentOverviews?: IAssessmentOverview[];
   name?: string;
   role?: Role;
-  xp: number;
 };
 
-type OwnProps = {
+export type OwnProps = {
   isOpen: boolean;
   onClose: () => void;
 };
 
 class Profile extends React.Component<ProfileProps> {
   public render() {
-    const isLoaded = this.props.name && this.props.role;
+    const isLoaded = this.props.name && this.props.role && this.props.assessmentOverviews;
     let content: JSX.Element;
-    if (isLoaded) {
-      content = (
-        <>
-          <div className="header">
-            <div>
-              <span className="name">{this.props.name}</span>
-              <span className="role">{this.props.role}</span>
-            </div>
-          </div>
-          <div className="progress">
-            <div className="grade">
-              <span className="label">Grade</span>
-              <span className="value">{this.props.grade}</span>
-            </div>
-            <ProgressBar className="grade" animate={false} stripes={false} />
-            <div className="xp">
-              <span className="label">XP</span>
-              <span className="value">{this.props.xp}</span>
-            </div>
-            <ProgressBar className="xp" animate={false} stripes={false} />
-          </div>
-        </>
-      );
-    } else {
+
+    if (!isLoaded) {
       content = <NonIdealState description="Loading..." icon={<Spinner />} />;
+    } else {
+      // Compute the user's current total grade and XP from submitted assessments
+      const [currentGrade, currentXp, maxGrade, maxXp] = this.props.assessmentOverviews!.reduce(
+        (acc, item) =>
+          item.status === AssessmentStatuses.submitted
+            ? [acc[0] + item.grade, acc[1] + item.xp, acc[2] + item.maxGrade, acc[3] + item.maxXp]
+            : acc,
+        [0, 0, 0, 0]
+      );
+
+      const parseFrac = (frac: number): Intent => {
+        return frac < 0
+          ? Intent.NONE
+          : frac >= 0.9
+            ? Intent.PRIMARY
+            : frac >= 0.8
+              ? Intent.SUCCESS
+              : frac >= 0.6
+                ? Intent.WARNING
+                : Intent.DANGER;
+      };
+
+      // Compute the user's maximum total grade and XP from submitted assessments
+      content = (
+        <div className='profile-content'>
+          <div className="profile-header">
+            <div className="profile-username">
+              <div className="name">{this.props.name}</div>
+              <div className="role">{this.props.role}</div>
+            </div>
+          </div>
+          <div className="profile-progress">
+            <div className="profile-grade">
+              <Spinner
+                className="grade-spinner"
+                intent={parseFrac(currentGrade / maxGrade)}
+                size={144}
+                value={currentGrade / maxGrade}
+              />
+              <div className="type">Grade</div>
+              <div className="total-value">
+                {currentGrade} / {maxGrade}
+              </div>
+              <div className="percentage">{((currentGrade / maxGrade) * 100).toFixed(2)}%</div>
+            </div>
+            <div className="profile-xp">
+              <Spinner
+                className="xp-spinner"
+                intent={parseFrac(currentXp / maxXp)}
+                size={144}
+                value={currentXp / maxXp}
+              />
+              <div className="type">XP</div>
+              <div className="total-value">
+                {currentXp} / {maxXp}
+              </div>
+              <div className="percentage">{((currentXp / maxXp) * 100).toFixed(2)}%</div>
+            </div>
+          </div>
+        </div>
+      );
     }
+
     return (
-      <Dialog
-        className="profile"
+      <Drawer
+        className='profile'
+        canEscapeKeyClose={true}
+        canOutsideClickClose={true}
         icon={IconNames.USER}
-        isCloseButtonShown={false}
+        isCloseButtonShown={true}
         isOpen={this.props.isOpen}
         onClose={this.props.onClose}
-        title="Profile"
+        title="User Profile"
+        position="left"
+        size={'30%'}
       >
-        <div className={Classes.DIALOG_BODY}>{content}</div>
-      </Dialog>
+        {content}
+      </Drawer>
     );
   }
 }

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -55,6 +55,14 @@ class Profile extends React.Component<ProfileProps> {
         [0, 0, 0, 0]
       );
 
+      // Performs boundary checks if denominator is 0 or if it exceeds 1 (100%)
+      const getFrac = (num: number, den: number): number => {
+        return den <= 0 || num / den > 1
+          ? 1
+          : num / den;
+      };
+
+      // Given a fraction between 0 and 1 inclusive, returns the corresponding Intent (colour)
       const parseFrac = (frac: number): Intent => {
         return frac < 0
           ? Intent.NONE
@@ -67,6 +75,7 @@ class Profile extends React.Component<ProfileProps> {
                 : Intent.DANGER;
       };
 
+      // Given an assessment category, return its icon
       const renderIcon = (category: AssessmentCategory) => {
         switch (category) {
           case AssessmentCategories.Mission:
@@ -103,28 +112,28 @@ class Profile extends React.Component<ProfileProps> {
                 icon={renderIcon(item.category)}
                 title={item.title}
               >
-              {item.maxGrade <= 0 ? '' :
+              {item.maxGrade <= 0 && item.grade === 0 ? '' :
                 <div className='grade-details'>
                   <div className='title'>Grade</div>
                   <div className='value'>{item.grade} / {item.maxGrade}</div>
                   <ProgressBar
                     animate={false}
                     className='value-bar'
-                    intent={parseFrac(item.grade / item.maxGrade)}
+                    intent={parseFrac(getFrac(item.grade, item.maxGrade))}
                     stripes={false}
-                    value={item.grade / item.maxGrade} />
+                    value={getFrac(item.grade, item.maxGrade)} />
                 </div>
               }
-              {item.maxXp <= 0 ? '' :
+              {item.maxXp <= 0 && item.xp === 0 ? '' :
                 <div className='xp-details'>
                   <div className='title'>XP</div>
                   <div className='value'>{item.xp} / {item.maxXp}</div>
                   <ProgressBar
                     animate={false}
                     className='value-bar'
-                    intent={parseFrac(item.xp / item.maxXp)}
+                    intent={parseFrac(getFrac(item.xp, item.maxXp))}
                     stripes={false}
-                    value={item.xp / item.maxXp} />
+                    value={getFrac(item.xp, item.maxXp)} />
                 </div>
               }
               </Callout>
@@ -145,28 +154,28 @@ class Profile extends React.Component<ProfileProps> {
             <div className="profile-grade">
               <Spinner
                 className="grade-spinner"
-                intent={parseFrac(currentGrade / maxGrade)}
+                intent={parseFrac(getFrac(currentGrade, maxGrade))}
                 size={144}
-                value={currentGrade / maxGrade}
+                value={getFrac(currentGrade, maxGrade)}
               />
               <div className="type">Grade</div>
               <div className="total-value">
                 {currentGrade} / {maxGrade}
               </div>
-              <div className="percentage">{((currentGrade / maxGrade) * 100).toFixed(2)}%</div>
+              <div className="percentage">{(getFrac(currentGrade, maxGrade) * 100).toFixed(2)}%</div>
             </div>
             <div className="profile-xp">
               <Spinner
                 className="xp-spinner"
-                intent={parseFrac(currentXp / maxXp)}
+                intent={parseFrac(getFrac(currentXp, maxXp))}
                 size={144}
-                value={currentXp / maxXp}
+                value={getFrac(currentXp, maxXp)}
               />
               <div className="type">XP</div>
               <div className="total-value">
                 {currentXp} / {maxXp}
               </div>
-              <div className="percentage">{((currentXp / maxXp) * 100).toFixed(2)}%</div>
+              <div className="percentage">{(getFrac(currentXp, maxXp) * 100).toFixed(2)}%</div>
             </div>
           </div>
           <div className="profile-callouts">

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -14,9 +14,9 @@ import ProfileCard from './ProfileCard';
 type ProfileProps = DispatchProps & OwnProps & StateProps;
 
 export type StateProps = {
-  assessmentOverviews?: IAssessmentOverview[];
   name?: string;
   role?: Role;
+  assessmentOverviews?: IAssessmentOverview[];
 };
 
 export type OwnProps = {
@@ -134,7 +134,7 @@ class Profile extends React.Component<ProfileProps, {}> {
             <div className="profile-progress">
               <div className="profile-grade">
                 <Spinner
-                  className="grade-spinner"
+                  className="profile-spinner"
                   intent={parseFrac(getFrac(currentGrade, maxGrade))}
                   size={144}
                   value={getFrac(currentGrade, maxGrade)}
@@ -149,7 +149,7 @@ class Profile extends React.Component<ProfileProps, {}> {
               </div>
               <div className="profile-xp">
                 <Spinner
-                  className="xp-spinner"
+                  className="profile-spinner"
                   intent={parseFrac(getFrac(currentXp, maxXp))}
                   size={144}
                   value={getFrac(currentXp, maxXp)}

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -1,18 +1,16 @@
-import {
-  Callout,
-  Drawer,
-  Intent,
-  NonIdealState,
-  ProgressBar,
-  Spinner
-} from '@blueprintjs/core';
+import { Callout, Drawer, Intent, NonIdealState, ProgressBar, Spinner } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
 import { NavLink } from 'react-router-dom';
 import { Role } from '../../reducers/states';
 import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
-import { AssessmentCategories, AssessmentCategory, AssessmentStatuses, IAssessmentOverview } from '../assessment/assessmentShape';
+import {
+  AssessmentCategories,
+  AssessmentCategory,
+  AssessmentStatuses,
+  IAssessmentOverview
+} from '../assessment/assessmentShape';
 
 type ProfileProps = DispatchProps & OwnProps & StateProps;
 
@@ -57,9 +55,7 @@ class Profile extends React.Component<ProfileProps> {
 
       // Performs boundary checks if denominator is 0 or if it exceeds 1 (100%)
       const getFrac = (num: number, den: number): number => {
-        return den <= 0 || num / den > 1
-          ? 1
-          : num / den;
+        return den <= 0 || num / den > 1 ? 1 : num / den;
       };
 
       // Given a fraction between 0 and 1 inclusive, returns the corresponding Intent (colour)
@@ -67,12 +63,12 @@ class Profile extends React.Component<ProfileProps> {
         return frac < 0
           ? Intent.NONE
           : frac >= 0.9
-            ? Intent.PRIMARY
-            : frac >= 0.8
-              ? Intent.SUCCESS
-              : frac >= 0.6
-                ? Intent.WARNING
-                : Intent.DANGER;
+          ? Intent.PRIMARY
+          : frac >= 0.8
+          ? Intent.SUCCESS
+          : frac >= 0.6
+          ? Intent.WARNING
+          : Intent.DANGER;
       };
 
       // Given an assessment category, return its icon
@@ -90,52 +86,62 @@ class Profile extends React.Component<ProfileProps> {
             // For rendering hidden assessments not visible to the student
             // e.g. studio participation marks
             return IconNames.PULSE;
-          }
+        }
       };
 
       // Build condensed assessment cards from an array of assessments
-      const summaryCallouts = this.props.assessmentOverviews!
-        .filter( (item) => item.status === AssessmentStatuses.submitted )
-        .map( (item) => {
+      const summaryCallouts = this.props
+        .assessmentOverviews!.filter(item => item.status === AssessmentStatuses.submitted)
+        .map(item => {
           return (
             // Make each card navigate the user to the respective assessment
             <NavLink
-              className='profile-summary-navlink'
+              className="profile-summary-navlink"
               key={`${item.title}-${item.id}`}
               target="_blank"
               to={`/academy/${assessmentCategoryLink(item.category)}/${item.id}/0`}
-              activeClassName='profile-summary-navlink'
+              activeClassName="profile-summary-navlink"
             >
               <Callout
-                className='profile-summary-callout'
+                className="profile-summary-callout"
                 key={`${item.title}-${item.id}`}
                 icon={renderIcon(item.category)}
                 title={item.title}
               >
-              {item.maxGrade <= 0 && item.grade === 0 ? '' :
-                <div className='grade-details'>
-                  <div className='title'>Grade</div>
-                  <div className='value'>{item.grade} / {item.maxGrade}</div>
-                  <ProgressBar
-                    animate={false}
-                    className='value-bar'
-                    intent={parseFrac(getFrac(item.grade, item.maxGrade))}
-                    stripes={false}
-                    value={getFrac(item.grade, item.maxGrade)} />
-                </div>
-              }
-              {item.maxXp <= 0 && item.xp === 0 ? '' :
-                <div className='xp-details'>
-                  <div className='title'>XP</div>
-                  <div className='value'>{item.xp} / {item.maxXp}</div>
-                  <ProgressBar
-                    animate={false}
-                    className='value-bar'
-                    intent={parseFrac(getFrac(item.xp, item.maxXp))}
-                    stripes={false}
-                    value={getFrac(item.xp, item.maxXp)} />
-                </div>
-              }
+                {item.maxGrade <= 0 && item.grade === 0 ? (
+                  ''
+                ) : (
+                  <div className="grade-details">
+                    <div className="title">Grade</div>
+                    <div className="value">
+                      {item.grade} / {item.maxGrade}
+                    </div>
+                    <ProgressBar
+                      animate={false}
+                      className="value-bar"
+                      intent={parseFrac(getFrac(item.grade, item.maxGrade))}
+                      stripes={false}
+                      value={getFrac(item.grade, item.maxGrade)}
+                    />
+                  </div>
+                )}
+                {item.maxXp <= 0 && item.xp === 0 ? (
+                  ''
+                ) : (
+                  <div className="xp-details">
+                    <div className="title">XP</div>
+                    <div className="value">
+                      {item.xp} / {item.maxXp}
+                    </div>
+                    <ProgressBar
+                      animate={false}
+                      className="value-bar"
+                      intent={parseFrac(getFrac(item.xp, item.maxXp))}
+                      stripes={false}
+                      value={getFrac(item.xp, item.maxXp)}
+                    />
+                  </div>
+                )}
               </Callout>
             </NavLink>
           );
@@ -143,7 +149,7 @@ class Profile extends React.Component<ProfileProps> {
 
       // Compute the user's maximum total grade and XP from submitted assessments
       content = (
-        <div className='profile-content'>
+        <div className="profile-content">
           <div className="profile-header">
             <div className="profile-username">
               <div className="name">{this.props.name}</div>
@@ -162,7 +168,9 @@ class Profile extends React.Component<ProfileProps> {
               <div className="total-value">
                 {currentGrade} / {maxGrade}
               </div>
-              <div className="percentage">{(getFrac(currentGrade, maxGrade) * 100).toFixed(2)}%</div>
+              <div className="percentage">
+                {(getFrac(currentGrade, maxGrade) * 100).toFixed(2)}%
+              </div>
             </div>
             <div className="profile-xp">
               <Spinner
@@ -178,16 +186,14 @@ class Profile extends React.Component<ProfileProps> {
               <div className="percentage">{(getFrac(currentXp, maxXp) * 100).toFixed(2)}%</div>
             </div>
           </div>
-          <div className="profile-callouts">
-              {summaryCallouts}
-          </div>
+          <div className="profile-callouts">{summaryCallouts}</div>
         </div>
       );
     }
 
     return (
       <Drawer
-        className='profile'
+        className="profile"
         canEscapeKeyClose={true}
         canOutsideClickClose={true}
         icon={IconNames.USER}

--- a/src/components/dropdown/ProfileCard.tsx
+++ b/src/components/dropdown/ProfileCard.tsx
@@ -4,7 +4,11 @@ import * as React from 'react';
 
 import { NavLink } from 'react-router-dom';
 import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
-import { AssessmentCategory, IAssessmentOverview } from '../assessment/assessmentShape';
+import {
+  AssessmentCategories,
+  AssessmentCategory,
+  IAssessmentOverview
+} from '../assessment/assessmentShape';
 
 type ProfileCardProps = {
   item: IAssessmentOverview;
@@ -30,7 +34,8 @@ class ProfileCard extends React.Component<ProfileCardProps, {}> {
           icon={this.props.renderIcon(this.props.item.category)}
           title={this.props.item.title}
         >
-          {this.props.item.maxGrade <= 0 && this.props.item.grade === 0 ? (
+          {this.props.item.category !== AssessmentCategories.Mission ||
+          (this.props.item.maxGrade <= 0 && this.props.item.grade === 0) ? (
             ''
           ) : (
             <div className="grade-details">

--- a/src/components/dropdown/ProfileCard.tsx
+++ b/src/components/dropdown/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import { Callout, Intent, ProgressBar } from '@blueprintjs/core';
+import { Callout, ProgressBar } from '@blueprintjs/core';
 import { IconName } from '@blueprintjs/icons';
 import * as React from 'react';
 
@@ -9,7 +9,7 @@ import { AssessmentCategory, IAssessmentOverview } from '../assessment/assessmen
 type ProfileCardProps = {
   item: IAssessmentOverview;
   getFrac: (num: number, den: number) => number;
-  parseFrac: (frac: number) => Intent;
+  parseColour: (frac: number) => string;
   renderIcon: (category: AssessmentCategory) => IconName;
 };
 
@@ -40,10 +40,12 @@ class ProfileCard extends React.Component<ProfileCardProps, {}> {
               </div>
               <ProgressBar
                 animate={false}
-                className="value-bar"
-                intent={this.props.parseFrac(
-                  this.props.getFrac(this.props.item.grade, this.props.item.maxGrade)
-                )}
+                className={
+                  'value-bar' +
+                  this.props.parseColour(
+                    this.props.getFrac(this.props.item.grade, this.props.item.maxGrade)
+                  )
+                }
                 stripes={false}
                 value={this.props.getFrac(this.props.item.grade, this.props.item.maxGrade)}
               />
@@ -59,10 +61,12 @@ class ProfileCard extends React.Component<ProfileCardProps, {}> {
               </div>
               <ProgressBar
                 animate={false}
-                className="value-bar"
-                intent={this.props.parseFrac(
-                  this.props.getFrac(this.props.item.xp, this.props.item.maxXp)
-                )}
+                className={
+                  'value-bar' +
+                  this.props.parseColour(
+                    this.props.getFrac(this.props.item.xp, this.props.item.maxXp)
+                  )
+                }
                 stripes={false}
                 value={this.props.getFrac(this.props.item.xp, this.props.item.maxXp)}
               />

--- a/src/components/dropdown/ProfileCard.tsx
+++ b/src/components/dropdown/ProfileCard.tsx
@@ -1,0 +1,77 @@
+import { Callout, Intent, ProgressBar } from '@blueprintjs/core';
+import { IconName } from '@blueprintjs/icons';
+import * as React from 'react';
+
+import { NavLink } from 'react-router-dom';
+import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
+import { AssessmentCategory, IAssessmentOverview } from '../assessment/assessmentShape';
+
+type ProfileCardProps = {
+  item: IAssessmentOverview;
+  getFrac: (num: number, den: number) => number;
+  parseFrac: (frac: number) => Intent;
+  renderIcon: (category: AssessmentCategory) => IconName;
+};
+
+class ProfileCard extends React.Component<ProfileCardProps, {}> {
+  public render() {
+    return (
+      // Make each card navigate the user to the respective assessment
+      <NavLink
+        className="profile-summary-navlink"
+        key={`${this.props.item.title}-${this.props.item.id}`}
+        target="_blank"
+        to={`/academy/${assessmentCategoryLink(this.props.item.category)}/${this.props.item.id}/0`}
+        activeClassName="profile-summary-navlink"
+      >
+        <Callout
+          className="profile-summary-callout"
+          key={`${this.props.item.title}-${this.props.item.id}`}
+          icon={this.props.renderIcon(this.props.item.category)}
+          title={this.props.item.title}
+        >
+          {this.props.item.maxGrade <= 0 && this.props.item.grade === 0 ? (
+            ''
+          ) : (
+            <div className="grade-details">
+              <div className="title">Grade</div>
+              <div className="value">
+                {this.props.item.grade} / {this.props.item.maxGrade}
+              </div>
+              <ProgressBar
+                animate={false}
+                className="value-bar"
+                intent={this.props.parseFrac(
+                  this.props.getFrac(this.props.item.grade, this.props.item.maxGrade)
+                )}
+                stripes={false}
+                value={this.props.getFrac(this.props.item.grade, this.props.item.maxGrade)}
+              />
+            </div>
+          )}
+          {this.props.item.maxXp <= 0 && this.props.item.xp === 0 ? (
+            ''
+          ) : (
+            <div className="xp-details">
+              <div className="title">XP</div>
+              <div className="value">
+                {this.props.item.xp} / {this.props.item.maxXp}
+              </div>
+              <ProgressBar
+                animate={false}
+                className="value-bar"
+                intent={this.props.parseFrac(
+                  this.props.getFrac(this.props.item.xp, this.props.item.maxXp)
+                )}
+                stripes={false}
+                value={this.props.getFrac(this.props.item.xp, this.props.item.maxXp)}
+              />
+            </div>
+          )}
+        </Callout>
+      </NavLink>
+    );
+  }
+}
+
+export default ProfileCard;

--- a/src/components/dropdown/__tests__/Profile.tsx
+++ b/src/components/dropdown/__tests__/Profile.tsx
@@ -15,6 +15,7 @@ test('Profile renders "no XP, no Grade and Staff role" correctly', () => {
     role: Role.Staff,
     xp: 0,
     isOpen: true,
+    handleAssessmentOverviewFetch: () => {},
     onClose: () => {}
   };
   const tree = shallow(<Profile {...props} />);
@@ -30,6 +31,7 @@ test('Profile renders "no XP, no Grade and Student role" correctly', () => {
     role: Role.Student,
     xp: 0,
     isOpen: true,
+    handleAssessmentOverviewFetch: () => {},
     onClose: () => {}
   };
   const tree = shallow(<Profile {...props} />);
@@ -45,6 +47,7 @@ test('Profile renders with XP, Grade and Student role" correctly', () => {
     role: Role.Student,
     xp: 66,
     isOpen: true,
+    handleAssessmentOverviewFetch: () => {},
     onClose: () => {}
   };
   const tree = shallow(<Profile {...props} />);
@@ -60,6 +63,7 @@ test('Profile renders with XP, Grade and Staff role" correctly', () => {
     role: Role.Staff,
     xp: 66,
     isOpen: true,
+    handleAssessmentOverviewFetch: () => {},
     onClose: () => {}
   };
   const tree = shallow(<Profile {...props} />);

--- a/src/components/dropdown/__tests__/Profile.tsx
+++ b/src/components/dropdown/__tests__/Profile.tsx
@@ -94,9 +94,9 @@ test('Profile renders correctly when there are closed assessments', () => {
     mockAssessmentOverviews.length - mockNoClosedAssessmentOverviews.length;
   expect(tree.find('.profile-summary-navlink').hostNodes()).toHaveLength(numClosedAssessments);
   expect(tree.find('.profile-summary-callout').hostNodes()).toHaveLength(numClosedAssessments);
-  expect(tree.find('.grade-details').hostNodes()).toHaveLength(3);
+  expect(tree.find('.grade-details').hostNodes()).toHaveLength(1);
   expect(tree.find('.xp-details').hostNodes()).toHaveLength(4);
   ['.title', '.value', '.value-bar'].forEach(className => {
-    expect(tree.find(className).hostNodes()).toHaveLength(7);
+    expect(tree.find(className).hostNodes()).toHaveLength(5);
   });
 });

--- a/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
+++ b/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
@@ -1,149 +1,433 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Profile renders "no XP, no Grade and Staff role" correctly 1`] = `
-"<Blueprint3.Dialog className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={false} isOpen={true} onClose={[Function: onClose]} title=\\"Profile\\" canOutsideClickClose={true}>
-  <div className=\\"bp3-dialog-body\\">
-    <div className=\\"header\\">
-      <div>
-        <span className=\\"name\\">
-          yeet
-        </span>
-        <span className=\\"role\\">
-          staff
-        </span>
-      </div>
-    </div>
-    <div className=\\"progress\\">
-      <div className=\\"grade\\">
-        <span className=\\"label\\">
-          Grade
-        </span>
-        <span className=\\"value\\">
-          0
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"grade\\" animate={false} stripes={false} />
-      <div className=\\"xp\\">
-        <span className=\\"label\\">
-          XP
-        </span>
-        <span className=\\"value\\">
-          0
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"xp\\" animate={false} stripes={false} />
-    </div>
-  </div>
-</Blueprint3.Dialog>"
+exports[`Profile renders correctly when there are closed assessments 1`] = `
+"<MemoryRouter initialEntries={{...}}>
+  <Router history={{...}}>
+    <Profile name=\\"yeeet\\" role=\\"staff\\" assessmentOverviews={{...}} isOpen={true} handleAssessmentOverviewFetch={[Function: handleAssessmentOverviewFetch]} onClose={[Function: onClose]}>
+      <Blueprint3.Drawer className=\\"profile\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false}>
+        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
+          <Blueprint3.Portal className={[undefined]} container={{...}}>
+            <Portal containerInfo={{...}}>
+              <TransitionGroup appear={true} className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" component=\\"div\\" onKeyDown={[Function]} childFactory={[Function: childFactory]}>
+                <div className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" onKeyDown={[Function]}>
+                  <CSSTransition classNames=\\"bp3-overlay\\" timeout={300} onExited={[Function: bound bound handleExited]} in={true} appear={true} enter={[undefined]} exit={[undefined]}>
+                    <Transition timeout={300} onExited={[Function]} in={true} appear={true} enter={true} exit={true} onEnter={[Function]} onEntered={[Function]} onEntering={[Function]} onExit={[Function]} onExiting={[Function]} mountOnEnter={false} unmountOnExit={false}>
+                      <div className=\\"bp3-overlay-backdrop\\" onMouseDown={[Function]} tabIndex={0} />
+                    </Transition>
+                  </CSSTransition>
+                  <CSSTransition classNames=\\"bp3-overlay\\" onEntering={[undefined]} onEntered={[undefined]} onExiting={[undefined]} onExited={[Function: bound bound handleExited]} timeout={300} in={true} appear={true} enter={[undefined]} exit={[undefined]}>
+                    <Transition onEntering={[Function]} onEntered={[Function]} onExiting={[Function]} onExited={[Function]} timeout={300} in={true} appear={true} enter={true} exit={true} onEnter={[Function]} onExit={[Function]} mountOnEnter={false} unmountOnExit={false}>
+                      <div className=\\"bp3-drawer bp3-position-left profile bp3-overlay-content\\" style={{...}} tabIndex={0}>
+                        <div className=\\"bp3-drawer-header\\">
+                          <Blueprint3.Icon icon=\\"user\\" iconSize={20}>
+                            <span icon=\\"user\\" className=\\"bp3-icon bp3-icon-user\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"user\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                <desc>
+                                  user
+                                </desc>
+                                <path d=\\"M10 0C4.48 0 0 4.48 0 10c0 .33.02.65.05.97.01.12.03.23.05.35.03.2.05.4.09.59.03.14.06.28.1.42l.12.48c.05.16.1.31.15.46.05.13.09.27.15.4.06.16.13.32.21.48.05.11.1.22.16.33.09.17.17.34.27.5.05.09.1.17.15.25.11.18.22.35.34.52.04.06.08.11.12.17 1.19 1.62 2.85 2.86 4.78 3.53l.09.03c.46.15.93.27 1.42.36.08.01.17.03.25.04.49.07.99.12 1.5.12s1.01-.05 1.5-.12c.08-.01.17-.02.25-.04.49-.09.96-.21 1.42-.36l.09-.03c1.93-.67 3.59-1.91 4.78-3.53.04-.05.08-.1.12-.16.12-.17.23-.35.34-.53.05-.08.1-.16.15-.25.1-.17.19-.34.27-.51.05-.11.1-.21.15-.32.07-.16.14-.32.21-.49.05-.13.1-.26.14-.39.05-.15.11-.31.15-.46.05-.16.08-.32.12-.48.03-.14.07-.28.1-.42.04-.19.06-.39.09-.59.02-.12.04-.23.05-.35.05-.32.07-.64.07-.97 0-5.52-4.48-10-10-10zm0 18a7.94 7.94 0 0 1-6.15-2.89c.84-.44 1.86-.82 2.67-1.19 1.45-.65 1.3-1.05 1.35-1.59.01-.07.01-.14.01-.21-.51-.45-.93-1.08-1.2-1.8l-.01-.01c0-.01-.01-.02-.01-.03a4.42 4.42 0 0 1-.15-.48c-.33-.07-.53-.44-.61-.79-.08-.14-.23-.48-.2-.87.05-.51.26-.74.49-.83v-.08c0-.63.06-1.55.17-2.15.02-.17.06-.33.11-.5.21-.73.66-1.4 1.26-1.86.62-.47 1.5-.72 2.28-.72.78 0 1.65.25 2.27.73.6.46 1.05 1.12 1.26 1.86.05.16.08.33.11.5.11.6.17 1.51.17 2.15v.09c.22.1.42.33.46.82.04.39-.12.73-.2.87-.07.34-.27.71-.6.78-.04.16-.09.33-.15.48 0 .01-.02.05-.02.05-.26.71-.67 1.33-1.17 1.78 0 .08.01.16.01.23.05.54-.15.94 1.31 1.59.81.36 1.84.74 2.68 1.19A7.958 7.958 0 0 1 10 18z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                          <Component>
+                            <h4 className=\\"bp3-heading\\">
+                              User Profile
+                            </h4>
+                          </Component>
+                          <Blueprint3.Button aria-label=\\"Close\\" className=\\"bp3-dialog-close-button\\" icon={{...}} minimal={true} onClick={[Function: onClose]}>
+                            <button type=\\"button\\" aria-label=\\"Close\\" className=\\"bp3-button bp3-minimal bp3-dialog-close-button\\" onClick={[Function: onClose]} disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                              <Blueprint3.Icon icon={{...}}>
+                                <Blueprint3.Icon icon=\\"small-cross\\" iconSize={20}>
+                                  <span icon=\\"small-cross\\" className=\\"bp3-icon bp3-icon-small-cross\\" title={[undefined]}>
+                                    <svg fill={[undefined]} data-icon=\\"small-cross\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                      <desc>
+                                        small-cross
+                                      </desc>
+                                      <path d=\\"M11.41 10l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 0 0-1.71-.71L10 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42L8.59 10 5.3 13.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l3.29-3.3 3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71L11.41 10z\\" fillRule=\\"evenodd\\" />
+                                    </svg>
+                                  </span>
+                                </Blueprint3.Icon>
+                              </Blueprint3.Icon>
+                              <Blueprint3.Icon icon={[undefined]} />
+                            </button>
+                          </Blueprint3.Button>
+                        </div>
+                        <div className=\\"profile-content\\">
+                          <div className=\\"profile-header\\">
+                            <div className=\\"profile-username\\">
+                              <div className=\\"name\\">
+                                yeeet
+                              </div>
+                              <div className=\\"role\\">
+                                staff
+                              </div>
+                            </div>
+                          </div>
+                          <div className=\\"profile-progress\\">
+                            <div className=\\"profile-grade\\">
+                              <Blueprint3.Spinner className=\\"profile-spinner\\" intent=\\"success\\" size={144} value={0.8656716417910447}>
+                                <div className=\\"bp3-spinner bp3-intent-success bp3-no-spin profile-spinner\\">
+                                  <div className=\\"bp3-spinner-animation\\">
+                                    <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
+                                      <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={37.61194029850748} />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </Blueprint3.Spinner>
+                              <div className=\\"type\\">
+                                Grade
+                              </div>
+                              <div className=\\"total-value\\">
+                                5800
+                                 / 
+                                6700
+                              </div>
+                              <div className=\\"percentage\\">
+                                86.57
+                                %
+                              </div>
+                            </div>
+                            <div className=\\"profile-xp\\">
+                              <Blueprint3.Spinner className=\\"profile-spinner\\" intent=\\"warning\\" size={144} value={0.79}>
+                                <div className=\\"bp3-spinner bp3-intent-warning bp3-no-spin profile-spinner\\">
+                                  <div className=\\"bp3-spinner-animation\\">
+                                    <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
+                                      <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={58.79999999999998} />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </Blueprint3.Spinner>
+                              <div className=\\"type\\">
+                                XP
+                              </div>
+                              <div className=\\"total-value\\">
+                                1975
+                                 / 
+                                2500
+                              </div>
+                              <div className=\\"percentage\\">
+                                79.00
+                                %
+                              </div>
+                            </div>
+                          </div>
+                          <div className=\\"profile-callouts\\">
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/missions/4/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
+                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/4\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                  <Link to=\\"/academy/missions/4/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
+                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/missions/4/0\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"flame\\" title=\\"A closed Mission\\">
+                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
+                                          <Blueprint3.Icon icon=\\"flame\\" iconSize={20}>
+                                            <span icon=\\"flame\\" className=\\"bp3-icon bp3-icon-flame\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"flame\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                                <desc>
+                                                  flame
+                                                </desc>
+                                                <path d=\\"M11.622 0c0 1.71.49 3.077 1.472 4.103C16.364 6.496 18 9.23 18 12.308c0 3.418-1.962 5.983-5.887 7.692 2.887-3 2.453-4.23-.49-8C8.5 13.5 9 14.5 9.5 16.5c-1.048 0-2 0-2.5-.5 0 .684 1.197 2.5 1.952 4-3.924-1.026-8.123-7.18-6.651-7.692.981-.342 2.126-.171 3.434.513C4.1 6.667 6.062 2.393 11.622 0z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <Component>
+                                            <h4 className=\\"bp3-heading\\">
+                                              A closed Mission
+                                            </h4>
+                                          </Component>
+                                          <div className=\\"grade-details\\">
+                                            <div className=\\"title\\">
+                                              Grade
+                                            </div>
+                                            <div className=\\"value\\">
+                                              2850
+                                               / 
+                                              3000
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"primary\\" stripes={false} value={0.95}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-primary bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                          <div className=\\"xp-details\\">
+                                            <div className=\\"title\\">
+                                              XP
+                                            </div>
+                                            <div className=\\"value\\">
+                                              850
+                                               / 
+                                              1000
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"success\\" stripes={false} value={0.85}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-success bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                        </div>
+                                      </Blueprint3.Callout>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </ProfileCard>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
+                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                  <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
+                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/quests/5/0\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Closed (partially graded) Sidequest\\">
+                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
+                                          <Blueprint3.Icon icon=\\"lightbulb\\" iconSize={20}>
+                                            <span icon=\\"lightbulb\\" className=\\"bp3-icon bp3-icon-lightbulb\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"lightbulb\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                                <desc>
+                                                  lightbulb
+                                                </desc>
+                                                <path d=\\"M6.33 13.39c0 .34.27.61.6.61h6.13c.33 0 .6-.27.6-.61C14.03 9.78 16 9.4 16 6.09 16 2.72 13.31 0 10 0S4 2.72 4 6.09c0 3.31 1.97 3.69 2.33 7.3zM13 15H7c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1zm-1 3H8c-.55 0-1 .45-1 1s.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <Component>
+                                            <h4 className=\\"bp3-heading\\">
+                                              Closed (partially graded) Sidequest
+                                            </h4>
+                                          </Component>
+                                          <div className=\\"grade-details\\">
+                                            <div className=\\"title\\">
+                                              Grade
+                                            </div>
+                                            <div className=\\"value\\">
+                                              2500
+                                               / 
+                                              3000
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"success\\" stripes={false} value={0.8333333333333334}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-success bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                          <div className=\\"xp-details\\">
+                                            <div className=\\"title\\">
+                                              XP
+                                            </div>
+                                            <div className=\\"value\\">
+                                              750
+                                               / 
+                                              1000
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"warning\\" stripes={false} value={0.75}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-warning bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                        </div>
+                                      </Blueprint3.Callout>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </ProfileCard>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
+                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                  <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
+                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/quests/5/0\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Closed (fully graded) Sidequest\\">
+                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
+                                          <Blueprint3.Icon icon=\\"lightbulb\\" iconSize={20}>
+                                            <span icon=\\"lightbulb\\" className=\\"bp3-icon bp3-icon-lightbulb\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"lightbulb\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                                <desc>
+                                                  lightbulb
+                                                </desc>
+                                                <path d=\\"M6.33 13.39c0 .34.27.61.6.61h6.13c.33 0 .6-.27.6-.61C14.03 9.78 16 9.4 16 6.09 16 2.72 13.31 0 10 0S4 2.72 4 6.09c0 3.31 1.97 3.69 2.33 7.3zM13 15H7c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1zm-1 3H8c-.55 0-1 .45-1 1s.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <Component>
+                                            <h4 className=\\"bp3-heading\\">
+                                              Closed (fully graded) Sidequest
+                                            </h4>
+                                          </Component>
+                                          <div className=\\"grade-details\\">
+                                            <div className=\\"title\\">
+                                              Grade
+                                            </div>
+                                            <div className=\\"value\\">
+                                              450
+                                               / 
+                                              700
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"warning\\" stripes={false} value={0.6428571428571429}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-warning bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                          <div className=\\"xp-details\\">
+                                            <div className=\\"title\\">
+                                              XP
+                                            </div>
+                                            <div className=\\"value\\">
+                                              275
+                                               / 
+                                              500
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"danger\\" stripes={false} value={0.55}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-danger bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                        </div>
+                                      </Blueprint3.Callout>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </ProfileCard>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
+                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                  <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
+                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/quests/5/0\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Ungraded assessment\\">
+                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
+                                          <Blueprint3.Icon icon=\\"lightbulb\\" iconSize={20}>
+                                            <span icon=\\"lightbulb\\" className=\\"bp3-icon bp3-icon-lightbulb\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"lightbulb\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                                <desc>
+                                                  lightbulb
+                                                </desc>
+                                                <path d=\\"M6.33 13.39c0 .34.27.61.6.61h6.13c.33 0 .6-.27.6-.61C14.03 9.78 16 9.4 16 6.09 16 2.72 13.31 0 10 0S4 2.72 4 6.09c0 3.31 1.97 3.69 2.33 7.3zM13 15H7c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1zm-1 3H8c-.55 0-1 .45-1 1s.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <Component>
+                                            <h4 className=\\"bp3-heading\\">
+                                              Ungraded assessment
+                                            </h4>
+                                          </Component>
+                                          <div className=\\"xp-details\\">
+                                            <div className=\\"title\\">
+                                              XP
+                                            </div>
+                                            <div className=\\"value\\">
+                                              100
+                                               / 
+                                              0
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"primary\\" stripes={false} value={1}>
+                                              <div className=\\"bp3-progress-bar bp3-intent-primary bp3-no-animation bp3-no-stripes value-bar\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                        </div>
+                                      </Blueprint3.Callout>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </ProfileCard>
+                          </div>
+                        </div>
+                      </div>
+                    </Transition>
+                  </CSSTransition>
+                </div>
+              </TransitionGroup>
+            </Portal>
+          </Blueprint3.Portal>
+        </Blueprint3.Overlay>
+      </Blueprint3.Drawer>
+    </Profile>
+  </Router>
+</MemoryRouter>"
 `;
 
-exports[`Profile renders "no XP, no Grade and Student role" correctly 1`] = `
-"<Blueprint3.Dialog className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={false} isOpen={true} onClose={[Function: onClose]} title=\\"Profile\\" canOutsideClickClose={true}>
-  <div className=\\"bp3-dialog-body\\">
-    <div className=\\"header\\">
-      <div>
-        <span className=\\"name\\">
-          yeeet
-        </span>
-        <span className=\\"role\\">
-          student
-        </span>
-      </div>
-    </div>
-    <div className=\\"progress\\">
-      <div className=\\"grade\\">
-        <span className=\\"label\\">
-          Grade
-        </span>
-        <span className=\\"value\\">
-          0
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"grade\\" animate={false} stripes={false} />
-      <div className=\\"xp\\">
-        <span className=\\"label\\">
-          XP
-        </span>
-        <span className=\\"value\\">
-          0
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"xp\\" animate={false} stripes={false} />
-    </div>
-  </div>
-</Blueprint3.Dialog>"
-`;
-
-exports[`Profile renders with XP, Grade and Staff role" correctly 1`] = `
-"<Blueprint3.Dialog className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={false} isOpen={true} onClose={[Function: onClose]} title=\\"Profile\\" canOutsideClickClose={true}>
-  <div className=\\"bp3-dialog-body\\">
-    <div className=\\"header\\">
-      <div>
-        <span className=\\"name\\">
-          yeeeeet
-        </span>
-        <span className=\\"role\\">
-          staff
-        </span>
-      </div>
-    </div>
-    <div className=\\"progress\\">
-      <div className=\\"grade\\">
-        <span className=\\"label\\">
-          Grade
-        </span>
-        <span className=\\"value\\">
-          33
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"grade\\" animate={false} stripes={false} />
-      <div className=\\"xp\\">
-        <span className=\\"label\\">
-          XP
-        </span>
-        <span className=\\"value\\">
-          66
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"xp\\" animate={false} stripes={false} />
-    </div>
-  </div>
-</Blueprint3.Dialog>"
-`;
-
-exports[`Profile renders with XP, Grade and Student role" correctly 1`] = `
-"<Blueprint3.Dialog className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={false} isOpen={true} onClose={[Function: onClose]} title=\\"Profile\\" canOutsideClickClose={true}>
-  <div className=\\"bp3-dialog-body\\">
-    <div className=\\"header\\">
-      <div>
-        <span className=\\"name\\">
-          yeeeet
-        </span>
-        <span className=\\"role\\">
-          student
-        </span>
-      </div>
-    </div>
-    <div className=\\"progress\\">
-      <div className=\\"grade\\">
-        <span className=\\"label\\">
-          Grade
-        </span>
-        <span className=\\"value\\">
-          33
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"grade\\" animate={false} stripes={false} />
-      <div className=\\"xp\\">
-        <span className=\\"label\\">
-          XP
-        </span>
-        <span className=\\"value\\">
-          66
-        </span>
-      </div>
-      <Blueprint3.ProgressBar className=\\"xp\\" animate={false} stripes={false} />
-    </div>
-  </div>
-</Blueprint3.Dialog>"
+exports[`Profile renders correctly when there are no closed assessments 1`] = `
+"<MemoryRouter initialEntries={{...}}>
+  <Router history={{...}}>
+    <Profile name=\\"yeet\\" role=\\"student\\" assessmentOverviews={{...}} isOpen={true} handleAssessmentOverviewFetch={[Function: handleAssessmentOverviewFetch]} onClose={[Function: onClose]}>
+      <Blueprint3.Drawer className=\\"profile\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false}>
+        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
+          <Blueprint3.Portal className={[undefined]} container={{...}}>
+            <Portal containerInfo={{...}}>
+              <TransitionGroup appear={true} className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" component=\\"div\\" onKeyDown={[Function]} childFactory={[Function: childFactory]}>
+                <div className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" onKeyDown={[Function]}>
+                  <CSSTransition classNames=\\"bp3-overlay\\" timeout={300} onExited={[Function: bound bound handleExited]} in={true} appear={true} enter={[undefined]} exit={[undefined]}>
+                    <Transition timeout={300} onExited={[Function]} in={true} appear={true} enter={true} exit={true} onEnter={[Function]} onEntered={[Function]} onEntering={[Function]} onExit={[Function]} onExiting={[Function]} mountOnEnter={false} unmountOnExit={false}>
+                      <div className=\\"bp3-overlay-backdrop\\" onMouseDown={[Function]} tabIndex={0} />
+                    </Transition>
+                  </CSSTransition>
+                  <CSSTransition classNames=\\"bp3-overlay\\" onEntering={[undefined]} onEntered={[undefined]} onExiting={[undefined]} onExited={[Function: bound bound handleExited]} timeout={300} in={true} appear={true} enter={[undefined]} exit={[undefined]}>
+                    <Transition onEntering={[Function]} onEntered={[Function]} onExiting={[Function]} onExited={[Function]} timeout={300} in={true} appear={true} enter={true} exit={true} onEnter={[Function]} onExit={[Function]} mountOnEnter={false} unmountOnExit={false}>
+                      <div className=\\"bp3-drawer bp3-position-left profile bp3-overlay-content\\" style={{...}} tabIndex={0}>
+                        <div className=\\"bp3-drawer-header\\">
+                          <Blueprint3.Icon icon=\\"user\\" iconSize={20}>
+                            <span icon=\\"user\\" className=\\"bp3-icon bp3-icon-user\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"user\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                <desc>
+                                  user
+                                </desc>
+                                <path d=\\"M10 0C4.48 0 0 4.48 0 10c0 .33.02.65.05.97.01.12.03.23.05.35.03.2.05.4.09.59.03.14.06.28.1.42l.12.48c.05.16.1.31.15.46.05.13.09.27.15.4.06.16.13.32.21.48.05.11.1.22.16.33.09.17.17.34.27.5.05.09.1.17.15.25.11.18.22.35.34.52.04.06.08.11.12.17 1.19 1.62 2.85 2.86 4.78 3.53l.09.03c.46.15.93.27 1.42.36.08.01.17.03.25.04.49.07.99.12 1.5.12s1.01-.05 1.5-.12c.08-.01.17-.02.25-.04.49-.09.96-.21 1.42-.36l.09-.03c1.93-.67 3.59-1.91 4.78-3.53.04-.05.08-.1.12-.16.12-.17.23-.35.34-.53.05-.08.1-.16.15-.25.1-.17.19-.34.27-.51.05-.11.1-.21.15-.32.07-.16.14-.32.21-.49.05-.13.1-.26.14-.39.05-.15.11-.31.15-.46.05-.16.08-.32.12-.48.03-.14.07-.28.1-.42.04-.19.06-.39.09-.59.02-.12.04-.23.05-.35.05-.32.07-.64.07-.97 0-5.52-4.48-10-10-10zm0 18a7.94 7.94 0 0 1-6.15-2.89c.84-.44 1.86-.82 2.67-1.19 1.45-.65 1.3-1.05 1.35-1.59.01-.07.01-.14.01-.21-.51-.45-.93-1.08-1.2-1.8l-.01-.01c0-.01-.01-.02-.01-.03a4.42 4.42 0 0 1-.15-.48c-.33-.07-.53-.44-.61-.79-.08-.14-.23-.48-.2-.87.05-.51.26-.74.49-.83v-.08c0-.63.06-1.55.17-2.15.02-.17.06-.33.11-.5.21-.73.66-1.4 1.26-1.86.62-.47 1.5-.72 2.28-.72.78 0 1.65.25 2.27.73.6.46 1.05 1.12 1.26 1.86.05.16.08.33.11.5.11.6.17 1.51.17 2.15v.09c.22.1.42.33.46.82.04.39-.12.73-.2.87-.07.34-.27.71-.6.78-.04.16-.09.33-.15.48 0 .01-.02.05-.02.05-.26.71-.67 1.33-1.17 1.78 0 .08.01.16.01.23.05.54-.15.94 1.31 1.59.81.36 1.84.74 2.68 1.19A7.958 7.958 0 0 1 10 18z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                          <Component>
+                            <h4 className=\\"bp3-heading\\">
+                              User Profile
+                            </h4>
+                          </Component>
+                          <Blueprint3.Button aria-label=\\"Close\\" className=\\"bp3-dialog-close-button\\" icon={{...}} minimal={true} onClick={[Function: onClose]}>
+                            <button type=\\"button\\" aria-label=\\"Close\\" className=\\"bp3-button bp3-minimal bp3-dialog-close-button\\" onClick={[Function: onClose]} disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                              <Blueprint3.Icon icon={{...}}>
+                                <Blueprint3.Icon icon=\\"small-cross\\" iconSize={20}>
+                                  <span icon=\\"small-cross\\" className=\\"bp3-icon bp3-icon-small-cross\\" title={[undefined]}>
+                                    <svg fill={[undefined]} data-icon=\\"small-cross\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                      <desc>
+                                        small-cross
+                                      </desc>
+                                      <path d=\\"M11.41 10l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 0 0-1.71-.71L10 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42L8.59 10 5.3 13.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l3.29-3.3 3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71L11.41 10z\\" fillRule=\\"evenodd\\" />
+                                    </svg>
+                                  </span>
+                                </Blueprint3.Icon>
+                              </Blueprint3.Icon>
+                              <Blueprint3.Icon icon={[undefined]} />
+                            </button>
+                          </Blueprint3.Button>
+                        </div>
+                        <div className=\\"profile-content\\">
+                          <div className=\\"profile-header\\">
+                            <div className=\\"profile-username\\">
+                              <div className=\\"name\\">
+                                yeet
+                              </div>
+                              <div className=\\"role\\">
+                                student
+                              </div>
+                            </div>
+                          </div>
+                          <div className=\\"profile-placeholder\\">
+                            There are no closed assessments to render grade and XP of.
+                          </div>
+                        </div>
+                      </div>
+                    </Transition>
+                  </CSSTransition>
+                </div>
+              </TransitionGroup>
+            </Portal>
+          </Blueprint3.Portal>
+        </Blueprint3.Overlay>
+      </Blueprint3.Drawer>
+    </Profile>
+  </Router>
+</MemoryRouter>"
 `;

--- a/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
+++ b/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
@@ -65,12 +65,12 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                           </div>
                           <div className=\\"profile-progress\\">
                             <div className=\\"profile-grade\\">
-                              <Blueprint3.Spinner className=\\"profile-spinner\\" intent=\\"success\\" size={144} value={0.8656716417910447}>
-                                <div className=\\"bp3-spinner bp3-intent-success bp3-no-spin profile-spinner\\">
+                              <Blueprint3.Spinner className=\\"profile-spinner progress-steelblue\\" size={144} value={0.9}>
+                                <div className=\\"bp3-spinner bp3-no-spin profile-spinner progress-steelblue\\">
                                   <div className=\\"bp3-spinner-animation\\">
                                     <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
                                       <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
-                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={37.61194029850748} />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={28} />
                                     </svg>
                                   </div>
                                 </div>
@@ -79,22 +79,22 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 Grade
                               </div>
                               <div className=\\"total-value\\">
-                                5800
+                                2700
                                  / 
-                                6700
+                                3000
                               </div>
                               <div className=\\"percentage\\">
-                                86.57
+                                90.00
                                 %
                               </div>
                             </div>
                             <div className=\\"profile-xp\\">
-                              <Blueprint3.Spinner className=\\"profile-spinner\\" intent=\\"warning\\" size={144} value={0.79}>
-                                <div className=\\"bp3-spinner bp3-intent-warning bp3-no-spin profile-spinner\\">
+                              <Blueprint3.Spinner className=\\"profile-spinner progress-deepskyblue\\" size={144} value={0.62}>
+                                <div className=\\"bp3-spinner bp3-no-spin profile-spinner progress-deepskyblue\\">
                                   <div className=\\"bp3-spinner-animation\\">
                                     <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
                                       <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
-                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={58.79999999999998} />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={106.4} />
                                     </svg>
                                   </div>
                                 </div>
@@ -103,18 +103,18 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 XP
                               </div>
                               <div className=\\"total-value\\">
-                                1975
+                                1550
                                  / 
                                 2500
                               </div>
                               <div className=\\"percentage\\">
-                                79.00
+                                62.00
                                 %
                               </div>
                             </div>
                           </div>
                           <div className=\\"profile-callouts\\">
-                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
                               <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/missions/4/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/4\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/missions/4/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
@@ -141,12 +141,12 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               Grade
                                             </div>
                                             <div className=\\"value\\">
-                                              2850
+                                              2700
                                                / 
                                               3000
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"primary\\" stripes={false} value={0.95}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-primary bp3-no-animation bp3-no-stripes value-bar\\">
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={0.9}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-steelblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
                                             </Blueprint3.ProgressBar>
@@ -156,12 +156,12 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               XP
                                             </div>
                                             <div className=\\"value\\">
-                                              850
+                                              800
                                                / 
                                               1000
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"success\\" stripes={false} value={0.85}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-success bp3-no-animation bp3-no-stripes value-bar\\">
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={0.8}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-steelblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
                                             </Blueprint3.ProgressBar>
@@ -173,7 +173,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 </Route>
                               </NavLink>
                             </ProfileCard>
-                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
                               <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
@@ -195,32 +195,17 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               Closed (partially graded) Sidequest
                                             </h4>
                                           </Component>
-                                          <div className=\\"grade-details\\">
-                                            <div className=\\"title\\">
-                                              Grade
-                                            </div>
-                                            <div className=\\"value\\">
-                                              2500
-                                               / 
-                                              3000
-                                            </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"success\\" stripes={false} value={0.8333333333333334}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-success bp3-no-animation bp3-no-stripes value-bar\\">
-                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
-                                              </div>
-                                            </Blueprint3.ProgressBar>
-                                          </div>
                                           <div className=\\"xp-details\\">
                                             <div className=\\"title\\">
                                               XP
                                             </div>
                                             <div className=\\"value\\">
-                                              750
+                                              500
                                                / 
                                               1000
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"warning\\" stripes={false} value={0.75}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-warning bp3-no-animation bp3-no-stripes value-bar\\">
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-deepskyblue\\" stripes={false} value={0.5}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-deepskyblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
                                             </Blueprint3.ProgressBar>
@@ -232,7 +217,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 </Route>
                               </NavLink>
                             </ProfileCard>
-                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
                               <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
@@ -254,32 +239,17 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               Closed (fully graded) Sidequest
                                             </h4>
                                           </Component>
-                                          <div className=\\"grade-details\\">
-                                            <div className=\\"title\\">
-                                              Grade
-                                            </div>
-                                            <div className=\\"value\\">
-                                              450
-                                               / 
-                                              700
-                                            </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"warning\\" stripes={false} value={0.6428571428571429}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-warning bp3-no-animation bp3-no-stripes value-bar\\">
-                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
-                                              </div>
-                                            </Blueprint3.ProgressBar>
-                                          </div>
                                           <div className=\\"xp-details\\">
                                             <div className=\\"title\\">
                                               XP
                                             </div>
                                             <div className=\\"value\\">
-                                              275
+                                              150
                                                / 
                                               500
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"danger\\" stripes={false} value={0.55}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-danger bp3-no-animation bp3-no-stripes value-bar\\">
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-skyblue\\" stripes={false} value={0.3}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-skyblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
                                             </Blueprint3.ProgressBar>
@@ -291,7 +261,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 </Route>
                               </NavLink>
                             </ProfileCard>
-                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseFrac={[Function: parseFrac]} renderIcon={[Function: renderIcon]}>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
                               <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
@@ -322,8 +292,8 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                                / 
                                               0
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar\\" intent=\\"primary\\" stripes={false} value={1}>
-                                              <div className=\\"bp3-progress-bar bp3-intent-primary bp3-no-animation bp3-no-stripes value-bar\\">
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={1}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-steelblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
                                             </Blueprint3.ProgressBar>

--- a/src/components/workspace/side-content/__tests__/Autograder.tsx
+++ b/src/components/workspace/side-content/__tests__/Autograder.tsx
@@ -2,7 +2,7 @@ import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
 import { ErrorSeverity, ErrorType, SourceError } from 'js-slang/dist/types';
-import { AutogradingResult, ITestcase } from 'src/components/assessment/assessmentShape';
+import { AutogradingResult, ITestcase } from '../../../../components/assessment/assessmentShape';
 import Autograder, { AutograderProps } from '../Autograder';
 
 const mockErrors: SourceError[] = [

--- a/src/containers/ProfileContainer.ts
+++ b/src/containers/ProfileContainer.ts
@@ -1,6 +1,8 @@
-import { connect, MapStateToProps } from 'react-redux';
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import Profile, { StateProps } from '../components/dropdown/Profile';
+import { bindActionCreators, Dispatch } from 'redux';
+import { fetchAssessmentOverviews } from '../actions';
+import Profile, { DispatchProps, StateProps } from '../components/dropdown/Profile';
 import { IState } from '../reducers/states';
 
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => ({
@@ -9,6 +11,15 @@ const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => ({
   role: state.session.role
 });
 
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch<any>) =>
+  bindActionCreators(
+    {
+      handleAssessmentOverviewFetch: fetchAssessmentOverviews
+    },
+    dispatch
+  );
+
 export default connect(
-  mapStateToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(Profile);

--- a/src/containers/ProfileContainer.ts
+++ b/src/containers/ProfileContainer.ts
@@ -4,12 +4,11 @@ import Profile, { StateProps } from '../components/dropdown/Profile';
 import { IState } from '../reducers/states';
 
 const mapStateToProps: MapStateToProps<StateProps, {}, IState> = state => ({
-  grade: state.session.grade,
-  maxGrade: state.session.maxGrade,
-  maxXp: state.session.maxXp,
+  assessmentOverviews: state.session.assessmentOverviews,
   name: state.session.name,
-  role: state.session.role,
-  xp: state.session.xp
+  role: state.session.role
 });
 
-export default connect(mapStateToProps)(Profile);
+export default connect(
+  mapStateToProps
+)(Profile);

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -101,7 +101,7 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
     category: AssessmentCategories.Mission,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
-    grade: 2850,
+    grade: 2700,
     id: 4,
     maxGrade: 3000,
     maxXp: 1000,
@@ -111,14 +111,14 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is not graded. It should render as a red cross.',
     status: AssessmentStatuses.submitted,
     story: 'mission-3',
-    xp: 850,
+    xp: 800,
     gradingStatus: 'none'
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 2500,
+    grade: 1950,
     id: 5,
     maxGrade: 3000,
     maxXp: 1000,
@@ -128,14 +128,14 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is partially graded (undergoing manual grading). It should render as an orange clock.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 750,
+    xp: 500,
     gradingStatus: 'grading'
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 450,
+    grade: 300,
     id: 5,
     maxGrade: 700,
     maxXp: 500,
@@ -145,7 +145,7 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is fully graded. It should render as a green tick. This sidequest links to the mock Sidequest 4.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 275,
+    xp: 150,
     gradingStatus: 'graded'
   },
   {

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -101,7 +101,7 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
     category: AssessmentCategories.Mission,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
-    grade: 5,
+    grade: 2850,
     id: 4,
     maxGrade: 3000,
     maxXp: 1000,
@@ -111,14 +111,14 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is not graded. It should render as a red cross.',
     status: AssessmentStatuses.submitted,
     story: 'mission-3',
-    xp: 4,
+    xp: 850,
     gradingStatus: 'none'
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 1500,
+    grade: 2500,
     id: 5,
     maxGrade: 3000,
     maxXp: 1000,
@@ -128,14 +128,14 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is partially graded (undergoing manual grading). It should render as an orange clock.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 500,
+    xp: 750,
     gradingStatus: 'grading'
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 250,
+    grade: 450,
     id: 5,
     maxGrade: 700,
     maxXp: 500,
@@ -145,7 +145,7 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment is fully graded. It should render as a green tick. This sidequest links to the mock Sidequest 4.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 500,
+    xp: 275,
     gradingStatus: 'graded'
   },
   {
@@ -162,7 +162,7 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
       'This is a test for the grading status tooltip when the assessment does not require manual grading (e.g. paths and contests). It should render as a blue disable sign. This sidequest links to the mock Sidequest 4.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 0,
+    xp: 100,
     gradingStatus: 'excluded'
   }
 ];
@@ -602,5 +602,14 @@ sapien
     missionPDF: 'www.google.com',
     questions: mockClosedAssessmentQuestions,
     title: 'A Closed Mission'
+  },
+  {
+    category: AssessmentCategories.Sidequest,
+    id: 5,
+    longSummary:
+      'This is the closed sidequest briefing. The save button should not exist. This is a placeholder sidequest for testing rendering of grading statuses.',
+    missionPDF: 'www.google.com',
+    questions: mockClosedAssessmentQuestions,
+    title: 'A Closed Sidequest'
   }
 ];

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -28,47 +28,84 @@ div.#{$ns}-dialog.help {
   }
 }
 
-div.#{$ns}-dialog.profile {
-  padding: 0;
+.profile {
+  // 30% of 1366 pixels
+  min-width: 410px;
 
-  div.header {
-    text-align: center;
+  .profile-content {
+    height: calc(100vh - 40px);
+    flex-grow: 1;
+    flex-shrink: 1;
+    padding: 20px;
+    line-height: 18px;
+    display: flex;
+    flex-direction: column;
 
-    span.name {
-      font-size: 1.5rem;
-      font-weight: 800;
-      padding-right: 0.7rem;
+    div.profile-header {
+      flex-grow: 0;
+      flex-shrink: 0;
+      text-align: center;
+      padding-bottom: 1.75em;
+
+      div.name {
+        font-size: 1.5rem;
+        font-weight: 800;
+        margin-bottom: 0.3em;
+      }
+
+      div.role {
+        font-size: 1rem;
+        font-style: italic;
+      }
     }
 
-    span.role {
-      font-style: italic;
-    }
-  }
-
-  div.progress {
-    div {
+    div.profile-progress {
+      flex: 0 0 auto;
       display: flex;
       flex-direction: row;
-      margin-bottom: 0.3em;
-      padding-top: 1rem;
+      padding-bottom: 1.75em;
+      justify-content: space-around;
+      align-items: stretch;
 
-      &:first-child {
-        padding-top: 0;
-      }
-    }
+      .profile-grade,
+      .profile-xp {
+        position: relative;
+        width: 42%;
+        flex-grow: 0;
+        flex-shrink: 0;
+        margin-bottom: 0.3em;
 
-    span {
-      display: block;
+        .grade-spinner svg,
+        .xp-spinner svg {
+          width: 100%;
+          height: 100%;
+          stroke-width: 6;
+          overflow: visible;
+        }
 
-      &.label {
-        /* Flush &.value to right */
-        flex-grow: 1;
-      }
+        div.type,
+        div.total-value,
+        div.percentage {
+          position: absolute;
+          text-align: center;
+          width: 100%;
+        }
 
-      &.value {
-        align-self: end;
-        font: 14px / normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro',
-          monospace;
+        div.type {
+          font-weight: bold;
+          font-size: 1.35em;
+          top: 35%;
+        }
+
+        div.total-value {
+          font-size: 1.15em;
+          top: 52%;
+        }
+
+        div.percentage {
+          font-size: 0.95em;
+          top: 78%;
+        }
       }
     }
   }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -108,5 +108,64 @@ div.#{$ns}-dialog.help {
         }
       }
     }
+
+    div.profile-callouts {
+      flex-grow: 1;
+      flex-shrink: 1;
+      overflow-y: auto;
+      
+      .profile-summary-callout {
+        line-height: 1em;
+        padding: 4px 12px 6px 30px;
+
+        &:hover {
+          background-color: rgba(138, 155, 168, 0.25)
+        }
+
+        h4 {
+          font-size: 1.1em;
+          font-weight: bold;
+        }
+
+        .#{$ns}-icon {
+          position: absolute;
+          top: 6px;
+          left: 6px;
+          
+          svg {
+            height: 18px;
+            width: 18px;
+          }
+        }
+
+        .grade-details, .xp-details {
+          & > * {
+            display: inline-block;
+          }
+
+          .title {
+            width: 12%;
+            text-align: left;
+          }
+
+          .value {
+            width: 35%;
+            text-align: center;
+          }
+
+          .value-bar {
+            width: 53%;
+          }
+        }
+
+        .xp-details {
+          margin-top: 0.2em;
+        }
+      }
+
+      .profile-summary-callout:not(:last-child) {
+        margin-bottom: 0.25em;
+      }
+    }
   }
 }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -114,56 +114,61 @@ div.#{$ns}-dialog.help {
       flex-shrink: 1;
       overflow-y: auto;
       
-      .profile-summary-callout {
-        line-height: 1em;
-        padding: 4px 12px 6px 30px;
+      .profile-summary-navlink{
+        color: black;
+        text-decoration: none;
 
-        &:hover {
-          background-color: rgba(138, 155, 168, 0.25)
-        }
-
-        h4 {
-          font-size: 1.1em;
-          font-weight: bold;
-        }
-
-        .#{$ns}-icon {
-          position: absolute;
-          top: 6px;
-          left: 6px;
-          
-          svg {
-            height: 18px;
-            width: 18px;
+        .profile-summary-callout {
+          line-height: 1em;
+          padding: 4px 12px 6px 30px;
+  
+          &:hover {
+            background-color: rgba(138, 155, 168, 0.25)
           }
-        }
-
-        .grade-details, .xp-details {
-          & > * {
-            display: inline-block;
+  
+          h4 {
+            font-size: 1.1em;
+            font-weight: bold;
           }
-
-          .title {
-            width: 12%;
-            text-align: left;
+  
+          .#{$ns}-icon {
+            position: absolute;
+            top: 6px;
+            left: 6px;
+            
+            svg {
+              height: 18px;
+              width: 18px;
+            }
           }
-
-          .value {
-            width: 35%;
-            text-align: center;
+  
+          .grade-details, .xp-details {
+            & > * {
+              display: inline-block;
+            }
+  
+            .title {
+              width: 12%;
+              text-align: left;
+            }
+  
+            .value {
+              width: 35%;
+              text-align: center;
+            }
+  
+            .value-bar {
+              width: 53%;
+            }
           }
-
-          .value-bar {
-            width: 53%;
+  
+          .xp-details {
+            margin-top: 0.2em;
           }
-        }
-
-        .xp-details {
-          margin-top: 0.2em;
         }
       }
 
-      .profile-summary-callout:not(:last-child) {
+      .profile-summary-navlink:not(:last-child) > .profile-summary-callout {
         margin-bottom: 0.25em;
       }
     }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -178,4 +178,34 @@ div.#{$ns}-dialog.help {
       }
     }
   }
+
+  .progress-steelblue {
+    &.profile-spinner svg path:last-of-type {
+      stroke: #137cbd;
+    }
+
+    &.value-bar > div {
+      background-color: #137cbd;
+    }
+  }
+
+  .progress-deepskyblue {
+    &.profile-spinner svg path:last-of-type {
+      stroke: #579ecb;
+    }
+
+    &.value-bar > div {
+      background-color: #579ecb;
+    }
+  }
+
+  .progress-skyblue {
+    &.profile-spinner svg path:last-of-type {
+      stroke: #9ac0d8;
+    }
+
+    &.value-bar > div {
+      background-color: #9ac0d8;
+    }
+  }
 }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -167,7 +167,7 @@ div.#{$ns}-dialog.help {
             }
           }
 
-          .xp-details {
+          & > div:not(:first-of-type) {
             margin-top: 0.2em;
           }
         }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -113,55 +113,56 @@ div.#{$ns}-dialog.help {
       flex-grow: 1;
       flex-shrink: 1;
       overflow-y: auto;
-      
-      .profile-summary-navlink{
+
+      .profile-summary-navlink {
         color: black;
         text-decoration: none;
 
         .profile-summary-callout {
           line-height: 1em;
           padding: 4px 12px 6px 30px;
-  
+
           &:hover {
-            background-color: rgba(138, 155, 168, 0.25)
+            background-color: rgba(138, 155, 168, 0.25);
           }
-  
+
           h4 {
             font-size: 1.1em;
             font-weight: bold;
           }
-  
+
           .#{$ns}-icon {
             position: absolute;
             top: 6px;
             left: 6px;
-            
+
             svg {
               height: 18px;
               width: 18px;
             }
           }
-  
-          .grade-details, .xp-details {
+
+          .grade-details,
+          .xp-details {
             & > * {
               display: inline-block;
             }
-  
+
             .title {
               width: 12%;
               text-align: left;
             }
-  
+
             .value {
               width: 35%;
               text-align: center;
             }
-  
+
             .value-bar {
               width: 53%;
             }
           }
-  
+
           .xp-details {
             margin-top: 0.2em;
           }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -80,8 +80,7 @@ div.#{$ns}-dialog.help {
         flex-shrink: 0;
         margin-bottom: 0.3em;
 
-        .grade-spinner svg,
-        .xp-spinner svg {
+        .profile-spinner svg {
           width: 100%;
           height: 100%;
           stroke-width: 6;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -59,6 +59,11 @@ div.#{$ns}-dialog.help {
       }
     }
 
+    div.profile-placeholder {
+      flex: 0 0 auto;
+      text-align: center;
+    }
+
     div.profile-progress {
       flex: 0 0 auto;
       display: flex;


### PR DESCRIPTION
## Redesign Profile component to a full-fledged user profile page
Summary: Redesign the current Profile component (a dialog prompt) to a full-fledged user profile page (side-panel from the left). Addresses #681.

### Changelog
- Update the Profile component from using bp3's `Dialog` component to use bp3's `Drawer` component - this opens a full-height sidebar overlaying the Academy from the left of the screen
   - The Profile component is still triggered from the dropdown at the top right of the Academy
- Amend the Profile component to compute the current and maximum grades and XP from `assessmentOverviews` of `ISessionState` of the Redux store, instead of displaying the `grade`, `xp`, `maxGrade` and `maxXp` attributes from `ISessionState`
   - This change renders the four above attributes redundant in the Redux store - they can be cleaned up along with the `SET_USER` action during refactoring
   - As a result, the Profile component is now entirely rendering derived data from `assessmentOverviews` - this improves the accuracy of the rendered total grade and XP, as the profile data agrees with the state of the assessment overviews and is updated whenever the assessment overviews are re-fetched
   - Further inspection of the `SET_USER` action suggests that it has never updated the `Xp`, `maxGrade` and `maxXp` attributes in the Redux store - this caused the `Profile` component to break during the past two semesters (where it would always render 0 for the grade and XP progress bars)
   - **Caveat**: Only closed assessments (with `status` of `AssessmentStatuses.submitted`) factor into the computation of total and max grade and XP, since open assessments are not yet graded
      - Additionally, **only Missions* factor into the computation of total and max Grade; see https://github.com/source-academy/cadet-frontend/pull/813#issuecomment-519070480
- Enable Profile component to trigger the `FETCH_ASSESSMENT_OVERVIEWS` action if `assessmentOverviews` are not loaded (e.g. upon just logging into the Academy, prior to loading the 'Missions' page)
- Render the proportion of total grade and XP obtained out of their respective current maximums as a fixed bp3 `Spinner`
- Render each closed assessment in a condensed card format using bp3's `Callout` component, displaying its `type` (as an icon), `title`, `grade`, `XP`, `maxGrade` and `maxXp`
   - The proportion of Grade and XP obtained is rendered as a fixed progress bar; Grade progress bar is **only rendered for Missions**, see https://github.com/source-academy/cadet-frontend/pull/813#issuecomment-519070480
   - Progress bars are coloured with custom shades of blue according to the table in https://github.com/source-academy/cadet-frontend/pull/813#issuecomment-519078600 - thanks @alcen!
   - **Caveat**: The corresponding progress bar is not rendered if both a value and its maximum value are 0, e.g. if `grade` is `0` and `maxGrade` is `0`, that assessment's card will not render its XP progress bar - this ensures bonus XP on assessments with `maxXp` of `0` still render the XP bar
- Allow clicking a closed assessment's card to directly open that assessment in a new browser tab, for quick user review
- Add a placeholder to render when there are no closed assessments

### Bugfixes
- Fix non-standard module import declaration in test file for 'Autograder' component

### Mocks and Tests
- Update mock assessments to render mock assessment cards with different grade and XP boundaries in the profile
- Update existing snapshots and add DOM rendering tests for the Profile component

### Screenshots

#### Before (Profile dialog prompt)
![profile-old](https://user-images.githubusercontent.com/44989315/62560027-c62a6c00-b8ae-11e9-925e-fed87ebabaae.png)

#### After (no closed assessments - placeholder rendered)
![profile-new-empty](https://user-images.githubusercontent.com/44989315/62560034-caef2000-b8ae-11e9-832a-fc4f4b0d92c7.png)

#### After (closed assessments exist - 1536 x 864 on a 15" laptop)
![profile-new-populated-rev1](https://user-images.githubusercontent.com/44989315/62702862-75d01d00-ba1a-11e9-9463-857624e9f2e9.png)

#### After (closed assessments exist and list of cards overflows - 1536 x 864 on a 15" laptop)
![profile-new-populated-overflow-rev1](https://user-images.githubusercontent.com/44989315/62702879-7e285800-ba1a-11e9-9d89-cbe01bcea6b4.png)

#### After (closed assessments exist - 1920 x 1080 on a 22" screen)
![profile-new-populated-large-rev1](https://user-images.githubusercontent.com/44989315/62702887-841e3900-ba1a-11e9-9055-de3c2064f76a.png)

#### Feature demonstration (GIF - not updated to latest patch)
![profile-page-new-feature-demo](https://user-images.githubusercontent.com/44989315/62561389-b19ba300-b8b1-11e9-9a0f-363741d5f102.gif)

Last updated 8 Aug 2019, 8:30PM