### PR TITLE
Improve custom tooltips in grading overviews page

### DIFF
--- a/src/components/academy/grading/GradeCell.tsx
+++ b/src/components/academy/grading/GradeCell.tsx
@@ -28,7 +28,7 @@ class GradeCell extends React.Component<GradeCellProps, {}> {
       } adj.)`;
       return (
         <div>
-          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
+          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={10} lazy={true}>
             {`${this.props.data.currentGrade} / ${this.props.data.maxGrade}`}
           </Tooltip>
         </div>

--- a/src/components/academy/grading/GradeCell.tsx
+++ b/src/components/academy/grading/GradeCell.tsx
@@ -21,11 +21,9 @@ class GradeCell extends React.Component<GradeCellProps, {}> {
 
   /** Component to render in table - marks */
   public render() {
-    if (this.props.data.maxGrade !== 0) {
+    if (this.props.data.maxGrade) {
       const tooltip = `Initial Grade: ${this.props.data.initialGrade}
-        (${this.props.data.gradeAdjustment > 0 ? '+' : ''}${
-        this.props.data.gradeAdjustment
-      } adjustment)`;
+        (${this.props.data.gradeAdjustment >= 0 ? '+' : ''}${this.props.data.gradeAdjustment} adj.)`;
       return (
         <div>
           <Tooltip content={tooltip} position={Position.LEFT}>

--- a/src/components/academy/grading/GradeCell.tsx
+++ b/src/components/academy/grading/GradeCell.tsx
@@ -23,10 +23,12 @@ class GradeCell extends React.Component<GradeCellProps, {}> {
   public render() {
     if (this.props.data.maxGrade) {
       const tooltip = `Initial Grade: ${this.props.data.initialGrade}
-        (${this.props.data.gradeAdjustment >= 0 ? '+' : ''}${this.props.data.gradeAdjustment} adj.)`;
+        (${this.props.data.gradeAdjustment >= 0 ? '+' : ''}${
+        this.props.data.gradeAdjustment
+      } adj.)`;
       return (
         <div>
-          <Tooltip content={tooltip} position={Position.LEFT}>
+          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
             {`${this.props.data.currentGrade} / ${this.props.data.maxGrade}`}
           </Tooltip>
         </div>

--- a/src/components/academy/grading/GradingStatusCell.tsx
+++ b/src/components/academy/grading/GradingStatusCell.tsx
@@ -55,7 +55,7 @@ class GradingStatusCell extends React.Component<GradingStatusCellProps, {}> {
 
     return (
       <div>
-        <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
+        <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={10} lazy={true}>
           <Icon icon={iconName} intent={intent} />
         </Tooltip>
       </div>

--- a/src/components/academy/grading/GradingStatusCell.tsx
+++ b/src/components/academy/grading/GradingStatusCell.tsx
@@ -55,7 +55,7 @@ class GradingStatusCell extends React.Component<GradingStatusCellProps, {}> {
 
     return (
       <div>
-        <Tooltip content={tooltip} position={Position.LEFT}>
+        <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
           <Icon icon={iconName} intent={intent} />
         </Tooltip>
       </div>

--- a/src/components/academy/grading/XPCell.tsx
+++ b/src/components/academy/grading/XPCell.tsx
@@ -21,13 +21,14 @@ class XPCell extends React.Component<XPCellProps, {}> {
 
   /** Component to render in table - XP */
   public render() {
-    if (this.props.data.currentXp && this.props.data.maxXp) {
+    if (this.props.data.maxXp || this.props.data.xpBonus) {
       const tooltip = `Initial XP: ${this.props.data.initialXp}
-        (${this.props.data.xpAdjustment > 0 ? '+' : ''}${this.props.data.xpAdjustment} adjustment)`;
+        (${this.props.data.xpBonus > 0 ? `+${this.props.data.xpBonus} bonus ` : ''}
+        ${this.props.data.xpAdjustment >= 0 ? '+' : ''}${this.props.data.xpAdjustment} adj.)`;
       return (
         <div>
           <Tooltip content={tooltip} position={Position.LEFT}>
-            {`${this.props.data.currentXp} / ${this.props.data.maxXp}`}
+            {`${this.props.data.currentXp + this.props.data.xpBonus} / ${this.props.data.maxXp}`}
           </Tooltip>
         </div>
       );

--- a/src/components/academy/grading/XPCell.tsx
+++ b/src/components/academy/grading/XPCell.tsx
@@ -27,7 +27,7 @@ class XPCell extends React.Component<XPCellProps, {}> {
         ${this.props.data.xpAdjustment >= 0 ? '+' : ''}${this.props.data.xpAdjustment} adj.)`;
       return (
         <div>
-          <Tooltip content={tooltip} position={Position.LEFT}>
+          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
             {`${this.props.data.currentXp + this.props.data.xpBonus} / ${this.props.data.maxXp}`}
           </Tooltip>
         </div>

--- a/src/components/academy/grading/XPCell.tsx
+++ b/src/components/academy/grading/XPCell.tsx
@@ -27,7 +27,7 @@ class XPCell extends React.Component<XPCellProps, {}> {
         ${this.props.data.xpAdjustment >= 0 ? '+' : ''}${this.props.data.xpAdjustment} adj.)`;
       return (
         <div>
-          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={0} lazy={true}>
+          <Tooltip content={tooltip} position={Position.LEFT} hoverOpenDelay={10} lazy={true}>
             {`${this.props.data.currentXp + this.props.data.xpBonus} / ${this.props.data.maxXp}`}
           </Tooltip>
         </div>

--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -201,7 +201,7 @@ class Grading extends React.Component<IGradingProps, State> {
       { headerName: 'XP Adjustment', field: 'xpAdjustment', hide: true },
       { headerName: 'Current Grade', field: 'currentGrade', hide: true },
       { headerName: 'Max Grade', field: 'maxGrade', hide: true },
-      { headerName: 'Current XP', field: 'currentXp', hide: true },
+      { headerName: 'Current XP (excl. bonus)', field: 'currentXp', hide: true },
       { headerName: 'Max XP', field: 'maxXp', hide: true },
       { headerName: 'Bonus XP', field: 'xpBonus', hide: true }
     ];
@@ -342,7 +342,28 @@ class Grading extends React.Component<IGradingProps, State> {
     if (this.gridApi === undefined) {
       return;
     }
-    this.gridApi.exportDataAsCsv({ allColumns: true });
+    this.gridApi.exportDataAsCsv({
+      fileName: `SA submissions (${new Date().toISOString()}).csv`,
+      // Explicitly declare exported columns to avoid exporting trash columns
+      columnKeys: [
+        'assessmentName',
+        'assessmentCategory',
+        'studentName',
+        'submissionStatus',
+        'gradingStatus',
+        'questionCount',
+        'gradedCount',
+        'initialGrade',
+        'gradeAdjustment',
+        'currentGrade',
+        'maxGrade',
+        'initialXp',
+        'xpAdjustment',
+        'currentXp',
+        'maxXp',
+        'xpBonus'
+      ]
+    });
   };
 
   /* Submissions will be sorted in the following order:

--- a/src/components/notification/NotificationBadge.tsx
+++ b/src/components/notification/NotificationBadge.tsx
@@ -64,6 +64,9 @@ const NotificationBadge: React.SFC<OwnProps & StateProps & DispatchProps> = prop
         content={notificationTags}
         interactionKind={PopoverInteractionKind.HOVER}
         position={Position.RIGHT}
+        hoverOpenDelay={50}
+        hoverCloseDelay={50}
+        lazy={true}
       >
         {notificationIcon}
       </Popover>

--- a/src/components/notification/__tests__/__snapshots__/NotificationBadge.tsx.snap
+++ b/src/components/notification/__tests__/__snapshots__/NotificationBadge.tsx.snap
@@ -4,7 +4,7 @@ exports[`Badge does not render with no notifications 1`] = `"<NotificationBadge 
 
 exports[`Badge renders properly with notifications 1`] = `
 "<NotificationBadge notifications={{...}} handleAcknowledgeNotifications={[Function: handleAcknowledgeNotifications]}>
-  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
+  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" hoverOpenDelay={50} hoverCloseDelay={50} lazy={true} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
     <Manager>
       <span className=\\"bp3-popover-wrapper\\">
         <Reference innerRef={[Function: target]}>
@@ -35,7 +35,7 @@ exports[`Badge renders properly with notifications 1`] = `
 
 exports[`Badge with filter, filterNotificationsByAssessment renders properly 1`] = `
 "<NotificationBadge notifications={{...}} handleAcknowledgeNotifications={[Function: handleAcknowledgeNotifications]} notificationFilter={[Function]}>
-  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
+  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" hoverOpenDelay={50} hoverCloseDelay={50} lazy={true} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
     <Manager>
       <span className=\\"bp3-popover-wrapper\\">
         <Reference innerRef={[Function: target]}>
@@ -66,7 +66,7 @@ exports[`Badge with filter, filterNotificationsByAssessment renders properly 1`]
 
 exports[`Badge with filter, filterNotificationsByAssessment renders properly 2`] = `
 "<NotificationBadge notifications={{...}} handleAcknowledgeNotifications={[Function: handleAcknowledgeNotifications]} notificationFilter={[Function]}>
-  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
+  <Blueprint3.Popover className={[undefined]} content={{...}} interactionKind=\\"hover\\" position=\\"right\\" hoverOpenDelay={50} hoverCloseDelay={50} lazy={true} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
     <Manager>
       <span className=\\"bp3-popover-wrapper\\">
         <Reference innerRef={[Function: target]}>


### PR DESCRIPTION
## Improve custom tooltips in grading overviews page
Summary: The datagrid component rendering submissions in the grading overviews page makes use of many custom tooltips - this PR improves their responsiveness and the usefulness of information displayed. Resolves #907.

### Changelog
- Fix the XP cell in the datagrid failing to include bonus XP in the total XP of a submission
- Fix the XP tooltip not rendering when the max XP of an assessment is zero despite the submission having non-zero total XP
   - XP tooltip now additionally displays the bonus XP for graded assessments
- Improve responsiveness of tooltips when hovering over cells by reducing the default hover delay for opening and closing
- Lazy-load all tooltips into the DOM for minor performance improvement
- Fix irrelevant columns from datagrid being exported when clicking 'Export to CSV'
   - All exported columns are explicitly named to avoid exporting cells with no actual data
- Apply a standard name to exported .csv file with format `SA submissions (<timestamp>).csv`

### Mocks and Tests
- Update failing snapshots for the notifications badge (`NotificationBadge` component)

### Screenshots

#### Updated XP cell and tooltip (before-after comparison)
![before-after-xp-tooltip](https://user-images.githubusercontent.com/44989315/64066261-ecdb8880-cc49-11e9-9458-c9f7d0f43002.png)

#### UX demonstration (reduced tooltip hover delays)
![more-responsive-tooltips](https://user-images.githubusercontent.com/44989315/64066562-f6ff8600-cc4d-11e9-8666-5784084da9b5.gif)

Last updated 1 Sept 2019, 12:15AM