### PR TITLE
Fix incorrect type declarations in IQuestion interface

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -371,8 +371,8 @@ class AssessmentWorkspace extends React.Component<
           iconName: IconNames.TICK,
           body: (
             <GradingResult
-              graderName={props.assessment!.questions[questionId].grader.name}
-              gradedAt={props.assessment!.questions[questionId].gradedAt}
+              graderName={props.assessment!.questions[questionId].grader!.name}
+              gradedAt={props.assessment!.questions[questionId].gradedAt!}
               xp={props.assessment!.questions[questionId].xp}
               grade={props.assessment!.questions[questionId].grade}
               maxGrade={props.assessment!.questions[questionId].maxGrade}

--- a/src/components/assessment/__tests__/AssessmentWorkspace.tsx
+++ b/src/components/assessment/__tests__/AssessmentWorkspace.tsx
@@ -67,6 +67,13 @@ const mockClosedProgrammingAssessmentWorkspaceProps: AssessmentWorkspaceProps = 
   closeDate: '2008-06-18T05:24:26.026Z'
 };
 
+const mockGradedProgrammingAssessmentWorkspaceProps: AssessmentWorkspaceProps = {
+  ...defaultProps,
+  assessment: mockAssessments[3],
+  assessmentId: 4,
+  questionId: 0
+};
+
 const mockMcqAssessmentWorkspaceProps: AssessmentWorkspaceProps = {
   ...defaultProps,
   assessment: mockAssessments[0],
@@ -96,4 +103,42 @@ test('AssessmentWorkspace page with MCQ question renders correctly', () => {
   const app = <AssessmentWorkspace {...mockMcqAssessmentWorkspaceProps} />;
   const tree = shallow(app);
   expect(tree.debug()).toMatchSnapshot();
+});
+
+/*  ===== Tester comments =====
+    Issue:
+      https://stackoverflow.com/questions/42813342/react-createelement-type-is-invalid-expected-a-string 
+    Description:
+      Mounting the AssessmentWorkspace deeply (rendering all recursive subcomponents) in Enzyme with mount
+      results in the test failing with the error
+          Warning: React.createElement: type is invalid -- expected a string (for built-in components) or
+          a class/function (for composite components) but got: undefined. You likely forgot to export your
+          component from the file it's defined in, or you might have mixed up default and named imports.
+     
+          Check the render method of `Workspace`.
+
+          The above error occurred in the <div> component:
+            in div (created by Workspace)
+            in div (created by Workspace)
+            in Workspace (created by AssessmentWorkspace)
+            in div (created by AssessmentWorkspace)
+            in AssessmentWorkspace (created by WrapperComponent)
+            in WrapperComponent
+      
+      whereas mounting it one-level deep in Enzyme using shallow throws no errors
+    Fix:
+      Stack trace suggests one of the React subcomponents of AssessmentWorkspace works in production
+      but is not set up correctly - requires re-examination of every single React component and
+      sub-component used in AssessmentWorkspace
+      
+      Current workaround is to mount AssessmentWorkspace shallowly since the behaviour is correct
+      during user testing
+*/
+
+test('AssessmentWorkspace renders Grading tab correctly if the question has been graded', () => {
+  const app = <AssessmentWorkspace {...mockGradedProgrammingAssessmentWorkspaceProps} />;
+  const tree = shallow(app);
+  expect(tree.debug()).toMatchSnapshot();
+  // Uncomment when fixed
+  // expect(tree.find('.grading-icon').hostNodes()).toHaveLength(1);
 });

--- a/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -85,3 +85,31 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
   <Workspace controlBarProps={{...}} editorProps={{...}} editorHeight={[undefined]} editorWidth=\\"50%\\" handleEditorHeightChange={[Function: handleEditorHeightChange]} handleEditorWidthChange={[Function: handleEditorWidthChange]} handleSideContentHeightChange={[Function: handleSideContentHeightChange]} hasUnsavedChanges={false} mcqProps={{...}} sideContentHeight={[undefined]} sideContentProps={{...}} replProps={{...}} />
 </div>"
 `;
+
+exports[`AssessmentWorkspace renders Grading tab correctly if the question has been graded 1`] = `
+"<div className=\\"WorkspaceParent bp3-dark\\">
+  <Blueprint3.Dialog className=\\"assessment-briefing\\" isOpen={true} canOutsideClickClose={true}>
+    <Blueprint3.Card elevation={0} interactive={false}>
+      <Markdown content=\\"This is the closed mission briefing. The save button should not be there. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. \\" />
+      <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
+    </Blueprint3.Card>
+  </Blueprint3.Dialog>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+    <div className=\\"bp3-dialog-body\\">
+      <Markdown content=\\"Are you sure you want to reset the template?\\" />
+      <Markdown content=\\"*Note this will not affect the saved copy of your code, unless you save over it.*\\" />
+    </div>
+    <div className=\\"bp3-dialog-footer\\">
+      <Blueprint3.ButtonGroup>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+          Cancel
+        </Blueprint3.Button>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"danger\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+          Confirm
+        </Blueprint3.Button>
+      </Blueprint3.ButtonGroup>
+    </div>
+  </Blueprint3.Dialog>
+  <Workspace controlBarProps={{...}} editorProps={{...}} editorHeight={[undefined]} editorWidth=\\"50%\\" handleEditorHeightChange={[Function: handleEditorHeightChange]} handleEditorWidthChange={[Function: handleEditorWidthChange]} handleSideContentHeightChange={[Function: handleSideContentHeightChange]} hasUnsavedChanges={false} mcqProps={{...}} sideContentHeight={[undefined]} sideContentProps={{...}} replProps={{...}} />
+</div>"
+`;

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -110,8 +110,8 @@ export interface IQuestion {
   grader: {
     name: string;
     id: number;
-  };
-  gradedAt: string;
+  } | null;
+  gradedAt: string | null;
   xp: number;
   grade: number;
   maxGrade: number;

--- a/src/components/missionControl/assessmentTemplates.ts
+++ b/src/components/missionControl/assessmentTemplates.ts
@@ -67,11 +67,8 @@ export const programmingTemplate = (): IProgrammingQuestion => {
     testcases: [],
     testcasesPrivate: [],
     type: 'programming',
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
+    grader: null,
+    gradedAt: null,
     xp: 0,
     grade: 0,
     maxGrade: 0,
@@ -115,11 +112,8 @@ export const mcqTemplate = (): IMCQQuestion => {
     graderLibrary: emptyLibrary(),
     type: 'mcq',
     solution: 0,
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
+    grader: null,
+    gradedAt: null,
     xp: 0,
     grade: 0,
     maxGrade: 0,

--- a/src/components/missionControl/xmlParseHelper.ts
+++ b/src/components/missionControl/xmlParseHelper.ts
@@ -158,11 +158,8 @@ const makeQuestions = (task: IXmlParseStrTask): [IQuestion[], number, number] =>
       library: makeLibrary(problem.DEPLOYMENT),
       graderLibrary: makeLibrary(problem.GRADERDEPLOYMENT),
       type: problem.$.type,
-      grader: {
-        name: 'fake person',
-        id: 1
-      },
-      gradedAt: '2038-06-18T05:24:26.026Z',
+      grader: null,
+      gradedAt: null,
       xp: 0,
       grade: 0,
       maxGrade: parseInt(problem.$.maxgrade, 10),

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -256,9 +256,185 @@ const chickenrice = "chicken rice";`,
       }
     ],
     solutionTemplate: `function answer() {
-  // Write something here!
+    // Write something here!
 }
 `,
