### PR TITLE
Improve UI of assessment overview listings

### DIFF
--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -91,17 +91,17 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/300/\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             An Odessey to Runes (Duplicate)
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -115,37 +115,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Max Grade: 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Max XP: 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -161,6 +162,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Opens at: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
+                                    <div className=\\"listing-button\\" />
                                   </div>
                                 </div>
                               </div>
@@ -202,17 +204,17 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             Basic logic gates
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -226,37 +228,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 0 / 0
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 0 / 200
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -272,14 +275,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Due: 20th April, 09:23
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/paths/6/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/paths\\\\\\\\/6\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/paths/6/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/paths/6/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/paths/6/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/paths\\\\\\\\/6\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/paths/6/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/paths/6/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -289,17 +292,20 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -315,11 +321,11 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             A sample Practical
                                             <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
                                               <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
@@ -352,7 +358,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -366,37 +372,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 4 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 3 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -412,14 +419,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -429,17 +436,20 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -455,17 +465,17 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             A sample Sidequest
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -479,37 +489,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 4 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 3 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -525,14 +536,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/quests/3/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/3\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/quests/3/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/3/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/quests/3/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/3\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/quests/3/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/3/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -542,17 +553,20 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -568,17 +582,17 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-attempting\\" src=\\"https://fakeimg.pl/350x200/?text=World&font=lobster\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             The Secret to Streams
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -592,37 +606,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 3 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 2 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -638,14 +653,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -655,17 +670,22 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Continue Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Continue
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\">
+                                                       Attempt
+                                                    </span>
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -681,17 +701,17 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <img className=\\"cover-image-attempted\\" src=\\"https://fakeimg.pl/300/\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             An Odessey to Runes
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={false} icon=\\"confirm\\" intent=\\"danger\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={[undefined]} onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal bp3-intent-danger\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -705,37 +725,38 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 2 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 1 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -751,14 +772,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"edit\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
+                                              <Blueprint3.Button icon=\\"edit\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"edit\\">
                                                     <span icon=\\"edit\\" className=\\"bp3-icon bp3-icon-edit\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"edit\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -768,17 +789,22 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Review Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Review
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\">
+                                                       Attempt
+                                                    </span>
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -918,17 +944,17 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/300/\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             An Odessey to Runes (Duplicate)
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -942,37 +968,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Max Grade: 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Max XP: 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -988,14 +1015,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Opens at: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1005,17 +1032,20 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1057,17 +1087,17 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             Basic logic gates
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -1081,37 +1111,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 0 / 0
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 0 / 200
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -1127,14 +1158,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Due: 20th April, 09:23
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/paths/6/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/paths\\\\\\\\/6\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/paths/6/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/paths/6/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/paths/6/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/paths\\\\\\\\/6\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/paths/6/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/paths/6/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1144,17 +1175,20 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1170,11 +1204,11 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             A sample Practical
                                             <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
                                               <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
@@ -1207,7 +1241,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -1221,37 +1255,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 4 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 3 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -1267,14 +1302,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1284,17 +1319,20 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1310,17 +1348,17 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             A sample Sidequest
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -1334,37 +1372,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 4 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 3 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -1380,14 +1419,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/quests/3/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/3\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/quests/3/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/3/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/quests/3/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/3\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/quests/3/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/3/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1397,17 +1436,20 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1423,17 +1465,17 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-attempting\\" src=\\"https://fakeimg.pl/350x200/?text=World&font=lobster\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             The Secret to Streams
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -1447,37 +1489,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 3 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 2 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -1493,14 +1536,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"play\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
                                                     <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1510,17 +1553,22 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Continue Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Continue
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\">
+                                                       Attempt
+                                                    </span>
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1536,17 +1584,17 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <img className=\\"cover-image-attempted\\" src=\\"https://fakeimg.pl/300/\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"row listing-title\\">
-                                    <Blueprint3.Text ellipsize={true} className=\\"col-xs-10\\">
-                                      <div className=\\"bp3-text-overflow-ellipsis col-xs-10\\" title={[undefined]}>
-                                        <Component>
-                                          <h4 className=\\"bp3-heading\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
                                             An Odessey to Runes
                                           </h4>
                                         </Component>
                                       </div>
                                     </Blueprint3.Text>
