### PR TITLE
Fix 'Save & Continue' functionality in grading

### DIFF
--- a/src/mocks/backend.ts
+++ b/src/mocks/backend.ts
@@ -18,7 +18,6 @@ import { store } from '../createStore';
 import { IState, Role } from '../reducers/states';
 import { history } from '../utils/history';
 import { showSuccessMessage, showWarningMessage } from '../utils/notification';
-import { stringParamToInt } from '../utils/paramParseHelpers';
 import { mockAssessmentOverviews, mockAssessments } from './assessmentAPI';
 import { mockFetchGrading, mockFetchGradingOverview } from './gradingAPI';
 import { mockNotifications } from './userAPI';
@@ -158,21 +157,18 @@ export function* mockBackendSaga(): SagaIterator {
     const { submissionId } = action.payload;
     yield* sendGrade(action);
 
-    const currentUrl = window.location.pathname;
-    const gradingPath = '/academy/grading';
-    const match =
-      currentUrl.match(new RegExp(gradingPath + `/${submissionId}/(\\d+)`)) ||
-      currentUrl.match(new RegExp(gradingPath + `/${submissionId}`));
-    if (match) {
-      /**
-       * Move to next question for grading.
-       *
-       * If the questionId is out of bounds, the componentDidUpdate callback of
-       * GradingWorkspace will cause a redirect back to '/academy/grading'
-       */
-      const questionId = stringParamToInt(match[1]);
-      yield history.push(gradingPath + `/${submissionId}` + `/${(questionId || 0) + 1}`);
-    }
+    const currentQuestion = yield select(
+      (state: IState) => state.workspaces.grading.currentQuestion
+    );
+    /**
+     * Move to next question for grading: this only works because the
+     * SUBMIT_GRADING_AND_CONTINUE Redux action is currently only
+     * used in the Grading Workspace
+     *
+     * If the questionId is out of bounds, the componentDidUpdate callback of
+     * GradingWorkspace will cause a redirect back to '/academy/grading'
+     */
+    yield history.push('/academy/grading' + `/${submissionId}` + `/${(currentQuestion || 0) + 1}`);
   };
 
   yield takeEvery(actionTypes.SUBMIT_GRADING, sendGrade);

--- a/src/sagas/backend.ts
+++ b/src/sagas/backend.ts
@@ -24,6 +24,7 @@ import {
 import { IState, Role } from '../reducers/states';
 import { history } from '../utils/history';
 import { showSuccessMessage, showWarningMessage } from '../utils/notification';
+import { stringParamToInt } from '../utils/paramParseHelpers';
 import * as request from './requests';
 
 function* backendSaga(): SagaIterator {
@@ -266,17 +267,24 @@ function* backendSaga(): SagaIterator {
   const sendGradeAndContinue = function*(
     action: ReturnType<typeof actions.submitGradingAndContinue>
   ) {
-    const { submissionId, questionId } = action.payload;
+    const { submissionId } = action.payload;
     yield* sendGrade(action);
-    /**
-     * Move to next question for grading: this only works because the
-     * SUBMIT_GRADING_AND_CONTINUE Redux action is currently only
-     * used in the Grading Workspace
-     *
-     * If the questionId is out of bounds, the componentDidUpdate callback of
-     * GradingWorkspace will cause a redirect back to '/academy/grading'
-     */
-    yield history.push(`/academy/grading` + `/${submissionId}` + `/${questionId + 1}`);
+
+    const currentUrl = window.location.pathname;
+    const gradingPath = '/academy/grading';
+    const match =
+      currentUrl.match(new RegExp(gradingPath + `/${submissionId}/(\\d+)`)) ||
+      currentUrl.match(new RegExp(gradingPath + `/${submissionId}`));
+    if (match) {
+      /**
+       * Move to next question for grading.
+       *
+       * If the questionId is out of bounds, the componentDidUpdate callback of
+       * GradingWorkspace will cause a redirect back to '/academy/grading'
+       */
+      const questionId = stringParamToInt(match[1]);
+      yield history.push(gradingPath + `/${submissionId}` + `/${(questionId || 0) + 1}`);
+    }
   };
 
   yield takeEvery(actionTypes.SUBMIT_GRADING, sendGrade);


### PR DESCRIPTION
This commit fixes the "Save & Continue" button in grading to consistently bring you to the correct page.

Previously, the function updated the URL with the wrong value. Now, the function will simply try to get the current URL, and add 1 to the question number