### PR TITLE
Fix assessment fetch not prompting password

### DIFF
--- a/src/sagas/requests.ts
+++ b/src/sagas/requests.ts
@@ -154,6 +154,7 @@ export async function getAssessment(id: number, tokens: Tokens): Promise<IAssess
       body: {
         password: input
       },
+      shouldAutoLogout: false,
       shouldRefresh: true
     });
   }

--- a/src/sagas/requests.ts
+++ b/src/sagas/requests.ts
@@ -135,6 +135,7 @@ export async function getAssessment(id: number, tokens: Tokens): Promise<IAssess
   let resp = await request(`assessments/${id}`, 'POST', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
+    shouldAutoLogout: false,
     shouldRefresh: true
   });
 


### PR DESCRIPTION
By setting the request option `shouldAutoLogout` to false, we should be able to obtain the 403 response and prompt user for password