-                                    <div className=\\"col-xs-2\\">
+                                    <div className=\\"listing-button\\">
                                       <Blueprint3.Button disabled={false} icon=\\"confirm\\" intent=\\"danger\\" minimal={true} onClick={[Function: onClick]}>
                                         <button type=\\"button\\" disabled={[undefined]} onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal bp3-intent-danger\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                           <Blueprint3.Icon icon=\\"confirm\\">
@@ -1560,37 +1608,38 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                             </span>
                                           </Blueprint3.Icon>
                                           <span className=\\"bp3-button-text\\">
-                                            Finalize Submission
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
                                           </span>
                                           <Blueprint3.Icon icon={[undefined]} />
                                         </button>
                                       </Blueprint3.Button>
                                     </div>
                                   </div>
-                                  <div className=\\"row listing-grade\\">
+                                  <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         Grade: 2 / 3000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-xp\\">
+                                  <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                         
                                         XP: 1 / 1000
-                                         
                                       </h6>
                                     </Component>
                                   </div>
-                                  <div className=\\"row listing-description\\">
+                                  <div className=\\"listing-description\\">
                                     <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
-                                  <div className=\\"listing-controls\\">
+                                  <div className=\\"listing-footer\\">
                                     <Blueprint3.Text className=\\"listing-due-date\\">
                                       <div className=\\"listing-due-date\\" title={[undefined]}>
                                         <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
@@ -1606,14 +1655,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         Due: 18th June, 13:24
                                       </div>
                                     </Blueprint3.Text>
-                                    <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                      <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                        <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                          <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
-                                            <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
-                                              <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                <Blueprint3.Icon icon={{...}}>
-                                                  <Blueprint3.Icon icon=\\"edit\\" color={[undefined]}>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/1/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/1\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/1/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/1/0\\">
+                                              <Blueprint3.Button icon=\\"edit\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"edit\\">
                                                     <span icon=\\"edit\\" className=\\"bp3-icon bp3-icon-edit\\" title={[undefined]}>
                                                       <svg fill={[undefined]} data-icon=\\"edit\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                         <desc>
@@ -1623,17 +1672,22 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                                       </svg>
                                                     </span>
                                                   </Blueprint3.Icon>
-                                                </Blueprint3.Icon>
-                                                <span className=\\"bp3-button-text\\">
-                                                  Review Attempt
-                                                </span>
-                                                <Blueprint3.Icon icon={[undefined]} />
-                                              </button>
-                                            </Blueprint3.Button>
-                                          </a>
-                                        </Link>
-                                      </Route>
-                                    </NavLink>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Review
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\">
+                                                       Attempt
+                                                    </span>
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
                                   </div>
                                 </div>
                               </div>

--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -321,16 +321,16 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                         <Component>
                                           <h4 className=\\"bp3-heading\\">
                                             A sample Practical
-                                            <Blueprint3.Tooltip content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
-                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
                                                 <Manager>
-                                                  <span className=\\"bp3-popover-wrapper\\">
+                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
                                                     <Reference innerRef={[Function: target]}>
                                                       <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
                                                         <Blueprint3.ResizeSensor onResize={[Function]}>
                                                           <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
