### PR TITLE
Fix data visualizer resizing

### DIFF
--- a/src/styles/_playground.scss
+++ b/src/styles/_playground.scss
@@ -7,6 +7,4 @@
 
 .kineticjs-content {
   width: 100% !important;
-  // height: 40vh !important; // 100% results in 0 height, 100vh is too big.
-  // overflow: scroll;
 }


### PR DESCRIPTION
Stops the visualizer from limiting the height of the display by creating a second, nested display area with its own set of scroll bars.

This solution is still not perfect, as if the drawing is too tall the user has to scroll to the bottom of the drawing to access the resizing bar and view the REPL.