### PR TITLE
Fix sendGrade not displaying a warning when grading is rejected

### DIFF
--- a/src/sagas/backend.ts
+++ b/src/sagas/backend.ts
@@ -259,7 +259,7 @@ function* backendSaga(): SagaIterator {
       });
       yield put(actions.updateGrading(submissionId, newGrading));
     } else {
-      request.handleResponseError(resp);
+      yield request.handleResponseError(resp);
     }
   };
 


### PR DESCRIPTION
## [Bugfix] Fix sendGrade not displaying a warning when grading is rejected
Fixes a silent bug required for implementation of https://github.com/source-academy/cadet/pull/474.

### Bug description
The `sendGrade` generator function, responsible for POSTing a staff member's grading for a question to the backend, does not correctly trigger `handleResponseError` to display a warning notification when the POST request is rejected with a HTTP error code. `handleResponseError` is itself a generator function and should be `yield`ed to instead of invoked directly.

### Changelog
- Add a `yield` to `handleResponseError` in `sendGrade` generator to ensure the HTTP error code and message are displayed in a warning notification

Last updated 19 Aug 2019, 11:00PM