### PR TITLE
Fix decoupling of active side-content tab and blue underline

### DIFF
--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -318,8 +318,21 @@ $code-color-error: #ff4444;
     justify-content: center;
     display: flex;
 
-    .#{$ns}-tab-list {
-      justify-content: center;
+    /*
+      Fixes an innate issue with bp3's Tabs component where the active tab underline
+      fails to re-compute its position when the browser window changes size
+
+      Also fixes an innate issue where the position of the active tab underline
+      decouples when the central divider is resized
+    */
+    .#{$ns}-tabs {
+      display: flex;
+      flex-direction: column;
+      flex-basis: center;
+
+      .#{$ns}-tab-list {
+        align-self: center;
+      }
     }
   }
 


### PR DESCRIPTION
## [Bugfix] Fix decoupling of active side-content tab and blue underline
Resolves issue #804.

### Bug description
Refer to issue #804 for full bug description.

### Changelog
- Applied CSS styling to some containers in bp3's `<Tabs>` to fix the decoupling between the active side-content tab and blue underline
   - Fixes both apply to resizing of the central divider and resizing of the browser window

### Demos
![fixed-side-content-tab-blue-underline](https://user-images.githubusercontent.com/44989315/63226794-4cc93c80-c211-11e9-89e4-77f3eb493f81.gif)

Last updated 18 Aug 2019, 11:45PM