### PR TITLE
Fix editor unable to be resized without disappearing

### DIFF
--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -214,7 +214,7 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
           editorWidth:
             (
               parseFloat(state[workspaceLocation].editorWidth.slice(0, -1)) +
-              action.payload.widthChange
+              parseFloat(action.payload.widthChange)
             ).toString() + '%'
         }
       };


### PR DESCRIPTION
This change fixes a bug where the editor would disappear if resized to be larger in width. It would be set to values of 500% window size or above, which was due to the value of `widthChange` being added as a string (instead of a number) to the original width value of 50%

e.g.
`50 + "11";` result: `"5011"`
`50 + 11;` result: `61`