### PR TITLE
Improve UI and UX of side-content components

### DIFF
--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -51,13 +51,18 @@
 .assessment-briefing {
   padding-bottom: 0;
 
-  // If the assessment briefing begins with a header, remove its top margin
-  *:first-child {
-    margin-top: 0;
-  }
+  & .md {
+    margin-bottom: 1rem;
 
-  .assessment-briefing-button {
-    margin-top: 1rem;
+    /* If the assessment briefing begins with a header, remove its top margin */
+    & > *:first-child {
+      margin-top: 0;
+    }
+
+    /* Remove bottom margins of the last element in the assessment briefing */
+    & > *:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -228,6 +228,7 @@ $code-color-error: #ff4444;
     word-break: break-word;
     color: $code-color-result;
     text-align: justify;
+    overflow-x: auto;
 
     div {
       p:last-child {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -157,6 +157,8 @@ $code-color-error: #ff4444;
   .resize-side-content {
     display: flex;
     flex-direction: column;
+    /* Prevents side-content from overflowing right-parent container on initial load */
+    max-height: 100%;
   }
 
   .resize-editor-content {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -234,10 +234,13 @@ $code-color-error: #ff4444;
     /* Respect padding of containing bp3 Card when scrollable */
     margin-bottom: 0.4rem;
 
-    div {
-      p:last-child {
-        margin-bottom: 0;
-      }
+    /* If the assessment briefing begins with a header, remove its top margin */
+    & > div > *:first-child {
+      margin-top: 0;
+    }
+
+    & > div > p:last-child {
+      margin-bottom: 0;
     }
 
     .GradingEditor {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -785,11 +785,13 @@ $code-color-error: #ff4444;
         padding: 8px;
         margin: 0;
         overflow: visible;
-        overflow-wrap: normal;
+        overflow-wrap: break-word;
         word-break: normal;
         white-space: pre-line;
         flex-grow: 0;
         flex-shrink: 0;
+        /* Override justify applied to side-content (intended for text blocks) */
+        text-align: initial;
       }
     }
 

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -229,6 +229,8 @@ $code-color-error: #ff4444;
     color: $code-color-result;
     text-align: justify;
     overflow-x: auto;
+    /* Respect padding of containing bp3 Card when scrollable */
+    margin-bottom: 0.4rem;
 
     div {
       p:last-child {
@@ -315,7 +317,6 @@ $code-color-error: #ff4444;
   .side-content-tabs {
     flex: 1 1 auto;
     height: 100%;
-    overflow-y: auto;
     justify-content: center;
     display: flex;
 


### PR DESCRIPTION
## Improve UI and UX of side-content components
Summary: Fixes a few bugs and UI issues in side-content components, including addressing #920.

### Changelog
- Fix odd spacing in long code blocks rendered in Autograder cells
   - Override text justify applied to the `side-content-text` container and force the cells to break words that exceed the cell width
- Fix the scrollbar for horizontally overflowing side-content from scrolling the tab list out of view
   - The horizontal scrollbar now renders at the level of the `side-content-text` container instead of the `side-content-tabs` container
- Fix missing right-padding between scrollbar and vertically overflowing side-content (#920)
   - The vertical scrollbar now renders at the same DOM level as that of the REPL, respecting the internal padding of bp3's `Card` component used in the `SideContent` component
- Fix the failed resize of the horizontal divider separating the side-content and REPL on initial load when the side-content vertically overflowed the `right-parent` container
- Fix excessive margins of header HTML elements in assessment briefing overlay and side-content tab (extracted from #921)

Last updated 15 Sept 2019, 08:30PM