### PR TITLE
[ENV] Visualizer Rework

### DIFF
--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -34,138 +34,11 @@
    * decrement from there.
    */
   let dataObjectKey = Math.pow(2, 24) - 1;
-  let builtinFnObjectKey = Math.pow(2, 23) - 1;
   let fnObjectKey = Math.pow(2, 22) - 1;
   
-  // List of built-in functions to ignore (i.e. not draw)
-  var builtins = [
-    'runtime',
-    'display',
-    'raw_display',
-    'stringify',
-    'error',
-    'prompt',
-    'is_number',
-    'is_string',
-    'is_function',
-    'is_boolean',
-    'is_undefined',
-    'parse_int',
-    'undefined',
-    'NaN',
-    'Infinity',
-    'null',
-    'pair',
-    'is_pair',
-    'head',
-    'tail',
-    'is_null',
-    'is_list',
-    'list',
-    'length',
-    'map',
-    'build_list',
-    'for_each',
-    'list_to_string',
-    'reverse',
-    'append',
-    'member',
-    'remove',
-    'remove_all',
-    'filter',
-    'enum_list',
-    'list_ref',
-    'accumulate',
-    'equal',
-    'draw_data',
-    'set_head',
-    'set_tail',
-    'array_length',
-    'is_array',
-    'parse',
-    'apply_in_underlying_javascript',
-    'is_object',
-    'is_NaN',
-    'has_own_property',
-    'alert',
-    'timed',
-    'assoc',
-    'rawDisplay',
-    'prompt',
-    'alert',
-    'visualiseList',
-    'math_abs',
-    'math_acos',
-    'math_acosh',
-    'math_asin',
-    'math_asinh',
-    'math_atan',
-    'math_atanh',
-    'math_atan2',
-    'math_ceil',
-    'math_cbrt',
-    'math_expm1',
-    'math_clz32',
-    'math_cos',
-    'math_cosh',
-    'math_exp',
-    'math_floor',
-    'math_fround',
-    'math_hypot',
-    'math_imul',
-    'math_log',
-    'math_log1p',
-    'math_log2',
-    'math_log10',
-    'math_max',
-    'math_min',
-    'math_pow',
-    'math_random',
-    'math_round',
-    'math_sign',
-    'math_sin',
-    'math_sinh',
-    'math_sqrt',
-    'math_tan',
-    'math_tanh',
-    'math_trunc',
-    'math_toSource',
-    'math_E',
-    'math_LN10',
-    'math_LN2',
-    'math_LOG10E',
-    'math_LOG2E',
-    'math_PI',
-    'math_SQRT1_2',
-    'math_SQRT2',
-    'stream_tail',
-    'stream',
-    'list_to_stream',
-    'is_stream',
-    'stream_to_list',
-    'stream_length',
-    'stream_map',
-    'build_stream',
-    'stream_for_each',
-    'stream_reverse',
-    'stream_append',
-    'stream_remove',
-    'stream_member',
-    'stream_remove_all',
-    'stream_filter',
-    'enum_stream',
-    'integers_from',
-    'eval_stream',
-    'stream_ref',
-  ];
+  // Initialise list of built-in functions to ignore (i.e. not draw)
+  var builtins = [];
   
-  /**
-   * List of built-in functions to draw and not ignore,
-   * i.e. built-ins that are called during the program's execution.
-   * Add name of such a function to this list when one is found.
-   */
-  var builtinsToDraw = [];
-
   /**
    * Helper functions for drawing different types of elements on the canvas.
    */
@@ -393,17 +266,25 @@
     y = config.y;
     context.beginPath();
 
-    // render frame name
+    // render frame name; rename as needed for aesthetic reasons
     let frameName;
