### PR TITLE
Render unsubmit button conditionally in grading overviews

### DIFF
--- a/src/actions/__tests__/session.ts
+++ b/src/actions/__tests__/session.ts
@@ -154,6 +154,7 @@ test('setUser generates correct action object', () => {
   const user = {
     name: 'test student',
     role: 'student' as Role,
+    group: '42D',
     grade: 150,
     story: {} as Story
   };

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -43,8 +43,13 @@ export const setTokens = ({
     refreshToken
   });
 
-export const setUser = (user: { name: string; role: Role; grade: number; story: Story }) =>
-  action(actionTypes.SET_USER, user);
+export const setUser = (user: {
+  name: string;
+  role: Role;
+  group: string | null;
+  grade: number;
+  story: Story;
+}) => action(actionTypes.SET_USER, user);
 
 export const submitAnswer = (id: number, answer: string | number) =>
   action(actionTypes.SUBMIT_ANSWER, {

--- a/src/components/academy/grading/UnsubmitCell.tsx
+++ b/src/components/academy/grading/UnsubmitCell.tsx
@@ -2,12 +2,15 @@ import { Alert, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
+import { Role } from '../../../reducers/states';
 import { controlButton } from '../../commons';
 import { GradingOverview } from './gradingShape';
 
 interface IUnsubmitCellProps {
   data: GradingOverview;
   handleUnsubmitSubmission: (submissionId: number) => void;
+  group: string | null;
+  role?: Role;
 }
 
 type UnsubmitCellState = {
@@ -25,6 +28,8 @@ class UnsubmitCell extends React.Component<IUnsubmitCellProps, UnsubmitCellState
 
   public render() {
     if (this.props.data.submissionStatus !== 'submitted') {
+      return null;
+    } else if (this.props.group !== this.props.data.groupName && this.props.role! !== Role.Admin) {
       return null;
     }
 

--- a/src/components/academy/grading/UnsubmitCell.tsx
+++ b/src/components/academy/grading/UnsubmitCell.tsx
@@ -24,6 +24,10 @@ class UnsubmitCell extends React.Component<IUnsubmitCellProps, UnsubmitCellState
   }
 
   public render() {
+    if (this.props.data.submissionStatus !== 'submitted') {
+      return null;
+    }
+
     return (
       <div>
         <Alert

--- a/src/components/academy/grading/UnsubmitCell.tsx
+++ b/src/components/academy/grading/UnsubmitCell.tsx
@@ -6,7 +6,7 @@ import { Role } from '../../../reducers/states';
 import { controlButton } from '../../commons';
 import { GradingOverview } from './gradingShape';
 
-interface IUnsubmitCellProps {
+export interface IUnsubmitCellProps {
   data: GradingOverview;
   handleUnsubmitSubmission: (submissionId: number) => void;
   group: string | null;

--- a/src/components/academy/grading/__tests__/UnsubmitCell.tsx
+++ b/src/components/academy/grading/__tests__/UnsubmitCell.tsx
@@ -1,0 +1,75 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+
+import { mockGradingOverviews as gradingOverviews } from '../../../../mocks/gradingAPI';
+import { Role } from '../../../../reducers/states';
+import UnsubmitCell, { IUnsubmitCellProps } from '../UnsubmitCell';
+
+// Pre-condition: only Staff and Admin users can view the grading overviews page
+
+// Default props has: submitted submission with group 1D, no user group and Staff user
+const defaultUnsubmitCellProps: IUnsubmitCellProps = {
+  data: gradingOverviews[2],
+  handleUnsubmitSubmission: (submissionId: number) => {},
+  group: null,
+  role: Role.Staff
+};
+
+test('Unsubmit cell does not render for unsubmitted submissions', () => {
+  const props = {
+    ...defaultUnsubmitCellProps,
+    data: { ...gradingOverviews[2], submissionStatus: 'attempted' },
+    role: Role.Admin
+  };
+  const app = <UnsubmitCell {...props} />;
+  const tree = mount(app);
+  expect(tree.debug()).toMatchSnapshot();
+  expect(tree.find('*').hostNodes().length).toEqual(0);
+});
+
+test("Unsubmit cell does not render for submitted submissions outside of non-Admin user's group", () => {
+  const props = {
+    ...defaultUnsubmitCellProps,
+    group: '1D'
+  };
+  const app = <UnsubmitCell {...props} />;
+  const tree = mount(app);
+  expect(tree.debug()).toMatchSnapshot();
+  expect(tree.find('*').hostNodes().length).toEqual(0);
+});
+
+test('Unsubmit cell renders for submitted submissions for Admin users regardless of group', () => {
+  const props = {
+    ...defaultUnsubmitCellProps,
+    role: Role.Admin
+  };
+  const app = <UnsubmitCell {...props} />;
+  const tree = mount(app);
+  expect(tree.debug()).toMatchSnapshot();
+  expect(tree.find('*').hostNodes().length).toBeGreaterThan(0);
+  expect(tree.find('.bp3-button').hostNodes()).toHaveLength(1);
+  expect(
+    tree
+      .find('.unsubmit-alert')
+      .at(0)
+      .prop('isOpen')
+  ).toEqual(false);
+});
+
+test("Unsubmit cell renders for submitted submissions belonging to a Staff user's group", () => {
+  const props = {
+    ...defaultUnsubmitCellProps,
+    group: '1F'
+  };
+  const app = <UnsubmitCell {...props} />;
+  const tree = mount(app);
+  expect(tree.debug()).toMatchSnapshot();
+  expect(tree.find('*').hostNodes().length).toBeGreaterThan(0);
+  expect(tree.find('.bp3-button').hostNodes()).toHaveLength(1);
+  expect(
+    tree
+      .find('.unsubmit-alert')
+      .at(0)
+      .prop('isOpen')
+  ).toEqual(false);
+});

--- a/src/components/academy/grading/__tests__/__snapshots__/UnsubmitCell.tsx.snap
+++ b/src/components/academy/grading/__tests__/__snapshots__/UnsubmitCell.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unsubmit cell does not render for submitted submissions outside of non-Admin user's group 1`] = `"<UnsubmitCell data={{...}} handleUnsubmitSubmission={[Function: handleUnsubmitSubmission]} group=\\"1D\\" role=\\"staff\\" />"`;
+
+exports[`Unsubmit cell does not render for unsubmitted submissions 1`] = `"<UnsubmitCell data={{...}} handleUnsubmitSubmission={[Function: handleUnsubmitSubmission]} group={{...}} role=\\"admin\\" />"`;
+
+exports[`Unsubmit cell renders for submitted submissions belonging to a Staff user's group 1`] = `
+"<UnsubmitCell data={{...}} handleUnsubmitSubmission={[Function: handleUnsubmitSubmission]} group=\\"1F\\" role=\\"staff\\">
+  <div>
+    <Blueprint3.Alert canEscapeKeyCancel={true} canOutsideClickCancel={true} cancelButtonText=\\"Cancel\\" className=\\"unsubmit-alert alert\\" intent=\\"danger\\" onConfirm={[Function]} isOpen={false} onCancel={[Function]} confirmButtonText=\\"OK\\">
+      <Blueprint3.Dialog onConfirm={[Function]} isOpen={false} onCancel={[Function]} className=\\"bp3-alert unsubmit-alert alert\\" canEscapeKeyClose={true} canOutsideClickClose={true} onClose={[Function]} portalContainer={[undefined]}>
+        <Blueprint3.Overlay onConfirm={[Function]} isOpen={false} onCancel={[Function]} className=\\"bp3-overlay-scroll-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} onClose={[Function]} portalContainer={[undefined]} hasBackdrop={true} autoFocus={true} backdropProps={{...}} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+      </Blueprint3.Dialog>
+    </Blueprint3.Alert>
+    <Blueprint3.Button disabled={false} fill={true} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
+      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-fill bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon={{...}}>
+          <Blueprint3.Icon icon=\\"arrow-left\\" color={[undefined]}>
+            <span icon=\\"arrow-left\\" className=\\"bp3-icon bp3-icon-arrow-left\\" title={[undefined]}>
+              <svg fill={[undefined]} data-icon=\\"arrow-left\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                <desc>
+                  arrow-left
+                </desc>
+                <path d=\\"M13.99 6.99H4.41L7.7 3.7a1.003 1.003 0 0 0-1.42-1.42l-5 5a1.014 1.014 0 0 0 0 1.42l5 5a1.003 1.003 0 0 0 1.42-1.42L4.41 8.99H14c.55 0 1-.45 1-1s-.46-1-1.01-1z\\" fillRule=\\"evenodd\\" />
+              </svg>
+            </span>
+          </Blueprint3.Icon>
+        </Blueprint3.Icon>
+        <Blueprint3.Icon icon={[undefined]} />
+      </button>
+    </Blueprint3.Button>
+  </div>
+</UnsubmitCell>"
+`;
+
+exports[`Unsubmit cell renders for submitted submissions for Admin users regardless of group 1`] = `
+"<UnsubmitCell data={{...}} handleUnsubmitSubmission={[Function: handleUnsubmitSubmission]} group={{...}} role=\\"admin\\">
+  <div>
+    <Blueprint3.Alert canEscapeKeyCancel={true} canOutsideClickCancel={true} cancelButtonText=\\"Cancel\\" className=\\"unsubmit-alert alert\\" intent=\\"danger\\" onConfirm={[Function]} isOpen={false} onCancel={[Function]} confirmButtonText=\\"OK\\">
+      <Blueprint3.Dialog onConfirm={[Function]} isOpen={false} onCancel={[Function]} className=\\"bp3-alert unsubmit-alert alert\\" canEscapeKeyClose={true} canOutsideClickClose={true} onClose={[Function]} portalContainer={[undefined]}>
+        <Blueprint3.Overlay onConfirm={[Function]} isOpen={false} onCancel={[Function]} className=\\"bp3-overlay-scroll-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} onClose={[Function]} portalContainer={[undefined]} hasBackdrop={true} autoFocus={true} backdropProps={{...}} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+      </Blueprint3.Dialog>
+    </Blueprint3.Alert>
+    <Blueprint3.Button disabled={false} fill={true} intent=\\"none\\" minimal={true} className=\\"\\" type={[undefined]} icon={{...}} onClick={[Function]}>
+      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-fill bp3-minimal\\" onClick={[Function]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon={{...}}>
+          <Blueprint3.Icon icon=\\"arrow-left\\" color={[undefined]}>
+            <span icon=\\"arrow-left\\" className=\\"bp3-icon bp3-icon-arrow-left\\" title={[undefined]}>
+              <svg fill={[undefined]} data-icon=\\"arrow-left\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                <desc>
+                  arrow-left
+                </desc>
+                <path d=\\"M13.99 6.99H4.41L7.7 3.7a1.003 1.003 0 0 0-1.42-1.42l-5 5a1.014 1.014 0 0 0 0 1.42l5 5a1.003 1.003 0 0 0 1.42-1.42L4.41 8.99H14c.55 0 1-.45 1-1s-.46-1-1.01-1z\\" fillRule=\\"evenodd\\" />
+              </svg>
+            </span>
+          </Blueprint3.Icon>
+        </Blueprint3.Icon>
+        <Blueprint3.Icon icon={[undefined]} />
+      </button>
+    </Blueprint3.Button>
+  </div>
+</UnsubmitCell>"
+`;

--- a/src/components/academy/grading/index.tsx
+++ b/src/components/academy/grading/index.tsx
@@ -17,6 +17,7 @@ import 'ag-grid/dist/styles/ag-theme-balham.css';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { Role } from 'src/reducers/states';
 import GradingWorkspaceContainer from '../../../containers/academy/grading/GradingWorkspaceContainer';
 import NotificationBadge from '../../../containers/notification/NotificationBadge';
 import { stringParamToInt } from '../../../utils/paramParseHelpers';
@@ -62,8 +63,10 @@ export interface IDispatchProps {
 }
 
 export interface IStateProps {
+  group: string | null;
   gradingOverviews?: GradingOverview[];
   notifications: Notification[];
+  role?: Role;
 }
 
 /** Component to render in table - grading status */
@@ -188,7 +191,9 @@ class Grading extends React.Component<IGradingProps, State> {
         field: '',
         cellRendererFramework: UnsubmitCell,
         cellRendererParams: {
-          handleUnsubmitSubmission: this.props.handleUnsubmitSubmission
+          group: this.props.group,
+          handleUnsubmitSubmission: this.props.handleUnsubmitSubmission,
+          role: this.props.role
         },
         suppressFilter: true,
         suppressSorting: true,

--- a/src/containers/academy/grading/index.ts
+++ b/src/containers/academy/grading/index.ts
@@ -11,7 +11,9 @@ import { IState } from '../../../reducers/states';
 
 const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   gradingOverviews: state.session.gradingOverviews,
-  notifications: state.session.notifications
+  group: state.session.group,
+  notifications: state.session.notifications,
+  role: state.session.role
 });
 
 const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Dispatch<any>) =>

--- a/src/mocks/backend.ts
+++ b/src/mocks/backend.ts
@@ -31,6 +31,7 @@ export function* mockBackendSaga(): SagaIterator {
     const user = {
       name: 'DevStaff',
       role: 'staff' as Role,
+      group: '1F',
       story: {
         story: 'mission-1',
         playStory: true

--- a/src/reducers/__tests__/session.ts
+++ b/src/reducers/__tests__/session.ts
@@ -59,6 +59,7 @@ test('SET_USER works correctly', () => {
   const payload = {
     name: 'test student',
     role: Role.Student,
+    group: '42D',
     grade: 150,
     story
   };

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -131,6 +131,7 @@ export interface ISessionState {
   readonly grade: number;
   readonly gradingOverviews?: GradingOverview[];
   readonly gradings: Map<number, Grading>;
+  readonly group: string | null;
   readonly historyHelper: HistoryHelper;
   readonly materialDirectoryTree: DirectoryData[] | null;
   readonly materialIndex: MaterialData[] | null;
@@ -412,6 +413,7 @@ export const defaultSession: ISessionState = {
   grade: 0,
   gradingOverviews: undefined,
   gradings: new Map<number, Grading>(),
+  group: null,
   historyHelper: {
     lastAcademyLocations: [null, null],
     lastGeneralLocations: [null, null]

--- a/src/sagas/__tests__/backend.ts
+++ b/src/sagas/__tests__/backend.ts
@@ -67,6 +67,7 @@ describe('Test FETCH_AUTH Action', () => {
     const user = {
       name: 'user',
       role: 'student' as Role,
+      group: '42D',
       story: {} as Story,
       grade: 1
     };
@@ -85,6 +86,7 @@ describe('Test FETCH_AUTH Action', () => {
     const user = {
       name: 'user',
       role: 'student' as Role,
+      group: '42D',
       story: {} as Story,
       grade: 1
     };


### PR DESCRIPTION
## Render unsubmit button conditionally in grading overviews
Summary: Resolves #753.

### Related PRs
Please review this PR in conjunction with this PR on cadet: https://github.com/source-academy/cadet/pull/506. Both PRs should be approved together. **This PR is complete.**

### Changelog
- Retrieve and store the name of the user's group in the Redux store under `ISessionState` as `group` during the `getUser` request
   - `group` has type `String | null`, and `null` here is used to explicitly denote when a user belongs to no group
- Disable rendering of unsubmit button for non-`submitted` submissions
- Render unsubmit button only for `submitted` submissions belonging to a Staff user's group
   - Unsubmit button will render irrespective of group for Admin users to reflect their elevated privileges

### Mocks and Tests
- Add tests for `UnsubmitCell` component for conditional rendering behaviour

### Screenshots

#### Conditional rendering of unsubmit button (Staff user in `group0`)
![conditional-unsubmit-rendering-demo](https://user-images.githubusercontent.com/44989315/65447269-bcfa5c00-de68-11e9-865b-1d42072a0c3a.png)

Last updated 24 Sept 2019, 01:15AM