### PR TITLE
Fix missing 'Group' column in exported grading overviews CSV

### DIFF
--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -433,6 +433,7 @@ class Grading extends React.Component<IGradingProps, State> {
           'assessmentName',
           'assessmentCategory',
           'studentName',
+          'groupName',
           'submissionStatus',
           'gradingStatus',
           'questionCount',


### PR DESCRIPTION
## [Bugfix] Fix missing 'Group' column in exported grading overviews CSV
Summary: Fixes a silent regression introduced by PR #908.

### Bug description
PR #908 replaced the use of the `allColumns: true` option when invoking `exportDataAsCsv` with an array of explicitly named columns, to prevent "trash" rendered columns with no real data from appearing in the final exported CSV. From this, the column key for the 'Group' column was accidentally excluded, resulting in the exported file lacking any group information about each submission.

### Changelog
- Explicitly declare the 'Group' column (with column key `groupName`) to be exported to CSV by the grading overviews datagrid

Last updated 7 Sept 2019, 11:30PM