### PR TITLE
Grading overview page improvements

### DIFF
--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -365,9 +365,7 @@ class Grading extends React.Component<IGradingProps, State> {
     );
 
     return sortBy(newOverviews, [
-      (a: GradingOverviewWithNotifications) => (a.notifications.length > 0 ? -1 : 0),
-      (a: GradingOverview) => -a.assessmentId,
-      (a: GradingOverview) => -a.submissionId
+      (a: GradingOverviewWithNotifications) => (a.notifications.length > 0 ? -1 : 0)
     ]);
   };
 }

--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -233,7 +233,7 @@ class Grading extends React.Component<IGradingProps, State> {
         icon={<Spinner size={Spinner.SIZE_LARGE} />}
       />
     );
-    const data = this.buildSubmissionsWithNotifications();
+    const data = this.sortSubmissionsByNotifications();
 
     const grid = (
       <div className="GradingContainer">
@@ -281,6 +281,7 @@ class Grading extends React.Component<IGradingProps, State> {
               enableFilter={true}
               columnDefs={this.columnDefs}
               onGridReady={this.onGridReady}
+              onGridSizeChanged={this.resizeGrid}
               rowData={data}
               rowHeight={30}
               pagination={true}
@@ -306,9 +307,17 @@ class Grading extends React.Component<IGradingProps, State> {
     // Only update grid data when a notification is acknowledged
     if (this.gridApi && this.props.notifications.length !== prevProps.notifications.length) {
       // Pass the new reconstructed row data to the grid after fetching the updated notifs
-      this.gridApi.setRowData(this.buildSubmissionsWithNotifications());
+      this.gridApi.setRowData(this.sortSubmissionsByNotifications());
     }
   }
+
+  // Forcibly resizes columns to fit the width of the datagrid - prevents datagrid
+  // from needing to render a horizontal scrollbar when columns overflow grid width
+  private resizeGrid = () => {
+    if (this.gridApi) {
+      this.gridApi.sizeColumnsToFit();
+    }
+  };
 
   private handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const changeVal = event.target.value;
@@ -337,7 +346,6 @@ class Grading extends React.Component<IGradingProps, State> {
   private onGridReady = (params: GridReadyEvent) => {
     this.gridApi = params.api;
     this.gridApi.sizeColumnsToFit();
-    window.onresize = () => this.gridApi!.sizeColumnsToFit();
   };
 
   private exportCSV = () => {
@@ -351,7 +359,7 @@ class Grading extends React.Component<IGradingProps, State> {
    *  @return Returns an array of data nodes, prioritising grading overviews with
    *  notifications first.
    */
-  private buildSubmissionsWithNotifications: () => GradingOverviewWithNotifications[] = () => {
+  private sortSubmissionsByNotifications = () => {
     if (!this.props.gradingOverviews) {
       return [];
     }

--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -284,7 +284,7 @@ class Grading extends React.Component<IGradingProps, State> {
               rowData={data}
               rowHeight={30}
               pagination={true}
-              paginationPageSize={50}
+              paginationPageSize={25}
               suppressMovableColumns={true}
             />
           </div>
@@ -328,8 +328,10 @@ class Grading extends React.Component<IGradingProps, State> {
   };
 
   private handleGroupsFilter = () => {
-    this.setState({ groupFilterEnabled: !this.state.groupFilterEnabled });
-    this.props.handleFetchGradingOverviews(this.state.groupFilterEnabled);
+    if (this.gridApi) {
+      this.setState({ groupFilterEnabled: !this.state.groupFilterEnabled });
+      this.props.handleFetchGradingOverviews(this.state.groupFilterEnabled);
+    }
   };
 
   private onGridReady = (params: GridReadyEvent) => {
@@ -339,10 +341,9 @@ class Grading extends React.Component<IGradingProps, State> {
   };
 
   private exportCSV = () => {
-    if (this.gridApi === undefined) {
-      return;
+    if (this.gridApi) {
+      this.gridApi.exportDataAsCsv({ allColumns: true });
     }
-    this.gridApi.exportDataAsCsv({ allColumns: true });
   };
 
   /** Constructs data nodes for the datagrid by joining grading overviews with their

--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -96,10 +96,11 @@ class Grading extends React.Component<IGradingProps, State> {
         headerName: '',
         field: 'notifications',
         cellRendererFramework: NotificationBadgeCell,
-        maxWidth: 30,
+        width: 30,
         suppressResize: true,
         suppressMovable: true,
-        suppressMenu: true
+        suppressMenu: true,
+        suppressSizeToFit: true
       },
       { headerName: 'Assessment Name', field: 'assessmentName' },
       { headerName: 'Category', field: 'assessmentCategory', maxWidth: 100 },

--- a/src/mocks/gradingAPI.ts
+++ b/src/mocks/gradingAPI.ts
@@ -89,11 +89,13 @@ export const mockFetchGradingOverview = (
   if (role === null || !permittedRoles.includes(role)) {
     return null;
   } else {
-    return group ? [mockGradingOverviews[0]] : mockGradingOverviews.sort(
-      (subX: GradingOverview, subY: GradingOverview) => subX.assessmentId !== subY.assessmentId
-        ? subY.assessmentId - subX.assessmentId
-        : subY.submissionId - subX.submissionId
-    );
+    return group
+      ? [mockGradingOverviews[0]]
+      : mockGradingOverviews.sort((subX: GradingOverview, subY: GradingOverview) =>
+          subX.assessmentId !== subY.assessmentId
+            ? subY.assessmentId - subX.assessmentId
+            : subY.submissionId - subX.submissionId
+        );
   }
 };
 

--- a/src/mocks/gradingAPI.ts
+++ b/src/mocks/gradingAPI.ts
@@ -89,7 +89,11 @@ export const mockFetchGradingOverview = (
   if (role === null || !permittedRoles.includes(role)) {
     return null;
   } else {
-    return group ? [mockGradingOverviews[0]] : mockGradingOverviews;
+    return group ? [mockGradingOverviews[0]] : mockGradingOverviews.sort(
+      (subX: GradingOverview, subY: GradingOverview) => subX.assessmentId !== subY.assessmentId
+        ? subY.assessmentId - subX.assessmentId
+        : subY.submissionId - subX.submissionId
+    );
   }
 };
 

--- a/src/sagas/requests.ts
+++ b/src/sagas/requests.ts
@@ -253,7 +253,11 @@ export async function getGradingOverviews(
       xpBonus: overview.xpBonus
     };
     return gradingOverview;
-  });
+  }).sort(
+    (subX: GradingOverview, subY: GradingOverview) => subX.assessmentId !== subY.assessmentId
+      ? subY.assessmentId - subX.assessmentId
+      : subY.submissionId - subX.submissionId
+  );
 }
 
 /**

--- a/src/sagas/requests.ts
+++ b/src/sagas/requests.ts
@@ -227,37 +227,39 @@ export async function getGradingOverviews(
     return null; // invalid accessToken _and_ refreshToken
   }
   const gradingOverviews = await resp.json();
-  return gradingOverviews.map((overview: any) => {
-    const gradingOverview: GradingOverview = {
-      assessmentId: overview.assessment.id,
-      assessmentName: overview.assessment.title,
-      assessmentCategory: capitalise(overview.assessment.type) as AssessmentCategory,
-      studentId: overview.student.id,
-      studentName: overview.student.name,
-      submissionId: overview.id,
-      submissionStatus: overview.status,
-      groupName: overview.groupName,
-      // Grade
-      initialGrade: overview.grade,
-      gradeAdjustment: overview.adjustment,
-      currentGrade: overview.grade + overview.adjustment,
-      maxGrade: overview.assessment.maxGrade,
-      gradingStatus: overview.gradingStatus,
-      questionCount: overview.questionCount,
-      gradedCount: overview.gradedCount,
-      // XP
-      initialXp: overview.xp,
-      xpAdjustment: overview.xpAdjustment,
-      currentXp: overview.xp + overview.xpAdjustment,
-      maxXp: overview.assessment.maxXp,
-      xpBonus: overview.xpBonus
-    };
-    return gradingOverview;
-  }).sort(
-    (subX: GradingOverview, subY: GradingOverview) => subX.assessmentId !== subY.assessmentId
-      ? subY.assessmentId - subX.assessmentId
-      : subY.submissionId - subX.submissionId
-  );
+  return gradingOverviews
+    .map((overview: any) => {
+      const gradingOverview: GradingOverview = {
+        assessmentId: overview.assessment.id,
+        assessmentName: overview.assessment.title,
+        assessmentCategory: capitalise(overview.assessment.type) as AssessmentCategory,
+        studentId: overview.student.id,
+        studentName: overview.student.name,
+        submissionId: overview.id,
+        submissionStatus: overview.status,
+        groupName: overview.groupName,
+        // Grade
+        initialGrade: overview.grade,
+        gradeAdjustment: overview.adjustment,
+        currentGrade: overview.grade + overview.adjustment,
+        maxGrade: overview.assessment.maxGrade,
+        gradingStatus: overview.gradingStatus,
+        questionCount: overview.questionCount,
+        gradedCount: overview.gradedCount,
+        // XP
+        initialXp: overview.xp,
+        xpAdjustment: overview.xpAdjustment,
+        currentXp: overview.xp + overview.xpAdjustment,
+        maxXp: overview.assessment.maxXp,
+        xpBonus: overview.xpBonus
+      };
+      return gradingOverview;
+    })
+    .sort((subX: GradingOverview, subY: GradingOverview) =>
+      subX.assessmentId !== subY.assessmentId
+        ? subY.assessmentId - subX.assessmentId
+        : subY.submissionId - subX.submissionId
+    );
 }
 
 /**

--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -232,6 +232,7 @@
 
 .ag-grid-controls {
   display: flex;
+  align-items: center;
   justify-content: space-between;
 
   .#{$ns}-icon {
@@ -241,6 +242,18 @@
 
   .ag-grid-button-text {
     margin-left: 7px;
+  }
+
+  .pagination-details.pagination-details.pagination-details {
+    /* Chain selectors for increased specificity: set default cursor */
+    cursor: default;
+    font-weight: bold;
+
+    .#{$ns}-button-text {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+    }
   }
 }
 


### PR DESCRIPTION
## Grading overview page improvements
Summary: Introduces changes and fixes to improve the performance and user experience of the datagrid rendering submissions in the grading overviews page. Addresses #751 and #896.

### Changelog
- Enforce default sort on grading overviews by descending `assessmentId` and `submissionId` during receipt of backend HTTP response
   - Avoids re-applying the default sort each time the `Grading` component changes internal state - significant performance improvement
- Edit `componentDidUpdate` of `Grading` component to only re-sort grading overviews in the datagrid when acknowledging notifications
   - Avoids re-applying the sort to float submissions with notifications to the top on every state change - significant performance improvement, resolves #896
- Reduce pagination page size of the datagrid from 50 to 25
   - Reduces rendering workload from custom rendered cells; improves UX by reducing amount of vertical scrolling required - significant performance improvement
- Add custom pagination controls for the datagrid in the control panel at top of the page
   - Replaces the default ag-grid pagination panel at the bottom of the datagrid
   - Uses BlueprintJS components, resolves #751

### Bugfixes
- Fix datagrid not resizing when its width shrinks, which introduces an unnecessary horizontal scrollbar
- Fix notifications column being partially hidden when datagrid width shrinks

### Screenshots

#### Demonstration of changes (GIF)
![grading-overviews-improvements](https://user-images.githubusercontent.com/44989315/64074844-4e036a80-cce3-11e9-8e54-ec0cdf79b0de.gif)

Last updated 1 Sept 2019, 06:00PM