+    type: 'programming',
+    grader: null,
+    gradedAt: null,
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2
+  },
+  {
+    autogradingResults: [],
+    answer: `function areaOfCircle(x) {
+    return square(x) * pi;
+}
+
+function volumeOfSphere(x) {
+    return 4 / 3 * cube(x) * pi;
+}`,
+    roomId: '19422043',
+    content: 'Hello and welcome to this assessment! This is the 1st question.',
+    id: 1,
+    library: mockRuneLibrary,
+    prepend: `const square = x => x * x;
+const cube = x => x * x * x;
+const pi = 3.1415928;`,
+    postpend: '',
+    testcases: [
+      {
+        program: `areaOfCircle(5);`,
+        score: 1,
+        answer: `78.53982`
+      },
+      {
+        program: `volumeOfSphere(5);`,
+        score: 1,
+        answer: `523.5988`
+      }
+    ],
+    solutionTemplate: `function areaOfCircle(x) {
+    // return area of circle
+}
+
+function volumeOfSphere(x) {
+    // return volume of sphere
+}`,
+    type: 'programming',
+    grader: null,
+    gradedAt: null,
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2
+  },
+  {
+    answer: 3,
+    roomId: '19422046',
+    content:
+      'This is the 3rd question. Oddly enough, it is an ungraded MCQ question that uses the curves library! Option C has a null hint!',
+    choices: [
+      {
+        content: '**Option** `A`',
+        hint: '_hint_ A is `here`'
+      },
+      {
+        content: '### B',
+        hint: 'hint B'
+      },
+      {
+        content: 'C',
+        hint: null
+      },
+      {
+        content: 'D',
+        hint: 'hint D'
+      }
+    ],
+    id: 2,
+    library: mockCurveLibrary,
+    type: 'mcq',
+    solution: 0,
+    grader: null,
+    gradedAt: null,
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2
+  },
+  {
+    answer: 3,
+    roomId: null,
+    content:
+      'This is the 4rth question. Oddly enough, it is a graded MCQ question that uses the curves library!',
+    choices: [
+      {
+        content: 'A',
+        hint: null
+      },
+      {
+        content: 'B',
+        hint: null
+      },
+      {
+        content: 'C',
+        hint: null
+      },
+      {
+        content: 'D',
+        hint: null
+      }
+    ],
+    id: 3,
+    library: mockCurveLibrary,
+    type: 'mcq',
+    solution: null,
+    grader: null,
+    gradedAt: null,
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2
+  },
+  {
+    autogradingResults: [],
+    answer: null,
+    roomId: '19422032',
+    content: 'You have reached the last question! Have some fun with the tone matrix...',
+    id: 4,
+    library: mockToneMatrixLibrary,
+    prepend: '',
+    postpend: '',
+    testcases: [],
+    solutionTemplate: '5th question mock solution template',
+    type: 'programming',
+    grader: null,
+    gradedAt: null,
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2
+  }
+];
+
+export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
+  {
+    answer: `function fibonacci(n) {
+    if (n <= 2) {
+        return 1;
+    } else {
+        return fibonacci(n-1) + fibonacci(n-2);
+    }
+}`,
+    roomId: '19422032',
+    content: 'You can see autograding results!!!',
+    id: 0,
+    library: mockCurveLibrary,
+    prepend: '',
+    postpend: "// This is a mock Postpend! You shouldn't be able to see me!",
+    testcases: [
+      {
+        program: `fibonacci(3);`,
+        score: 1,
+        answer: `2`
+      },
+      {
+        program: `fibonacci(4);`,
+        score: 1,
+        answer: `3`
+      },
+      {
+        program: `fibonacci(5);`,
+        score: 1,
+        answer: `5`
+      }
+    ],
+    solutionTemplate: `function fibonacci(n) {
+    // Your answer here
+}`,
     type: 'programming',
     grader: {
       name: 'avenger',
@@ -292,232 +468,7 @@ _italics_
 
 [link to Source Academy](https://sourceacademy.nus.edu.sg)  
 
-![](image-url-goes-here)
-      `
-  },
-  {
-    autogradingResults: [],
-    answer: `function areaOfCircle(x) {
-  return square(x) * pi;
-}
-
-function volumeOfSphere(x) {
-  return 4 / 3 * cube(x) * pi;
-}`,
-    roomId: '19422043',
-    content: 'Hello and welcome to this assessment! This is the 1st question.',
-    id: 1,
-    library: mockRuneLibrary,
-    prepend: `const square = x => x * x;
-const cube = x => x * x * x;
-const pi = 3.1415928;`,
-    postpend: '',
-    testcases: [
-      {
-        program: `areaOfCircle(5);`,
-        score: 1,
-        answer: `78.53982`
-      },
-      {
-        program: `volumeOfSphere(5);`,
-        score: 1,
-        answer: `523.5988`
-      }
-    ],
-    solutionTemplate: `function areaOfCircle(x) {
-  // return area of circle
-}
-
-function volumeOfSphere(x) {
-  // return volume of sphere
-}`,
-    type: 'programming',
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
-    xp: 0,
-    grade: 0,
-    maxGrade: 2,
-    maxXp: 2,
-    comments: `You open the Report Card, not knowing what to expect...
-
-## WOW!
-Amazing grasp of runes. We can now move on to the next assignment.
-
-<br/>
-
-Robot Dog: \`woof\`
-
-You look at the display of the robot dog.
-
-    FEED ME
-1. Bread
-2. Water
-
-<br/>
-
-* I am hungry.
-* I am thirsty.
-
-<br/>
-<br/>
-    
-New message from **Avenger**!
-
-> _Cadet, please meet me at Level X-05, outside the pod bay doors. There is an important mission awaiting us._
-
-> _May the [Source](https://sourceacademy.nus.edu.sg) be with you._
-
-> Best regards, Avocado A. Avenger
-
-#### Upcoming Tasks
-- [] Meet Avenger Avenger at Level X-05
-- [] Open the Pod Bay Doors
-    `
-  },
-  {
-    answer: 3,
-    roomId: '19422046',
-    content:
-      'This is the 3rd question. Oddly enough, it is an ungraded MCQ question that uses the curves library! Option C has a null hint!',
-    choices: [
-      {
-        content: '**Option** `A`',
-        hint: '_hint_ A is `here`'
-      },
-      {
-        content: '### B',
-        hint: 'hint B'
-      },
-      {
-        content: 'C',
-        hint: null
-      },
-      {
-        content: 'D',
-        hint: 'hint D'
-      }
-    ],
-    id: 2,
-    library: mockCurveLibrary,
-    type: 'mcq',
-    solution: 0,
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
-    xp: 0,
-    grade: 0,
-    maxGrade: 2,
-    maxXp: 2
-  },
-  {
-    answer: 3,
-    roomId: null,
-    content:
-      'This is the 4rth question. Oddly enough, it is a graded MCQ question that uses the curves library!',
-    choices: [
-      {
-        content: 'A',
-        hint: null
-      },
-      {
-        content: 'B',
-        hint: null
-      },
-      {
-        content: 'C',
-        hint: null
-      },
-      {
-        content: 'D',
-        hint: null
-      }
-    ],
-    id: 3,
-    library: mockCurveLibrary,
-    type: 'mcq',
-    solution: null,
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
-    xp: 0,
-    grade: 0,
-    maxGrade: 2,
-    maxXp: 2
-  },
-  {
-    autogradingResults: [],
-    answer: null,
-    roomId: '19422032',
-    content: 'You have reached the last question! Have some fun with the tone matrix...',
-    id: 4,
-    library: mockToneMatrixLibrary,
-    prepend: '',
-    postpend: '',
-    testcases: [],
-    solutionTemplate: '5th question mock solution template',
-    type: 'programming',
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
-    xp: 0,
-    grade: 0,
-    maxGrade: 2,
-    maxXp: 2
-  }
-];
-
-export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
-  {
-    answer: `function fibonacci(n) {
-  if (n <= 2) {
-    return 1;
-  } else {
-    return fibonacci(n-1) + fibonacci(n-2);
-  }
-}`,
-    roomId: '19422032',
-    content: 'You can see autograding results!!!',
-    id: 0,
-    library: mockToneMatrixLibrary,
-    prepend: '',
-    postpend: "// This is a mock Postpend! You shouldn't be able to see me!",
-    testcases: [
-      {
-        program: `fibonacci(3);`,
-        score: 1,
-        answer: `2`
-      },
-      {
-        program: `fibonacci(4);`,
-        score: 1,
-        answer: `3`
-      },
-      {
-        program: `fibonacci(5);`,
-        score: 1,
-        answer: `5`
-      }
-    ],
-    solutionTemplate: 'Make Fibonacci!!!',
-    type: 'programming',
-    grader: {
-      name: 'avenger',
-      id: 1
-    },
-    gradedAt: '2038-06-18T05:24:26.026Z',
-    xp: 0,
-    grade: 0,
-    maxGrade: 2,
-    maxXp: 2,
+![](image-url-goes-here)`,
     autogradingResults: [
       {
         resultType: 'pass'
@@ -543,6 +494,66 @@ export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQue
         ]
       }
     ]
+  },
+  {
+    answer: `function recurse(rune, n) {
+    return n <= 1 ? rune : make_cross(recurse(rune, n - 1));
+}`,
+    roomId: '19422033',
+    content: 'This is a runes question - there are no testcases nor autograding results.',
+    id: 1,
+    library: mockRuneLibrary,
+    prepend: '',
+    postpend: '',
+    testcases: [],
+    solutionTemplate: `function recurse(rune, n) {
+    // Your answer here
+}`,
+    type: 'programming',
+    grader: {
+      name: 'some avenger',
+      id: 1
+    },
+    gradedAt: '2038-06-18T05:24:26.026Z',
+    xp: 0,
+    grade: 0,
+    maxGrade: 2,
+    maxXp: 2,
+    comments: `You open the Report Card, not knowing what to expect...
+
+    ## WOW!
+    Amazing grasp of runes. We can now move on to the next assignment.
+    
+    <br/>
+    
+    Robot Dog: \`woof\`
+    
+    You look at the display of the robot dog.
+    
+        FEED ME
+    1. Bread
+    2. Water
+    
+    <br/>
+    
+    * I am hungry.
+    * I am thirsty.
+    
+    <br/>
+    <br/>
+        
+    New message from **Avenger**!
+    
+    > _Cadet, please meet me at Level X-05, outside the pod bay doors. There is an important mission awaiting us._
+    
+    > _May the [Source](https://sourceacademy.nus.edu.sg) be with you._
+    
+    > Best regards, Avocado A. Avenger
+    
+    #### Upcoming Tasks
+    - [] Meet Avenger Avenger at Level X-05
+    - [] Open the Pod Bay Doors`,
+    autogradingResults: []
   }
 ];
 


