### PR TITLE
Fix Blueprint Toast having dark background

### DIFF
--- a/src/styles/_commons.scss
+++ b/src/styles/_commons.scss
@@ -55,4 +55,8 @@
 
 .#{$ns}-overlay-open {
   background-color: rgba(16, 22, 26, 0.7);
+
+  &.#{$ns}-toast-container {
+    background-color: unset;
+  }
 }


### PR DESCRIPTION
A small fix for the dark background present on these notifications:

<img width="959" alt="bp3-overlay-open-fix" src="https://user-images.githubusercontent.com/49450743/63169918-8c095900-c06a-11e9-8e1a-df5652fe016e.png">

This is a consequence of the workaround introduced in #863. Apparently the notifications, which use the Blueprint Toast component, use the `bp3-overlay-open` CSS style as well
