### PR TITLE
Render template reset button unconditionally in assessments

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -513,7 +513,6 @@ class AssessmentWorkspace extends React.Component<
     const questionView = <QuestionView questionProgress={questionProgress} key="question_view" />;
 
     const resetButton =
-      !beforeNow(this.props.closeDate) &&
       this.props.assessment!.questions[questionId].type !== QuestionTypes.mcq ? (
         <ResetButton onClick={onClickResetTemplate} key="reset_template" />
       ) : null;


### PR DESCRIPTION
## Render template reset button unconditionally in assessments
Summary: Special request by @blackening.

### Changelog
- Removed the condition where the template reset button is hidden after an assessment passes its closing date, allowing students to attempt (but not submit answers for) questions in a closed assessment

Last updated 20 Sept 2019, 03:00AM