### PR TITLE
Improve warning notifications for failed HTTP requests to backend

### DIFF
--- a/src/sagas/requests.ts
+++ b/src/sagas/requests.ts
@@ -55,14 +55,14 @@ type Tokens = {
  * POST /auth
  */
 export async function postAuth(luminusCode: string): Promise<Tokens | null> {
-  const response = await request('auth', 'POST', {
+  const resp = await request('auth', 'POST', {
     body: { login: { luminus_code: luminusCode } },
     errorMessage: 'Could not login. Please contact the module administrator.'
   });
-  if (!response) {
+  if (!resp) {
     return null;
   }
-  const tokens = await response.json();
+  const tokens = await resp.json();
   return {
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token
@@ -73,13 +73,13 @@ export async function postAuth(luminusCode: string): Promise<Tokens | null> {
  * POST /auth/refresh
  */
 async function postRefresh(refreshToken: string): Promise<Tokens | null> {
-  const response = await request('auth/refresh', 'POST', {
+  const resp = await request('auth/refresh', 'POST', {
     body: { refresh_token: refreshToken }
   });
-  if (!response) {
+  if (!resp) {
     return null;
   }
-  const tokens = await response.json();
+  const tokens = await resp.json();
   return {
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token
@@ -90,15 +90,15 @@ async function postRefresh(refreshToken: string): Promise<Tokens | null> {
  * GET /user
  */
 export async function getUser(tokens: Tokens): Promise<object | null> {
-  const response = await request('user', 'GET', {
+  const resp = await request('user', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
-  if (!response || !response.ok) {
+  if (!resp || !resp.ok) {
     return null;
   }
-  return await response.json();
+  return await resp.json();
 }
 
 /**
@@ -107,15 +107,15 @@ export async function getUser(tokens: Tokens): Promise<object | null> {
 export async function getAssessmentOverviews(
   tokens: Tokens
 ): Promise<IAssessmentOverview[] | null> {
-  const response = await request('assessments', 'GET', {
+  const resp = await request('assessments', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
-  if (!response || !response.ok) {
+  if (!resp || !resp.ok) {
     return null; // invalid accessToken _and_ refreshToken
   }
-  const assessmentOverviews = await response.json();
+  const assessmentOverviews = await resp.json();
   return assessmentOverviews.map((overview: any) => {
     /**
      * backend has property ->     type: 'mission' | 'sidequest' | 'path' | 'contest'
@@ -132,15 +132,15 @@ export async function getAssessmentOverviews(
  * GET /assessments/${assessmentId}
  */
 export async function getAssessment(id: number, tokens: Tokens): Promise<IAssessment | null> {
-  const response = await request(`assessments/${id}`, 'GET', {
+  const resp = await request(`assessments/${id}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
-  if (!response || !response.ok) {
+  if (!resp || !resp.ok) {
     return null;
   }
-  const assessment = (await response.json()) as IAssessment;
+  const assessment = (await resp.json()) as IAssessment;
   // backend has property ->     type: 'mission' | 'sidequest' | 'path' | 'contest'
   //              we have -> category: 'Mission' | 'Sidequest' | 'Path' | 'Contest'
   assessment.category = capitalise((assessment as any).type) as AssessmentCategory;
@@ -211,15 +211,15 @@ export async function getGradingOverviews(
   tokens: Tokens,
   group: boolean
 ): Promise<GradingOverview[] | null> {
-  const response = await request(`grading?group=${group}`, 'GET', {
+  const resp = await request(`grading?group=${group}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
-  if (!response) {
+  if (!resp) {
     return null; // invalid accessToken _and_ refreshToken
   }
-  const gradingOverviews = await response.json();
+  const gradingOverviews = await resp.json();
   return gradingOverviews.map((overview: any) => {
     const gradingOverview: GradingOverview = {
       assessmentId: overview.assessment.id,
@@ -254,15 +254,15 @@ export async function getGradingOverviews(
  * @returns {Grading}
  */
 export async function getGrading(submissionId: number, tokens: Tokens): Promise<Grading | null> {
-  const response = await request(`grading/${submissionId}`, 'GET', {
+  const resp = await request(`grading/${submissionId}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
-  if (!response) {
+  if (!resp) {
     return null;
   }
-  const gradingResult = await response.json();
+  const gradingResult = await resp.json();
   const grading: Grading = gradingResult.map((gradingQuestion: any) => {
     const { student, question, grade } = gradingQuestion;
 
@@ -405,30 +405,30 @@ export async function postNotify(tokens: Tokens, assessmentId?: number, submissi
  * DELETE /sourcecast
  */
 export async function deleteSourcecastEntry(id: number, tokens: Tokens) {
-  const response = await request(`sourcecast/${id}`, 'DELETE', {
+  const resp = await request(`sourcecast/${id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return response;
+  return resp;
 }
 
 /**
  * GET /sourcecast
  */
 export async function getSourcecastIndex(tokens: Tokens): Promise<ISourcecastData[] | null> {
-  const response = await request('sourcecast', 'GET', {
+  const resp = await request('sourcecast', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  if (!response || !response.ok) {
+  if (!resp || !resp.ok) {
     return null;
   }
-  const index = await response.json();
+  const index = await resp.json();
   return index;
 }
 
@@ -464,14 +464,14 @@ export const postSourcecast = async (
  * DELETE /material
  */
 export async function deleteMaterial(id: number, tokens: Tokens) {
-  const response = await request(`material/${id}`, 'DELETE', {
+  const resp = await request(`material/${id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return response;
+  return resp;
 }
 
 /**
@@ -479,14 +479,14 @@ export async function deleteMaterial(id: number, tokens: Tokens) {
  */
 export async function getMaterialIndex(id: number, tokens: Tokens): Promise<MaterialData[] | null> {
   const url = id === -1 ? `material` : `material?id=${id}`;
-  const response = await request(url, 'GET', {
+  const resp = await request(url, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  if (response && response.ok) {
-    return await response.json();
+  if (resp && resp.ok) {
+    return await resp.json();
   } else {
     return null;
   }
@@ -525,14 +525,14 @@ export const postMaterial = async (
  * DELETE /category
  */
 export async function deleteMaterialFolder(id: number, tokens: Tokens) {
-  const response = await request(`category/${id}`, 'DELETE', {
+  const resp = await request(`category/${id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return response;
+  return resp;
 }
 
 /**
@@ -585,10 +585,10 @@ async function request(
     }
   }
   try {
-    const response = await fetch(`${BACKEND_URL}/v1/${path}`, fetchOpts);
+    const resp = await fetch(`${BACKEND_URL}/v1/${path}`, fetchOpts);
     // response.ok is (200 <= response.status <= 299)
     // response.status of > 299 does not raise error; so deal with in in the try clause
-    if (opts.shouldRefresh && response && response.status === 401) {
+    if (opts.shouldRefresh && resp && resp.status === 401) {
       const newTokens = await postRefresh(opts.refreshToken!);
       store.dispatch(actions.setTokens(newTokens!));
       const newOpts = {
@@ -598,16 +598,16 @@ async function request(
       };
       return request(path, method, newOpts);
     }
-    if (response && !response.ok && opts.shouldAutoLogout === false) {
+    if (resp && !resp.ok && opts.shouldAutoLogout === false) {
       // this clause is mostly for SUBMIT_ANSWER; show an error message instead
       // and ask student to manually logout, so that they have a chance to save
       // their answers
-      return response;
+      return resp;
     }
-    if (!response || !response.ok) {
+    if (!resp || !resp.ok) {
       throw new Error('API call failed or got non-OK response');
     }
-    return response;
+    return resp;
   } catch (e) {
     store.dispatch(actions.logOut());
     showWarningMessage(opts.errorMessage ? opts.errorMessage : 'Please login again.');
@@ -615,21 +615,40 @@ async function request(
   }
 }
 
-export function* handleResponseError(resp: Response | null) {
+/**
+ * Handles display of warning notifications for failed HTTP requests, i.e. those with no response
+ * or a HTTP error status code (not 2xx).
+ *
+ * @param   {(Response|null)}     resp    Result of the failed HTTP request
+ * @param   {Map<number, string>} codes   Optional Map for status codes to custom warning messages
+ */
+export function* handleResponseError(resp: Response | null, codes?: Map<number, string>) {
+  // Default: check if the response is null
   if (!resp) {
     yield call(showWarningMessage, "Couldn't reach our servers. Are you online?");
     return;
   }
 
   let errorMessage: string;
-  switch (resp.status) {
-    case 401:
-      errorMessage = 'Session expired. Please login again.';
-      break;
-    default:
-      errorMessage = `Error ${resp.status}: ${resp.statusText}`;
-      break;
+
+  // Show a generic message if the failed response is missing a status code
+  if (!resp.status) {
+    errorMessage = 'Something went wrong (received response with no status code)';
+  } else if (codes && codes.has(resp.status)) {
+    // If the optional map was supplied, check the response against it with its status code
+    errorMessage = codes.get(resp.status)!;
+  } else {
+    // Otherwise match on the status code for common status codes
+    switch (resp.status) {
+      case 401:
+        errorMessage = 'Session expired. Please login again.';
+        break;
+      default:
+        errorMessage = `Something went wrong (got ${resp.status} response)`;
+        break;
+    }
   }
+
   yield call(showWarningMessage, errorMessage);
 }
 


### PR DESCRIPTION
## Improve warning notifications for failed HTTP requests to backend
Summary: Cleans up and simplifies the handling of failed HTTP requests (those with no response or a response with a HTTP error status code).

### Changelog
- Standardise the use of `resp` in place of `response` across `backend.ts` and `requests.ts` to avoid naming conflict with the `Response` interface
- Rewrote handling of non-ideal responses to make use of guards to invoke `handleResponseError` instead of explicit `if`-`else` blocks
- Abstract out error status code handling into `handleResponseError`
   - `handleResponseError` now accepts an optional argument `codes` of type `Map<number, string>`
   - This allows each backend Saga to display custom messages in the warning notification by matching the error status code to a string value in `codes`, if supplied
   - Otherwise, the message defaults to `Something went wrong (got ${resp.status} response)`
- Added custom warning messages to the backend Sagas for the actions `SUBMIT_ANSWER`, `SUBMIT_ASSESSMENT`, `UNSUBMIT_SUBMISSION` and `SUBMIT_GRADING`

### Mocks and Tests
- Update backend Saga tests to include a HTTP error status code for tests using an error response

### Screenshots

#### Warning notification (student attempting to submit answer on a finalised submission)
![warning-notification-submit-answer-on-finalised](https://user-images.githubusercontent.com/44989315/63650548-42152700-c77e-11e9-9b54-8411e0e4ac30.png)

#### Warning notification (staff attempting to unsubmit a non-finalised submission)
![warning-notification-unsubmit-on-non-finalised-submission](https://user-images.githubusercontent.com/44989315/63650549-46414480-c77e-11e9-96cb-0d6335917a59.png)

#### Warning notification (staff attempting to grade on a non-finalised submission)
![warning-notification-submit-grading-on-non-finalised-submission](https://user-images.githubusercontent.com/44989315/63650552-480b0800-c77e-11e9-8326-4ac829572e4a.png)

Last updated 25 Aug 2019, 09:00PM