### PR TITLE
Fix playground share links not sharing execution time limit

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -3,7 +3,6 @@ import * as qs from 'query-string';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router';
 
-import { stringParamToInt } from 'src/utils/paramParseHelpers';
 import Academy from '../containers/academy';
 import Login from '../containers/LoginContainer';
 import Material from '../containers/material/MaterialContainer';
@@ -11,6 +10,7 @@ import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import Sourcecast from '../containers/sourcecast/SourcecastContainer';
 import { Role, sourceChapters } from '../reducers/states';
+import { stringParamToInt } from '../utils/paramParseHelpers';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
 import Contributors from './contributors';
 import NavigationBar from './NavigationBar';

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -3,6 +3,7 @@ import * as qs from 'query-string';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router';
 
+import { stringParamToInt } from 'src/utils/paramParseHelpers';
 import Academy from '../containers/academy';
 import Login from '../containers/LoginContainer';
 import Material from '../containers/material/MaterialContainer';
@@ -33,6 +34,7 @@ export interface IDispatchProps {
   handleEnsureLibrariesLoaded: () => void;
   handleLogOut: () => void;
   handleExternalLibrarySelect: (external: ExternalLibraryName) => void;
+  handleSetExecTime: (execTime: string) => void;
 }
 
 const assessmentRegExp = ':assessmentId(-?\\d+)?/:questionId(\\d+)?';
@@ -89,11 +91,13 @@ const parsePlayground = (props: IApplicationProps) => {
   const prgrm = parsePrgrm(props);
   const chapter = parseChapter(props) || props.currentPlaygroundChapter;
   const externalLibraryName = parseExternalLibrary(props) || props.currentExternalLibrary;
+  const execTime = parseExecTime(props);
   if (prgrm) {
     props.handleEditorValueChange(prgrm);
     props.handleEnsureLibrariesLoaded();
     props.handleClearContext(chapter, externalLibraryName);
     props.handleExternalLibrarySelect(externalLibraryName);
+    props.handleSetExecTime(execTime);
   }
 };
 
@@ -115,6 +119,13 @@ const parseChapter = (props: RouteComponentProps<{}>) => {
 const parseExternalLibrary = (props: RouteComponentProps<{}>) => {
   const ext = qs.parse(props.location.hash).ext || '';
   return Object.values(ExternalLibraryNames).includes(ext) ? ext : ExternalLibraryNames.NONE;
+};
+
+const parseExecTime = (props: RouteComponentProps<{}>) => {
+  const time = qs.parse(props.location.hash).exec || '1000';
+  // Parse the time string to a number, defaulting execTime to 1000
+  const execTime = stringParamToInt(time) || 1000;
+  return `${execTime < 1000 ? 1000 : execTime}`;
 };
 
 export default Application;

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -16,7 +16,8 @@ test('Application renders correctly', () => {
     handleEditorValueChange: (val: string) => {},
     handleEditorUpdateBreakpoints: (breakpoints: string[]) => {},
     handleEnsureLibrariesLoaded: () => {},
-    handleExternalLibrarySelect: (externalLibraryName: ExternalLibraryName) => {}
+    handleExternalLibrarySelect: (externalLibraryName: ExternalLibraryName) => {},
+    handleSetExecTime: (execTime: string) => {}
   };
   const app = <Application {...props} />;
   const tree = shallow(app);

--- a/src/containers/ApplicationContainer.ts
+++ b/src/containers/ApplicationContainer.ts
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
 import { beginClearContext, logOut, setEditorBreakpoint, updateEditorValue } from '../actions';
 import {
+  changeExecTime,
   ensureLibrariesLoaded,
   externalLibrarySelect,
   WorkspaceLocations
@@ -51,7 +52,8 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
       handleEnsureLibrariesLoaded: ensureLibrariesLoaded,
       handleLogOut: logOut,
       handleExternalLibrarySelect: (externalLibraryName: ExternalLibraryName) =>
-        externalLibrarySelect(externalLibraryName, workspaceLocation)
+        externalLibrarySelect(externalLibraryName, workspaceLocation),
+      handleSetExecTime: (execTime: string) => changeExecTime(execTime, workspaceLocation)
     },
     dispatch
   );

--- a/src/sagas/__tests__/playground.ts
+++ b/src/sagas/__tests__/playground.ts
@@ -78,10 +78,12 @@ describe('Playground saga tests', () => {
 function createQueryString(code: string, state: IState): string {
   const chapter: number = state.workspaces.playground.context.chapter;
   const external: ExternalLibraryName = state.workspaces.playground.externalLibrary;
+  const execTime: number = state.workspaces.playground.execTime;
   const newQueryString: string = qs.stringify({
     prgrm: compressToEncodedURIComponent(code),
     chap: chapter,
-    ext: external
+    ext: external,
+    exec: execTime
   });
   return newQueryString;
 }

--- a/src/sagas/playground.ts
+++ b/src/sagas/playground.ts
@@ -26,10 +26,12 @@ function* updateQueryString() {
   const external: ExternalLibraryName = yield select(
     (state: IState) => state.workspaces.playground.externalLibrary
   );
+  const execTime: number = yield select((state: IState) => state.workspaces.playground.execTime);
   const newQueryString: string = qs.stringify({
     prgrm: compressToEncodedURIComponent(codeString),
     chap: chapter,
-    ext: external
+    ext: external,
+    exec: execTime
   });
   yield put(actions.changeQueryString(newQueryString));
 }


### PR DESCRIPTION
## [Bugfix] Fix playground share links not sharing execution time limit
Summary: Resolves #877 by ensuring the 'Share' button encodes the execution time limit in the output URL.

### Changelog
- Update the playground saga to additionally encode the new parameter `exec` (for `execTime`) in the generated URL
- Add a new helper function `parseExecTime` for parsing the `exec` field in shared playground links to an `execTime` to update the Playground workspace with
   - If the `exec` parameter is missing or not a number or parsed to a number less than 1000 ms, the default execution time limit of 1000 ms for the Playground is used instead.

Last updated 4 Sept 2019, 11:55PM