### PR TITLE
PIX&FLIX: 'Still Image' button updates image when clicked

### DIFF
--- a/src/components/workspace/side-content/VideoDisplay.tsx
+++ b/src/components/workspace/side-content/VideoDisplay.tsx
@@ -67,8 +67,8 @@ class VideoDisplay extends React.Component<{}, VideoDisplayState> {
       display: 'none'
     };
 
-    const videoIsActive = this.state.mode === 'video';
-    const stillIsActive = this.state.mode === 'still';
+    const videoIsActive = this.state.mode === ('video' as VideoDisplayMode);
+    const stillIsActive = this.state.mode === ('still' as VideoDisplayMode);
 
     return (
       <div className="sa-video">
@@ -76,15 +76,17 @@ class VideoDisplay extends React.Component<{}, VideoDisplayState> {
           <div className="sa-video-header-element">
             <ButtonGroup>
               <Button
+                className={'sa-live-video-button'}
                 icon={IconNames.VIDEO}
                 active={videoIsActive}
                 onClick={this.swapModes(this.state.mode)}
                 text={'Live Video'}
               />
               <Button
+                className={'sa-still-image-button'}
                 icon={IconNames.CAMERA}
                 active={stillIsActive}
-                onClick={this.swapModes(this.state.mode)}
+                onClick={stillIsActive ? this.handleSnapPicture : this.swapModes(this.state.mode)}
                 text={'Still Image'}
               />
             </ButtonGroup>

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -367,10 +367,10 @@ $code-color-error: #ff4444;
           display: inherit;
           padding: 5px 0px;
 
-          .bp3-button-group {
+          .#{$ns}-button-group {
             width: max-content;
 
-            .bp3-active {
+            .#{$ns}-button.sa-live-video-button.#{$ns}-active {
               pointer-events: none;
             }
           }
@@ -381,7 +381,7 @@ $code-color-error: #ff4444;
           }
         }
 
-        .bp3-divider {
+        .#{$ns}-divider {
           margin: 0;
         }
       }


### PR DESCRIPTION
Small fix for #837: now when selected, the "Still Image" button can be clicked again to update the image from the webcam