### PR TITLE
Fix scroll bar not clickable when Mission briefing is open

### DIFF
--- a/src/styles/_commons.scss
+++ b/src/styles/_commons.scss
@@ -33,6 +33,26 @@
   }
 }
 
+/*
+  Force Blueprint Dialog to scroll on focus
+
+  Note: there should exist a better fix, as the Blueprint Dialog behaves
+  properly on the official demo/documentation website
+  https://blueprintjs.com/docs/#core/components/dialog
+*/
 .#{$ns}-dialog-container {
   pointer-events: all;
+}
+
+/*
+  Temporary fix for this issue: https://github.com/palantir/blueprint/issues/1008
+
+  (when Blueprint Dialog is open, browser scroll bar is not clickable)
+*/
+.#{$ns}-overlay-backdrop {
+  display: none;
+}
+
+.#{$ns}-overlay-open {
+  background-color: rgba(16, 22, 26, 0.7);
 }


### PR DESCRIPTION
A fix for an innate BlueprintJS issue: the Dialog component does not allow you to click on the scroll bar. Currently mouse scrolling, arrow keys, or Page Up/Page Down keys have to be used to navigate the Mission briefing, which uses the Blueprint Dialog

Also, I added some comments to explain the CSS fixes