### PR TITLE
Fix Profile component incorrectly mounting when not logged in

### DIFF
--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -30,7 +30,7 @@ export type DispatchProps = {
 
 class Profile extends React.Component<ProfileProps, {}> {
   public componentDidMount() {
-    if (!this.props.assessmentOverviews) {
+    if (this.props.name && this.props.role && !this.props.assessmentOverviews) {
       // If assessment overviews are not loaded, fetch them
       this.props.handleAssessmentOverviewFetch();
     }

--- a/src/components/dropdown/__tests__/Profile.tsx
+++ b/src/components/dropdown/__tests__/Profile.tsx
@@ -1,10 +1,10 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
+import { MemoryRouter } from 'react-router';
 
 import { mockAssessmentOverviews } from '../../../mocks/assessmentAPI';
 import { Role } from '../../../reducers/states';
 
-import { MemoryRouter } from 'react-router-dom';
 import { AssessmentStatuses } from '../../../components/assessment/assessmentShape';
 import Profile from '../Profile';
 

--- a/src/components/dropdown/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/dropdown/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown correctly mounts Profile component when a user is logged in 1`] = `
+"<Fragment>
+  <Blueprint3.Popover content={{...}} inheritDarkTheme={false} position=\\"bottom\\" boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} />
+  </Blueprint3.Popover>
+  <About isOpen={false} onClose={[Function]} />
+  <Help isOpen={false} onClose={[Function]} />
+  <Connect(Profile) isOpen={false} onClose={[Function]} />
+</Fragment>"
+`;
+
+exports[`Dropdown does not mount Profile component when a user is not logged in 1`] = `
+"<Fragment>
+  <Blueprint3.Popover content={{...}} inheritDarkTheme={false} position=\\"bottom\\" boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} />
+  </Blueprint3.Popover>
+  <About isOpen={false} onClose={[Function]} />
+  <Help isOpen={false} onClose={[Function]} />
+</Fragment>"
+`;

--- a/src/components/dropdown/__tests__/index.tsx
+++ b/src/components/dropdown/__tests__/index.tsx
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import ProfileContainer from '../../../containers/ProfileContainer';
+import Dropdown from '../index';
+
+test('Dropdown does not mount Profile component when a user is not logged in', () => {
+  const props = {
+    handleLogOut: () => {},
+    isAboutOpen: false,
+    isHelpOpen: false,
+    isProfileOpen: false
+  };
+  const app = <Dropdown {...props} />;
+  const tree = shallow(app);
+  expect(tree.debug()).toMatchSnapshot();
+  // Expect the Profile component to NOT be mounted
+  expect(tree.find(ProfileContainer)).toHaveLength(0);
+});
+
+test('Dropdown correctly mounts Profile component when a user is logged in', () => {
+  const props = {
+    handleLogOut: () => {},
+    isAboutOpen: false,
+    isHelpOpen: false,
+    isProfileOpen: false,
+    name: 'Some user'
+  };
+  const app = <Dropdown {...props} />;
+  const tree = shallow(app);
+  expect(tree.debug()).toMatchSnapshot();
+  // Expect the Profile component to be mounted
+  expect(tree.find(ProfileContainer)).toHaveLength(1);
+});

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -40,7 +40,9 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
         </Popover>
         <About isOpen={this.state.isAboutOpen} onClose={this.toggleAboutOpen} />
         <Help isOpen={this.state.isHelpOpen} onClose={this.toggleHelpOpen} />
-        <Profile isOpen={this.state.isProfileOpen} onClose={this.toggleProfileOpen} />
+        {this.props.name ? (
+          <Profile isOpen={this.state.isProfileOpen} onClose={this.toggleProfileOpen} />
+        ) : null}
       </>
     );
   }


### PR DESCRIPTION
## [Bugfix] Fix Profile component incorrectly mounting when not logged in
Fixes issue #846.

### Bug description
When the Academy loads, as part of `<NavigationBar>`, `<Dropdown>` was incorrectly mounting the `Profile` component despite the user not being logged into the Academy. As a result, `<Profile>`'s `componentDidMount` was triggering `handleAssessmentOverviewFetch()` to the backend, which correctly returned HTTP error code `401` (`Unauthorized`). This and the subsequent attempt to obtain a session token triggers the two 'Please login again.' warning notifications.

### Changelog
- Disable Profile component from mounting when not logged into Academy
- Add new tests to `<Dropdown>` to ensure Profile component is not mounted when a user is not logged in, and mounted when a user is logged in

Last updated 14 Aug 2019, 11:55PM