### PR TITLE
Fix broken CSS of ChatApp component

### DIFF
--- a/src/components/chat/ChatApp.js
+++ b/src/components/chat/ChatApp.js
@@ -96,7 +96,7 @@ class ChatApp extends React.Component {
         return (
           <div className="Chat">
             <MessageList
-              className="message-list"
+              className="chat-messages"
               viewingUserId={this.state.currentUser.id}
               messages={this.state.messages}
             />

--- a/src/components/chat/ChatApp.js
+++ b/src/components/chat/ChatApp.js
@@ -96,12 +96,10 @@ class ChatApp extends React.Component {
         return (
           <div className="Chat">
             <MessageList
-              className="chat-messages"
-              viewingUserId={this.state.currentUser.id}
               messages={this.state.messages}
             />
             <hr />
-            <Input className="input-field" onSubmit={this.addMessage} />
+            <Input onSubmit={this.addMessage} />
             <div ref={this.messagesEndRef} />
           </div>
         );

--- a/src/components/chat/Input.tsx
+++ b/src/components/chat/Input.tsx
@@ -29,10 +29,10 @@ class Input extends React.Component<IInputProps, StateProps> {
     };
 
     return (
-      <div className="Input">
-        <div className="Input-zone">
+      <div>
+        <div className="input-zone">
           <TextArea
-            className="Input-msg"
+            className="input-msg"
             placeholder="Type your message here"
             onChange={this.handleChange}
             value={this.state.message}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -18,7 +18,7 @@ type StateProps = {
 class MessageList extends React.Component<StateProps> {
   public render() {
     return (
-      <div className="MessageList">
+      <div>
         <ul className="msg-list">
           {this.props.messages.length > 0 ? (
             this.props.messages.map((message: Message, index: number) => (

--- a/src/styles/_chat.scss
+++ b/src/styles/_chat.scss
@@ -1,44 +1,49 @@
-.MessageList {
-  .dialogue-box {
-    font-family: inherit;
-    padding: 8px 15px 9px 15px;
-    white-space: pre-wrap; /* CSS3 */
-    white-space: -moz-pre-wrap; /* Firefox */
-    white-space: -pre-wrap; /* Opera <7 */
-    white-space: -o-pre-wrap; /* Opera 7 */
-    word-break: break-word;
-  }
+.Chat {
+  .chat-messages {
+    .dialogue-box {
+      font-family: inherit;
+      padding: 8px 15px 9px 15px;
+      white-space: pre-wrap; /* CSS3 */
+      white-space: -moz-pre-wrap; /* Firefox */
+      white-space: -pre-wrap; /* Opera <7 */
+      white-space: -o-pre-wrap; /* Opera 7 */
+      word-break: break-word;
+    }
 
-  .msg-item {
-    list-style-type: none;
-  }
+    .msg-list {
+      padding: 0px 0px 5px 0px;
+    }
 
-  .msg-list {
-    padding: 0px 0px 5px 0px;
-  }
+    .msg-item {
+      list-style-type: none;
+    }
 
-  .msg-sender {
-    font-weight: bold;
-    margin: 0px 0px 7px 0px;
-  }
-  .msg-date {
-    font-size: 11px;
-    font-family: monospace;
-  }
-}
+    .msg-sender {
+      font-weight: bold;
+      margin: 0px 0px 7px 0px;
+    }
 
-.Input {
-  .Input-zone {
-    padding: 0px 0px 5px 0px;
-    .Input-msg {
-      height: 90px;
-      outline: none;
-      resize: none;
-      width: 100%;
+    .msg-date {
+      font-size: 11px;
+      font-family: monospace;
     }
   }
-  .markdown-link {
-    color: inherit;
-    font-style: italic;
+
+  .input-field {
+    .input-zone {
+      padding: 0px 0px 5px 0px;
+
+      .input-msg {
+        height: 90px;
+        outline: none;
+        resize: none;
+        width: 100%;
+      }
+    }
+
+    .markdown-link {
+      color: inherit;
+      font-style: italic;
+    }
   }
 }

--- a/src/styles/_chat.scss
+++ b/src/styles/_chat.scss
@@ -1,49 +1,45 @@
 .Chat {
-  .chat-messages {
-    .dialogue-box {
-      font-family: inherit;
-      padding: 8px 15px 9px 15px;
-      white-space: pre-wrap; /* CSS3 */
-      white-space: -moz-pre-wrap; /* Firefox */
-      white-space: -pre-wrap; /* Opera <7 */
-      white-space: -o-pre-wrap; /* Opera 7 */
-      word-break: break-word;
-    }
+  .dialogue-box {
+    font-family: inherit;
+    padding: 8px 15px 9px 15px;
+    white-space: pre-wrap; /* CSS3 */
+    white-space: -moz-pre-wrap; /* Firefox */
+    white-space: -pre-wrap; /* Opera <7 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-break: break-word;
+  }
 
-    .msg-list {
-      padding: 0px 0px 5px 0px;
-    }
+  .msg-list {
+    padding: 0px 0px 5px 0px;
+  }
 
-    .msg-item {
-      list-style-type: none;
-    }
+  .msg-item {
+    list-style-type: none;
+  }
 
-    .msg-sender {
-      font-weight: bold;
-      margin: 0px 0px 7px 0px;
-    }
+  .msg-sender {
+    font-weight: bold;
+    margin: 0px 0px 7px 0px;
+  }
 
-    .msg-date {
-      font-size: 11px;
-      font-family: monospace;
+  .msg-date {
+    font-size: 11px;
+    font-family: monospace;
+  }
+
+  .input-zone {
+    padding: 0px 0px 5px 0px;
+
+    .input-msg {
+      height: 90px;
+      outline: none;
+      resize: none;
+      width: 100%;
     }
   }
 
-  .input-field {
-    .input-zone {
-      padding: 0px 0px 5px 0px;
-
-      .input-msg {
-        height: 90px;
-        outline: none;
-        resize: none;
-        width: 100%;
-      }
-    }
-
-    .markdown-link {
-      color: inherit;
-      font-style: italic;
-    }
+  .markdown-link {
+    color: inherit;
+    font-style: italic;
   }
 }


### PR DESCRIPTION
## [Bugfix] Fix broken CSS of ChatApp component
Fixes inconsistencies in the class names of HTML elements in the ChatApp component and the corresponding stylesheet. **These changes were not tested in the current development environment as it is not connected to a live Chatkit instance.**

### Bug description
The current UI of the ChatApp component in production is currently broken as the CSS styles are not being correctly applied.

![broken-chatkit-css](https://user-images.githubusercontent.com/44989315/63855286-a5e35e00-c9d1-11e9-9ff0-81f07fb57a01.png)

### Changelog
- Standardise the class names of HTML elements in `<ChatApp>` referenced by the `_chat.scss` stylesheet, with the same naming convention as the rest of the Academy

Last updated 18 Aug 2019, 11:45PM