### PR TITLE
Fix default tab of ungraded assessments

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -410,7 +410,7 @@ class AssessmentWorkspace extends React.Component<
     }
     return {
       handleActiveTabChange: props.handleActiveTabChange,
-      defaultSelectedTabId: isGraded ? SideContentType.grading : SideContentType.briefing,
+      defaultSelectedTabId: isGraded ? SideContentType.grading : SideContentType.questionOverview,
       tabs
     };
   };


### PR DESCRIPTION
In pull request #819, the default tab of graded assessments was set to the grading results. However, I accidentally set the tab of ungraded assessments to 'Mission Briefing' instead of the original 'Task 1/2/...'.

This commit fixes the unintended change!