### PR TITLE
Add question blocking to 'Return to Academy' button for Paths

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -433,32 +433,35 @@ class AssessmentWorkspace extends React.Component<
       history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`);
     const onClickReturn = () => history.push(listingPath);
 
-    // Replaces onClickNext if the current assessment is a Path
-    const onClickProgress = () => {
-      // Perform question blocking - determine the highest question number previously accessed
-      // by counting the number of questions that have a non-null answer
-      const blockedQuestionId =
-        this.props.assessment!.questions.filter(qn => qn.answer !== null).length - 1;
+    // Returns a nullary function that defers the navigation of the browser window, until the
+    // student's answer passes some checks - presently only used for Paths
+    const onClickProgress = (deferredNavigate: () => void) => {
+      return () => {
+        // Perform question blocking - determine the highest question number previously accessed
+        // by counting the number of questions that have a non-null answer
+        const blockedQuestionId =
+          this.props.assessment!.questions.filter(qn => qn.answer !== null).length - 1;
 
-      // If the current question does not block the next question, proceed as usual
-      if (questionId < blockedQuestionId) {
-        return history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`);
-      }
-      // Else evaluate its correctness - proceed iff the answer to the current question is correct
-      const question: IQuestion = this.props.assessment!.questions[questionId];
-      if (question.type === QuestionTypes.mcq) {
-        if (question.answer !== (question as IMCQQuestion).solution) {
-          return showWarningMessage('Your MCQ solution is incorrect!', 750);
+        // If the current question does not block the next question, proceed as usual
+        if (questionId < blockedQuestionId) {
+          return deferredNavigate();
         }
-      } else if (question.type === QuestionTypes.programming) {
-        const isCorrect = this.props.editorTestcases.reduce((acc, testcase) => {
-          return acc && stringify(testcase.result) === testcase.answer;
-        }, true);
-        if (!isCorrect) {
-          return showWarningMessage('Your solution has not passed all testcases!', 750);
+        // Else evaluate its correctness - proceed iff the answer to the current question is correct
+        const question: IQuestion = this.props.assessment!.questions[questionId];
+        if (question.type === QuestionTypes.mcq) {
+          if (question.answer !== (question as IMCQQuestion).solution) {
+            return showWarningMessage('Your MCQ solution is incorrect!', 750);
+          }
+        } else if (question.type === QuestionTypes.programming) {
+          const isCorrect = this.props.editorTestcases.reduce((acc, testcase) => {
+            return acc && stringify(testcase.result) === testcase.answer;
+          }, true);
+          if (!isCorrect) {
+            return showWarningMessage('Your solution has not passed all testcases!', 750);
+          }
         }
-      }
-      history.push(assessmentWorkspacePath + `/${(questionId + 1).toString()}`);
+        return deferredNavigate();
+      };
     };
 
     const onClickSave = () =>
@@ -485,11 +488,15 @@ class AssessmentWorkspace extends React.Component<
     const nextButton = (
       <NextButton
         onClickNext={
-          this.props.assessment && this.props.assessment.category === AssessmentCategories.Path
-            ? onClickProgress
+          this.props.assessment!.category === AssessmentCategories.Path
+            ? onClickProgress(onClickNext)
             : onClickNext
         }
-        onClickReturn={onClickReturn}
+        onClickReturn={
+          this.props.assessment!.category === AssessmentCategories.Path
+            ? onClickProgress(onClickReturn)
+            : onClickReturn
+        }
         questionProgress={questionProgress}
         key="next_question"
       />


### PR DESCRIPTION
## Add question blocking to 'Return to Academy' button for Paths
Summary: Addresses the disparity between question blocking enforcement by the 'Next' and 'Return to Academy' buttons in guided Paths, as introduced in https://github.com/source-academy/cadet-frontend/pull/833.

### Changelog
- Abstract out question blocking behaviour as a separate function `onClickProgress`, which accepts a nullary function performing a window navigation
   - In guided Paths, `onClickProgress` is used to defer the execution of the navigation function until the student's answer passes the relevant checks

### Mocks and Tests
The change was manually tested with the mock assessments in the development environment. Due to errors from attempting to deep-mount the `AssessmentWorkspace` component with Enzyme, no additional automated tests were written.

Last updated 21 Aug 2019, 03:45AM