-                                                            <Blueprint3.Icon icon=\\"lock\\" style={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
-                                                              <span icon=\\"lock\\" style={{...}} disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
+                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
                                                                 <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                                   <desc>
                                                                     lock
@@ -1176,16 +1176,16 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                         <Component>
                                           <h4 className=\\"bp3-heading\\">
                                             A sample Practical
-                                            <Blueprint3.Tooltip content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
-                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
                                                 <Manager>
-                                                  <span className=\\"bp3-popover-wrapper\\">
+                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
                                                     <Reference innerRef={[Function: target]}>
                                                       <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
                                                         <Blueprint3.ResizeSensor onResize={[Function]}>
                                                           <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
-                                                            <Blueprint3.Icon icon=\\"lock\\" style={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
-                                                              <span icon=\\"lock\\" style={{...}} disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
+                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
                                                                 <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
                                                                   <desc>
                                                                     lock

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -284,17 +284,20 @@ class Assessment extends React.Component<IAssessmentProps, State> {
       icon={IconNames.CONFIRM}
       intent={overview.status === AssessmentStatuses.attempted ? Intent.DANGER : Intent.NONE}
       minimal={true}
-      // intentional: each menu renders own version of onClick
+      // intentional: each listing renders its own version of onClick
       // tslint:disable-next-line:jsx-no-lambda
       onClick={() => this.setBetchaAssessment(overview)}
     >
-      Finalize Submission
+      <span className="custom-hidden-xxxs">Finalize</span>
+      <span className="custom-hidden-xxs"> Submission</span>
     </Button>
   );
 
-  private makeOverviewCardButton = (overview: IAssessmentOverview) => {
+  private makeAssessmentInteractButton = (overview: IAssessmentOverview) => {
     let icon: IconName;
     let label: string;
+    let optionalLabel: string = '';
+
     switch (overview.status) {
       case AssessmentStatuses.not_attempted:
         icon = IconNames.PLAY;
@@ -302,15 +305,18 @@ class Assessment extends React.Component<IAssessmentProps, State> {
         break;
       case AssessmentStatuses.attempting:
         icon = IconNames.PLAY;
-        label = 'Continue Attempt';
+        label = 'Continue';
+        optionalLabel = ' Attempt';
         break;
       case AssessmentStatuses.attempted:
         icon = IconNames.EDIT;
-        label = 'Review Attempt';
+        label = 'Review';
+        optionalLabel = ' Attempt';
         break;
       case AssessmentStatuses.submitted:
         icon = IconNames.EYE_OPEN;
-        label = 'Review Submission';
+        label = 'Review';
+        optionalLabel = ' Submission';
         break;
       default:
         // If we reach this case, backend data did not fit IAssessmentOverview
@@ -324,9 +330,18 @@ class Assessment extends React.Component<IAssessmentProps, State> {
           overview.category
         )}/${overview.id.toString()}/${DEFAULT_QUESTION_ID}`}
       >
-        {controlButton(label, icon, () =>
-          this.props.handleAcknowledgeNotifications(filterNotificationsByAssessment(overview.id))
-        )}
+        <Button
+          icon={icon}
+          minimal={true}
+          // intentional: each listing renders its own version of onClick
+          // tslint:disable-next-line:jsx-no-lambda
+          onClick={() =>
+            this.props.handleAcknowledgeNotifications(filterNotificationsByAssessment(overview.id))
+          }
+        >
+          <span className="custom-hidden-xxxs">{label}</span>
+          <span className="custom-hidden-xxs">{optionalLabel}</span>
+        </Button>
       </NavLink>
     );
   };
@@ -385,8 +400,8 @@ class Assessment extends React.Component<IAssessmentProps, State> {
                 ? `Due: ${getPrettyDate(overview.closeAt)}`
                 : `Opens at: ${getPrettyDate(overview.openAt)}`}
             </Text>
-            <div className="listing-interact-button">
-              {renderAttemptButton ? this.makeOverviewCardButton(overview) : null}
+            <div className="listing-button">
+              {renderAttemptButton ? this.makeAssessmentInteractButton(overview) : null}
             </div>
           </div>
         </div>
@@ -414,7 +429,7 @@ class Assessment extends React.Component<IAssessmentProps, State> {
           {renderGradingStatus ? makeGradingStatus(overview.gradingStatus) : null}
         </H4>
       </Text>
-      <div className="listing-finalise-button">{this.makeSubmissionButton(overview, index)}</div>
+      <div className="listing-button">{this.makeSubmissionButton(overview, index)}</div>
     </div>
   );
 }

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -404,8 +404,11 @@ class Assessment extends React.Component<IAssessmentProps, State> {
         <H4>
           {overview.title}
           {overview.private ? (
-            <Tooltip content="This assessment is password-protected.">
-              <Icon icon="lock" style={{ verticalAlign: 'middle', padding: '0.2rem' }} />
+            <Tooltip
+              className="listing-title-tooltip"
+              content="This assessment is password-protected."
+            >
+              <Icon icon="lock" />
             </Tooltip>
           ) : null}
           {renderGradingStatus ? makeGradingStatus(overview.gradingStatus) : null}
@@ -427,19 +430,16 @@ const makeGradingStatus = (gradingStatus: string) => {
       intent = Intent.SUCCESS;
       tooltip = 'Fully graded';
       break;
-
     case GradingStatuses.grading:
       iconName = IconNames.TIME;
       intent = Intent.WARNING;
       tooltip = 'Grading in progress';
       break;
-
     case GradingStatuses.none:
       iconName = IconNames.CROSS;
       intent = Intent.DANGER;
       tooltip = 'Not graded yet';
       break;
-
     default:
       // Shows default icon if this assessment is ungraded
       iconName = IconNames.DISABLE;
@@ -449,7 +449,7 @@ const makeGradingStatus = (gradingStatus: string) => {
   }
 
   return (
-    <Tooltip content={tooltip} position={Position.RIGHT}>
+    <Tooltip className="listing-title-tooltip" content={tooltip} position={Position.RIGHT}>
       <Icon icon={iconName} intent={intent} />
     </Tooltip>
   );

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -361,33 +361,33 @@ class Assessment extends React.Component<IAssessmentProps, State> {
         </div>
         <div className="col-xs-9 listing-text">
           {this.makeOverviewCardTitle(overview, index, renderGradingStatus)}
-          <div className="row listing-grade">
+          <div className="listing-grade">
             <H6>
-              {' '}
               {beforeNow(overview.openAt)
                 ? `Grade: ${overview.grade} / ${overview.maxGrade}`
-                : `Max Grade: ${overview.maxGrade}`}{' '}
+                : `Max Grade: ${overview.maxGrade}`}
             </H6>
           </div>
-          <div className="row listing-xp">
+          <div className="listing-xp">
             <H6>
-              {' '}
               {beforeNow(overview.openAt)
                 ? `XP: ${overview.xp} / ${overview.maxXp}`
-                : `Max XP: ${overview.maxXp}`}{' '}
+                : `Max XP: ${overview.maxXp}`}
             </H6>
           </div>
-          <div className="row listing-description">
+          <div className="listing-description">
             <Markdown content={overview.shortSummary} />
           </div>
-          <div className="listing-controls">
+          <div className="listing-footer">
             <Text className="listing-due-date">
               <Icon className="listing-due-icon" iconSize={12} icon={IconNames.TIME} />
               {beforeNow(overview.openAt)
                 ? `Due: ${getPrettyDate(overview.closeAt)}`
                 : `Opens at: ${getPrettyDate(overview.openAt)}`}
             </Text>
-            {renderAttemptButton ? this.makeOverviewCardButton(overview) : null}
+            <div className="listing-interact-button">
+              {renderAttemptButton ? this.makeOverviewCardButton(overview) : null}
+            </div>
           </div>
         </div>
       </Card>
@@ -399,9 +399,9 @@ class Assessment extends React.Component<IAssessmentProps, State> {
     index: number,
     renderGradingStatus: boolean
   ) => (
-    <div className="row listing-title">
-      <Text ellipsize={true} className={'col-xs-10'}>
-        <H4>
+    <div className="listing-header">
+      <Text ellipsize={true}>
+        <H4 className="listing-title">
           {overview.title}
           {overview.private ? (
             <Tooltip
@@ -414,7 +414,7 @@ class Assessment extends React.Component<IAssessmentProps, State> {
           {renderGradingStatus ? makeGradingStatus(overview.gradingStatus) : null}
         </H4>
       </Text>
-      <div className="col-xs-2">{this.makeSubmissionButton(overview, index)}</div>
+      <div className="listing-finalise-button">{this.makeSubmissionButton(overview, index)}</div>
     </div>
   );
 }

--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -1,3 +1,19 @@
+@media only screen and (max-width: 512px) {
+  .custom-hidden-xxxs {
+    display: none;
+  }
+
+  .listing-button .#{$ns}-button .#{$ns}-icon {
+    margin-right: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .custom-hidden-xxs {
+    display: none;
+  }
+}
+
 .Academy {
   height: 100%;
   width: 100%;
@@ -181,8 +197,7 @@
     }
   }
 
-  .listing-finalise-button,
-  .listing-interact-button {
+  .listing-button {
     /* Prevent <div> container collapsing and forcing button text to two lines */
     flex-grow: 0;
     flex-shrink: 0;

--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -84,9 +84,8 @@
     padding: 0;
     text-align: justify;
 
-    .listing-due-icon {
-      vertical-align: baseline;
-      margin-right: 0.4rem;
+    & > * {
+      overflow-wrap: break-word;
     }
   }
 
@@ -114,15 +113,25 @@
   }
 
   .listing-text {
-    padding: 0.5rem 1rem 0.5rem 1.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
     border: 1rem;
     display: flex;
     flex-direction: column;
   }
 
-  .listing-title {
+  .listing-header {
+    margin-bottom: 0.8rem;
     display: flex;
-    margin-bottom: 2px;
+    align-items: center;
+    justify-content: space-between;
+
+    .listing-title {
+      margin-bottom: 0;
+
+      h4 {
+        margin-top: 4px;
+      }
+    }
 
     .listing-title-tooltip {
       /* Space out icon tooltips */
@@ -137,46 +146,46 @@
         vertical-align: baseline;
       }
     }
-
-    .#{$ns}-text-overflow-ellipsis {
-      /* Pushes button to the right of container */
-      flex-grow: 1;
-      display: flex;
-    }
-
-    div {
-      /* overwrite default padding */
-      padding: 0;
-      margin-bottom: 0.4rem;
-    }
-
-    .col-xs-2 {
-      /* flush menu button, span.#{$ns}-popover-wrapper, to right */
-      text-align: right;
-    }
-
-    h4 {
-      margin: 4px 0 0 0;
-    }
   }
 
   .listing-description {
-    /* Pushes .listing-controls to the bottom of container */
     flex-grow: 1;
+    flex-shrink: 0;
     /* Creates space between the description text, buttons and title */
-    margin: 1rem 0rem 1rem 0rem;
+    margin: 0.5rem 0rem 0.5rem 0.5rem;
+
+    & > * {
+      /* Limit height of description on smaller screens */
+      max-height: 30vh;
+      /* Add padding to visually separate scrollbar from content */
+      padding-right: 0.5rem;
+      overflow-y: auto;
+    }
   }
 
-  .listing-controls {
+  .listing-footer {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
 
     .listing-due-date {
-      /* Pushes button to the right of container */
       display: flex;
-      flex-grow: 1;
+      overflow-x: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
       align-items: center;
-      padding-top: 6px;
     }
+
+    .listing-due-icon {
+      margin-right: 0.4rem;
+    }
+  }
+
+  .listing-finalise-button,
+  .listing-interact-button {
+    /* Prevent <div> container collapsing and forcing button text to two lines */
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 }
 

--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -124,8 +124,18 @@
     display: flex;
     margin-bottom: 2px;
 
-    .#{$ns}-icon {
-      vertical-align: baseline;
+    .listing-title-tooltip {
+      /* Space out icon tooltips */
+      margin-left: 2px;
+
+      /* Visually separate first icon tooltip from assessment title */
+      &:first-of-type {
+        margin-left: 6px;
+      }
+
+      .#{$ns}-icon {
+        vertical-align: baseline;
+      }
     }
 
     .#{$ns}-text-overflow-ellipsis {


### PR DESCRIPTION
## Improve UI of assessment overview listings
Summary: This PR improves the usability of the assessment page by redesigning the assessment overview listings to be compliant with a much larger range of screen widths.

### Changelog
- Improve visual spacing between assessment title and icon tooltips (grading status indicator, password-protected indicator)
- Fix assessment overview contents overflowing the listing container when the screen width is below 1000px
   - This required the removal of certain Bootstrap flexgrid layouts that were introducing the overflow due to rigid column widths
- Limit the height of the description in each listing to 25% of the screen height, rendering a scrollbar for any overflow
   - Prevents assessment listings with long descriptions from occupying the entire screen height on smaller devices
- Progressively hide the text of buttons in assessment listings as screen width shrinks
   - Screen widths less or equal to 768px hide part of the button text
   - Screen widths less or equal to 512px hide the entire button text, leaving just the button icon

### Mocks and Tests
- Update failing snapshots for the assessment page (`Assessment` component)

### Screenshots

#### Assessment title icon tooltips comparison (old - top, new - bottom)
![assessment-title-icons-comparison](https://user-images.githubusercontent.com/44989315/64910034-6ba1ec80-d745-11e9-98ef-5b027ebd52ee.png)

#### Assessment page comparison at screen width of 768px (old - left, new - right)
![assessment-finalise-overflow-comparison](https://user-images.githubusercontent.com/44989315/64910210-642f1300-d746-11e9-904a-384045db4171.png)

#### Assessment page behaviour with shrinking screen widths (GIF)
![assessment-page-behaviour-shrinking-width](https://user-images.githubusercontent.com/44989315/64910251-cb4cc780-d746-11e9-8a51-a1455e61b34c.gif)

Last updated 14 Sept 2019, 11:15PM