### PR TITLE
Bump js-slang to latest (0.3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10202,9 +10202,9 @@
       "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q=="
     },
     "js-slang": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/js-slang/-/js-slang-0.3.0.tgz",
-      "integrity": "sha512-EPhU/qxNq35sCYSv8b43eOtK/zMl5+1E8gsHScfLlKzlz9C68jNkq5T3aWNcqcBfiOCiYasMF+ni+xmq2CSMbQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/js-slang/-/js-slang-0.3.1.tgz",
+      "integrity": "sha512-9L8Esl8dgsIA1j4eMs3lROv8sqBsviBGrsrVFb7Py2L+rZRYFy1mddUA1xKlXe/vPomUGgkbOxMhes6MktCBMg==",
       "requires": {
         "@types/estree": "0.0.39",
         "acorn": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "draft-js": "^0.10.5",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.3.0",
+    "js-slang": "^0.3.1",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.13",
     "lz-string": "^1.4.4",


### PR DESCRIPTION
The current version of js-slang used will crash the Playground when the Substituter is used with libraries like RUNES. In version 0.3.1, this was fixed, and running programs like this will no longer cause a crash:
```
function stackn_2(n, pic) {
    return n === 1
        ? pic
        : stack_frac(1 / n, pic, stackn_2(n - 1, pic));
}
show(stackn_2(3, heart));
```