-    if (config.name == 'forLoopEnvironment') {
-      frameName = 'for loop';
-    } else if (config.name == 'forBlockEnvironment') {
-      frameName = 'for block';
-    } else if (config.name == 'blockEnvironment') {
-      frameName = 'block';
-    } else {
-      frameName = config.name;
+    switch (config.name) {
+      case 'forLoopEnvironment':
+        frameName = 'for loop';
+        break;
+      case 'forBlockEnvironment':
+        frameName = 'for block';
+        break;
+      case 'blockEnvironment':
+        frameName = 'block';
+        break;
+      case 'global':
+        frameName = "Global";
+        break;
+      default:
+        frameName = config.name;
     }
+    
     if (frameName.length * 9 < config.width / 2 || frameName == 'global') {
       context.fillText(frameName, x, y - 10);
     } else {
@@ -414,20 +295,22 @@
     let elements = config.elements;
     let i = 0;
     for (let k in elements) {
-      if (builtins.indexOf('' + k) < 0 || builtinsToDraw.indexOf('' + k) >= 0) {
-        if (typeof elements[k] == 'number' || typeof elements[k] == 'string') {
-          if (k == '(Other predclr. names)') {
+      switch (typeof elements[k]) {
+        case 'number':
+        case 'boolean':
+          context.fillText(`${'' + k}: ${'' + elements[k]}`, x + 10, y + 30 + i * 30);
+          break;
+        case 'string':
+          if (k == '(other predclr. names)') {
             context.fillText(`${'' + k}`, x + 10, y + 30 + i * 30);
           } else {
-            context.fillText(`${'' + k}: ${'' + elements[k]}`, x + 10, y + 30 + i * 30);
+            context.fillText(`${'' + k}: "${'' + elements[k]}"`, x + 10, y + 30 + i * 30);
           }
-        } else if (typeof elements[k] == 'object') {
+          break;
+        default:
           context.fillText(`${'' + k}:`, x + 10, y + 30 + i * 30);
-        } else {
-          context.fillText(`${'' + k}:`, x + 10, y + 30 + i * 30);
-        }
-        i++;
       }
+      i++;
     }
 
     context.rect(x, y, config.width, config.height);
@@ -719,8 +602,6 @@
   var frameLayer = new Concrete.Layer();
   var arrowLayer = new Concrete.Layer();
 
-  
-
   fnObjects = [];
   /**
    * Unlike function objects, data objects are represented internally not as
@@ -841,6 +722,11 @@
 
   // main function to be exported
   function draw_env(context) {
+    // add built-in functions to list of builtins
+    const allEnvs = context.context.context.runtime.environments;
+    builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 1].head));
+    builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 2].head));
+    
     // add library-specific built-in functions to list of builtins
     const externalSymbols = context.context.context.externalSymbols;
     for (let i in externalSymbols) {
@@ -865,7 +751,6 @@
     levels = {};
     builtinsToDraw = [];
     
-    let allEnvs = context.context.context.runtime.environments;
     // parse input from interpreter
     function parseInput(allFrames, environments) {
       let frames = [];
@@ -946,7 +831,6 @@
               // e.g. "const a = pair". In this case, add it to the global frame
               // to be drawn and subsequently referenced.
               frames[0].elements[getFnName(envElements[e])] = envElements[e];
-              builtinsToDraw.push(getFnName(envElements[e])); // TEMP WORKAROUND
             }
           }
         } 
@@ -1024,9 +908,18 @@
        */
       const missing = []; // think of a better name
       fnObjects.forEach(function (fnObject) {
-        if (!allEnvs.includes(fnObject.environment)) {
-          missing.push(fnObject.environment);
-          allEnvs.push(fnObject.environment);
+        let otherEnv = fnObject.environment;
+        /**
+         * There may be multiple levels of anonymous function frames, e.g.
+         * from the expression (w => x => y => z)(1)(2), where
+         * w => x => ... generates one frame, and
+         * x => y => ... generates another.
+         * The while loop ensure all of these frames are extracted.
+         */
+        while (!allEnvs.includes(otherEnv)) {
+          missing.push(otherEnv);
+          allEnvs.push(otherEnv);
+          otherEnv = otherEnv.tail;
         };
       });
       if (missing.length > 0) {

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -1153,9 +1153,9 @@
   
   function getDrawingHeight(levels) {
     let y = 0;
-    levels.forEach(function(level) {
-      y += level.height + LEVEL_SPACING;
-    });
+    for (l in levels) {
+      y += levels[l].height + LEVEL_SPACING;
+    }
     return y;
   }
   

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -75,7 +75,9 @@
 
   function drawSceneFrames() {
     frames.forEach(function(frame) {
-      drawSceneFrame(frame);
+      if (!isEmptyFrame(frame)) {
+        drawSceneFrame(frame);
+      }
     });
     viewport.render();
   }
@@ -104,7 +106,9 @@
 
   function drawSceneFrameArrows() {
     frames.forEach(function(frame) {
-      drawSceneFrameArrow(frame);
+      if (!isEmptyFrame(frame)) {
+        drawSceneFrameArrow(frame);
+      }
     });
     viewport.render();
   }
@@ -981,9 +985,9 @@
        * Refactor end
        */
     }
-try{
+
     frames = parseInput([], context.context.context.runtime.environments);
-}catch(e){console.log(e);}
+
     positionItems(frames);
 
     viewport.setSize(getDrawingWidth(levels) * 1.5, getDrawingHeight(levels));
@@ -1225,6 +1229,23 @@ try{
       i++;
     }
     return -1;
+  }
+  
+  function isEmptyFrame(frame) {
+    let hasObject = false;
+    fnObjects.forEach(function(f) {
+      if (f.parent == frame) {
+        hasObject = true;
+      }
+    });
+    dataObjectWrappers.forEach(function(d) {
+      if (d.parent == frame) {
+        hasObject = true;
+      }
+    });
+    return !hasObject 
+            && frame.children.length == 0 
+            && Object.keys(frame.elements).length == 0;
   }
   
   exports.EnvVisualizer = {

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -16,6 +16,7 @@
   const frameFontSetting = '14px Roboto Mono, Courier New';
   const FNOBJECT_RADIUS = 12; // radius of function object circle
   const DATA_OBJECT_SIDE = 24; // length of data object triangle
+  const DRAWING_LEFT_PADDING = 100; // left padding for entire drawing
   const FRAME_HEIGHT_LINE = 30; // height in px of each line of text in a frame;
   const FRAME_HEIGHT_PADDING = 20; // height in px to pad each frame with
   const FRAME_WIDTH_CHAR = 10; // width in px of each text character in a frame;
@@ -669,7 +670,8 @@
       frame.x =
         (levels[currLevel].frames.indexOf(frame) + 1) * partitionWidth
         - partitionWidth / 2
-        - frame.width / 2;
+        - frame.width / 2
+        + DRAWING_LEFT_PADDING;
     });
     
     /**
@@ -763,18 +765,27 @@
        * allFrames is all frames created so far (including from previous
        * recursive calls of parseInput).
        */
-      
+
+      /**
+       * For some reason, some environments are not present in the top level 
+       * array of environments in the input context. Here, we extract those
+       * missing environments.
+       */
       let i = environments.length - 4; // skip global and program environments
       while (i >= 0) {
         const currEnv = allEnvs[i];
         if (!allEnvs.includes(currEnv.tail)) {
-           allEnvs.splice(i + 1, 0, currEnv.tail);
-           environments.splice(i + 1, 0, currEnv.tail);
-           i++;
+          if(environments === allEnvs) {
+            allEnvs.splice(i + 1, 0, currEnv.tail);
+          } else {
+            allEnvs.splice(i + 1, 0, currEnv.tail);
+            environments.splice(i + 1, 0, currEnv.tail);
+          }
+          i += 2;
         }
         i--;
       }
-      
+
       // add layers
       viewport
         .add(frameLayer)
@@ -857,6 +868,7 @@
        *   other frame is 1 level below its parent.
        */
       frames.forEach(function(frame) {
+        
         if (frame.name == "global") {
           frame.parent = null;
           frame.level = 0;
@@ -968,7 +980,9 @@
 
     positionItems(frames);
 
-    viewport.setSize(getDrawingWidth(levels), getDrawingHeight(levels));
+    viewport.setSize(getDrawingWidth(levels) * 1.5, getDrawingHeight(levels));
+    // "* 1.5" is a partial workaround for drawing being cut off on the right
+    
     /**
      * Find the source frame for each fnObject. The source frame is the frame
      * which generated the function. This may be different from the parent

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -16,14 +16,14 @@
   const frameFontSetting = '14px Roboto Mono, Courier New';
   const FNOBJECT_RADIUS = 12; // radius of function object circle
   const DATA_OBJECT_SIDE = 24; // length of data object triangle
-  const DRAWING_LEFT_PADDING = 100; // left padding for entire drawing
+  const DRAWING_LEFT_PADDING = 20; // left padding for entire drawing
   const FRAME_HEIGHT_LINE = 30; // height in px of each line of text in a frame;
   const FRAME_HEIGHT_PADDING = 20; // height in px to pad each frame with
-  const FRAME_WIDTH_CHAR = 10; // width in px of each text character in a frame;
+  const FRAME_WIDTH_CHAR = 8; // width in px of each text character in a frame;
   const FRAME_WIDTH_PADDING = 50; // width in px to pad each frame with;
   const FRAME_SPACING = 100; // spacing between horizontally adjacent frames
   const LEVEL_SPACING = 60; // spacing between vertical frame levels
-  const OBJECT_FRAME_RIGHT_SPACING = 60; // space to right frame border
+  const OBJECT_FRAME_RIGHT_SPACING = 50; // space to right frame border
   const OBJECT_FRAME_TOP_SPACING = 25; // perpendicular distance to top border
   
   /**
@@ -374,7 +374,7 @@
     if (wrapper.parent == frame) {
       // dataObject belongs to current frame
       // simply draw straight arrow from frame to function
-      const x0 = frame.x + name.length * FRAME_WIDTH_CHAR + 20;
+      const x0 = frame.x + name.length * FRAME_WIDTH_CHAR + 25;
       const y0 = wrapper.y,
         xf = wrapper.x - FNOBJECT_RADIUS * 2 - 3; // left circle
       context.moveTo(x0, y0);
@@ -454,7 +454,7 @@
     if (fnObject.parent == frame) {
       // fnObject belongs to current frame
       // simply draw straight arrow from frame to function
-      const x0 = frame.x + name.length * FRAME_WIDTH_CHAR + 20;
+      const x0 = frame.x + name.length * FRAME_WIDTH_CHAR + 25;
       const y0 = fnObject.y,
         xf = fnObject.x - FNOBJECT_RADIUS * 2 - 3; // left circle
       context.moveTo(x0, y0);
@@ -535,7 +535,7 @@
         y0 = startCoord[1],
         x1 = x0,
         y1 = y0 - 15,
-        x2 = x1 - 70,
+        x2 = fnObject.parent.x + fnObject.parent.width + 3,
         y2 = y1;
       context.moveTo(x0, y0);
       context.lineTo(x1, y1);
@@ -549,7 +549,7 @@
         x1 = x0 + FNOBJECT_RADIUS + 3;
         y1 = y0,
         x2 = x1,
-        y2 = fnObject.source.y - 30,
+        y2 = fnObject.source.y - 40,
         x3 = fnObject.source.x + fnObject.source.width / 2 + 10,
         y3 = y2
         x4 = x3,
@@ -730,7 +730,7 @@
     let allEnvs = context.context.context.runtime.environments;
     builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 1].head));
     builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 2].head));
-    
+
     // add library-specific built-in functions to list of builtins
     const externalSymbols = context.context.context.externalSymbols;
     for (let i in externalSymbols) {
@@ -814,18 +814,18 @@
               
         /**
          * There are two environments named programEnvironment. We only want one
-         * corresponding "Program Environment" frame.
+         * corresponding "Program" frame.
          */
         if (environment.name == "programEnvironment") {
           let isProgEnvPresent = false;
           frames.forEach(function (f) {
-            if (f.name == "Program Environment") {
+            if (f.name == "Program") {
               frame = f;
               isProgEnvPresent = true;
             }
           });
           if (!isProgEnvPresent) {
-            frame = createEmptyFrame("Program Environment");
+            frame = createEmptyFrame("Program");
             frame.key = environment.envKeyCounter;
             frames.push(frame);
             allFrames.push(frame);
@@ -873,7 +873,7 @@
           frame.parent = null;
           frame.level = 0;
         } else {
-          if (frame.name == "Program Environment") {
+          if (frame.name == "Program") {
             frame.parent = getFrameByName(allFrames, "global");
           } else {
             env = getEnvByKeyCounter(environments, frame.key);
@@ -958,11 +958,17 @@
           }
           const params = pointer.params;
           let paramArray = [];
-          params.forEach(function(p) {
-            paramArray.push(p.name);
-          });
-          const paramString = "(" + paramArray.join(", ") + ") => ...";
-          otherEnv.name = paramString;
+          let paramString;
+          try {
+            params.forEach(function(p) {
+              paramArray.push(p.name);
+            });
+            const paramString = "(" + paramArray.join(", ") + ") => ...";
+            otherEnv.name = paramString;
+          } catch (e) {
+            // for some reason or other the function definition expression is
+            // not always available. In that case, just use the frame name
+          }
           otherEnv = otherEnv.tail;
         };
       });
@@ -975,9 +981,9 @@
        * Refactor end
        */
     }
-
+try{
     frames = parseInput([], context.context.context.runtime.environments);
-
+}catch(e){console.log(e);}
     positionItems(frames);
 
     viewport.setSize(getDrawingWidth(levels) * 1.5, getDrawingHeight(levels));

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -115,7 +115,26 @@
     'math_LOG2E',
     'math_PI',
     'math_SQRT1_2',
-    'math_SQRT2'
+    'math_SQRT2',
+    'stream_tail',
+    'stream',
+    'list_to_stream',
+    'is_stream',
+    'stream_to_list',
+    'stream_length',
+    'stream_map',
+    'build_stream',
+    'stream_for_each',
+    'stream_reverse',
+    'stream_append',
+    'stream_remove',
+    'stream_member',
+    'stream_remove_all',
+    'stream_filter',
+    'enum_stream',
+    'integers_from',
+    'eval_stream',
+    'stream_ref',
   ];
   
   /**
@@ -689,7 +708,9 @@
     let dataObjectKey = Math.pow(2, 24) - 1;
     let builtinFnObjectKey = Math.pow(2, 23) - 1;
     frames.reverse(); // more natural ordering! Global frame now comes first
+
     while (i < frames.length) {
+      
       const frame = frames[i];
 
       // load basic ConcreteJS properties
@@ -750,7 +771,9 @@
       for (let k in env) {
         let varLength;
         // first sieve out built-in functions in non-global frames
-        if (frame.name !== 'global' && builtins.indexOf(getFnName(env[k])) >= 0) {
+        if ((frame.name !== 'global' 
+            && (frame.name == "programEnvironment" && frame.tail.name == "programEnvironment"))
+            && (builtins.indexOf(getFnName(env[k])) >= 0 || builtins.indexOf(k) >= 0)) {
           builtinsToDraw.push(getFnName(env[k]));
           heightFactor++;
           if (k.length > maxLength) {
@@ -774,7 +797,7 @@
         }
 
         if (typeof env[k] == 'function') {
-          const fnName = getFnName(env[k]);
+          const fnName = k;
           if (builtins.indexOf(fnName) < 0 || builtinsToDraw.indexOf(fnName) >= 0) {
             // check if function was already declared in another frame
             let existing = false;
@@ -797,7 +820,7 @@
                 }
               }
             }
-
+            
             env[k].hovered = false;
             env[k].selected = false;
             env[k].layer = fnObjectLayer;
@@ -817,11 +840,11 @@
               if (!existing) {
                 env[k].key = builtinFnObjectKey--;
                 env[k].functionName = fnName;
-                env[k].parent = frames[0];
-                frames[0].fnObjects.push(env[k].key);
-                frames[0].variables.push(env[k]);
+                env[k].parent = frame;
+                frame.fnObjects.push(env[k].key);
+                frame.variables.push(env[k]);
                 // update height of global frame
-                frames[0].height += 30;
+                frame.height += 30;
               }
               frame.variables.push(env[k]);
             }
@@ -895,7 +918,7 @@
     }
     viewport.setSize(drawingWidth, drawingHeight);
     */
-    
+
     for (f in frames) {
       /**
        * x-coordinate
@@ -975,7 +998,6 @@
 
   // main function to be exported
   function draw_env(context) {
-    
     // add library-specific built-in functions to list of builtins
     const externalSymbols = context.context.context.externalSymbols;
     for (let i in externalSymbols) {

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -270,13 +270,13 @@
     let frameName;
     switch (config.name) {
       case 'forLoopEnvironment':
-        frameName = 'for loop';
+        frameName = 'Body of for-loop';
         break;
       case 'forBlockEnvironment':
-        frameName = 'for block';
+        frameName = 'Control variable of for-loop';
         break;
       case 'blockEnvironment':
-        frameName = 'block';
+        frameName = 'Block';
         break;
       case 'global':
         frameName = "Global";
@@ -725,7 +725,7 @@
   function draw_env(context) {
 
     // add built-in functions to list of builtins
-    const allEnvs = context.context.context.runtime.environments;
+    let allEnvs = context.context.context.runtime.environments;
     builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 1].head));
     builtins = builtins.concat(Object.keys(allEnvs[allEnvs.length - 2].head));
     
@@ -754,7 +754,8 @@
     builtinsToDraw = [];
     
     // parse input from interpreter
-    function parseInput(allFrames, environments) {
+    function parseInput(allFrames, envs) {
+      let environments = envs;
       let frames = [];
       /**
        * environments is the array of environments in the interpreter.
@@ -762,6 +763,17 @@
        * allFrames is all frames created so far (including from previous
        * recursive calls of parseInput).
        */
+      
+      let i = environments.length - 4; // skip global and program environments
+      while (i >= 0) {
+        const currEnv = allEnvs[i];
+        if (!allEnvs.includes(currEnv.tail)) {
+           allEnvs.splice(i + 1, 0, currEnv.tail);
+           environments.splice(i + 1, 0, currEnv.tail);
+           i++;
+        }
+        i--;
+      }
       
       // add layers
       viewport
@@ -939,9 +951,6 @@
           });
           const paramString = "(" + paramArray.join(", ") + ") => ...";
           otherEnv.name = paramString;
-          console.log(otherEnv);
-          console.log(paramString);
-          console.log(pointer.toString);
           otherEnv = otherEnv.tail;
         };
       });

--- a/public/externalLibs/env_visualizer/visualizer.js
+++ b/public/externalLibs/env_visualizer/visualizer.js
@@ -20,6 +20,8 @@
   const FRAME_HEIGHT_PADDING = 20; // height in px to pad each frame with
   const FRAME_WIDTH_CHAR = 10; // width in px of each text character in a frame;
   const FRAME_WIDTH_PADDING = 50; // width in px to pad each frame with;
+  const FRAME_SPACING = 100; // spacing between horizontally adjacent frames
+  const LEVEL_SPACING = 60; // spacing between vertical frame levels
   const OBJECT_FRAME_RIGHT_SPACING = 60; // space to right frame border
   const OBJECT_FRAME_TOP_SPACING = 25; // perpendicular distance to top border
   
@@ -638,6 +640,7 @@
     /**
      * Calculate x- and y-coordinates for each frame
      */ 
+    const drawingWidth = getDrawingWidth(levels);
     frames.forEach(function(frame) {
       let currLevel = frame.level;
 
@@ -662,7 +665,7 @@
        * "tree" of child frame.
        */
       const partitionCount = levels[currLevel].count;
-      const partitionWidth = viewport.width / partitionCount;
+      const partitionWidth = drawingWidth / partitionCount;
       frame.x =
         (levels[currLevel].frames.indexOf(frame) + 1) * partitionWidth
         - partitionWidth / 2
@@ -951,11 +954,12 @@
        * Refactor end
        */
     }
-try{
+
     frames = parseInput([], context.context.context.runtime.environments);
-}catch(e){console.log(e);}
+
     positionItems(frames);
 
+    viewport.setSize(getDrawingWidth(levels), getDrawingHeight(levels));
     /**
      * Find the source frame for each fnObject. The source frame is the frame
      * which generated the function. This may be different from the parent
@@ -1132,6 +1136,27 @@ try{
       maxLength = Math.max(maxLength, currLength);
     }
     return maxLength * FRAME_WIDTH_CHAR + FRAME_WIDTH_PADDING;    
+  }
+  
+  function getDrawingWidth(levels) {
+    let maxX = 0;
+    for (l in levels) {
+      let currX = 0;
+      level = levels[l];
+      level.frames.forEach(function(f) {
+        currX += f.width + FRAME_SPACING;
+      });
+      maxX = Math.max(maxX, currX);
+    }
+    return maxX;
+  }
+  
+  function getDrawingHeight(levels) {
+    let y = 0;
+    levels.forEach(function(level) {
+      y += level.height + LEVEL_SPACING;
+    });
+    return y;
   }
   
   function getWrapperFromDataObject(dataObject) {


### PR DESCRIPTION
- Major refactor of main function
- Frames generated by function definition expressions are now displayed
- Built-in names redeclared by user are now correctly displayed
- Strings are now correctly displayed with inverted commas
- List of built-in functions is now obtained at runtime instead of being hardcoded
- Environments not in the main array of the input context are now detected and displayed
- Frame positions are now computed differently to reduce overlapping

Known issues:
- Larger drawings still get cut off on the right side