### PR DESCRIPTION
## [Bugfix] Fix incorrect type declarations in IQuestion interface
Fixes a silent bug.

### Bug description
Currently, in the TypeScript configuration file for the frontend, the `strictNullChecks` flag is set to `true`. According to the TS documentation,

> In strict null checking mode, the `null` and `undefined` values are not in the domain of every type and are only assignable to themselves and `any` (the one exception being that `undefined` is also assignable to `void`).

When an assessment is loaded in the assessment workspace, the frontend conditionally renders the Grading tab if the value of the `grader` attribute of the current `IQuestion` is non-`null`, from

https://github.com/source-academy/cadet-frontend/blob/a1a2ccf70c0771a3ebfd40f343f4a21f80fc7eb5/src/components/assessment/AssessmentWorkspace.tsx#L366-L370

However, the type declarations for both the `grader` and `gradedAt` attributes do not explicitly allow them to take on the value of `null`, 

https://github.com/source-academy/cadet-frontend/blob/e5c7d0e5e074c96b7800f66eacc6a89a778cab9c/src/components/assessment/assessmentShape.ts#L110-L114

and as a result, the backend returns an object for `IQuestion` that does not strictly conform to the interface. This can be verified by logging the `assessment` object containing the `questions` array,

![backend-fetch-assessment](https://user-images.githubusercontent.com/44989315/62820225-b7d09e80-bb93-11e9-8ff1-7521a0f6e438.png)

which shows that the backend does indeed assign `null` to both of these fields when a question has not been manually graded yet. Presumably, this bug will never manifest as an error during live deployment, due to type erasure during compilation of TypeScript.

As a result of this, all the mock assessments were set up to include a valid `grader` object, causing the frontend to incorrectly render the Grading tab for the mock unopened and open assessments (which are not expected to have any graded questions),

![frontend-mock-open-assessment](https://user-images.githubusercontent.com/44989315/62820229-c15a0680-bb93-11e9-9848-e1758df87722.png)

In addition, applying the fix from https://github.com/source-academy/cadet-frontend/pull/826 correctly shows 'Task X' as the default side-content tab for the mock open assessments.

### Changelog
- Include `null` type in type declaration for `grader` and `gradedAt` attributes in IQuestion
- Update mock assessments such that Grading tab only renders for closed assessments
- Add placeholder snapshot test to assert the Grading tab is correctly rendered in the assessment workspace when `grader` is non-`null`
   - Test should be updated when the failing sub-component in `<AssessmentWorkspace>` has been identified and rectified to allow for deep mounting in Enzyme

Last updated 10 Aug 2019, 05:30PM