### PR TITLE
Scrolling for long SUBST statements

### DIFF
--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -337,11 +337,8 @@ $code-color-error: #ff4444;
 
     // Specific CSS for the Substituter tab, since REPL is hidden
     ##{$ns}-tab-panel_side-content-tabs_subst_visualiser {
-      height: -webkit-fit-content;
-      height: -moz-fit-content;
-      height: fit-content;
+      height: calc(100% - 60px);
       margin-top: -45px;
-      overflow: hidden;
 
       .side-content-text {
         height: 100%;


### PR DESCRIPTION
This change is meant for issue #899.

Fixes #899

Overflow in the SUBST box is now no longer hidden, and height is calculated differently in order to fix an issue with Firefox where multiple scroll bars would appear

SUBST now works as intended for extremely long programs
