### PR TITLE
Fix aggressive application of search filter to submissions

### DIFF
--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -247,6 +247,8 @@ class Grading extends React.Component<IGradingProps, State> {
               placeholder="Enter any text (e.g. mission)"
               value={this.state.filterValue}
               onChange={this.handleFilterChange}
+              onKeyPress={this.handleFilterKeypress}
+              onBlur={this.handleApplyFilter}
             />
           </FormGroup>
 
@@ -311,9 +313,17 @@ class Grading extends React.Component<IGradingProps, State> {
   private handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const changeVal = event.target.value;
     this.setState({ filterValue: changeVal });
+  };
 
+  private handleFilterKeypress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      this.handleApplyFilter();
+    }
+  };
+
+  private handleApplyFilter = () => {
     if (this.gridApi) {
-      this.gridApi.setQuickFilter(changeVal);
+      this.gridApi.setQuickFilter(this.state.filterValue);
     }
   };
 


### PR DESCRIPTION
## Fix aggressive application of search filter to submissions
Summary: Addresses #896 by modifying the filter bar to apply the search filter to datagrid submissions only on certain user actions.

### Changelog
- Edit `handleFilterChange` to no longer apply the filter when invoked - it now only updates the local state of the `Grading` component with the new `filterValue`
- Edit the filter bar `<InputGroup>` to only apply the filter when the user presses the ENTER key (whilst in focus) or clicks away from the filter bar (loses focus)

Last updated 25 Aug 2019, 05:00AM