### PR TITLE
Fix some minor frontend bugs on SourceCast

### DIFF
--- a/src/components/sourcecast/SourcecastControlbar.tsx
+++ b/src/components/sourcecast/SourcecastControlbar.tsx
@@ -172,12 +172,16 @@ class SourcecastControlbar extends React.PureComponent<
   };
 
   private renderLabel = (value: number) => {
-    const totalTime = this.props.duration * value;
-    const min = Math.floor(totalTime / 60);
-    const sec = Math.floor(totalTime - min * 60);
-    const minString = min < 10 ? '0' + min : min;
-    const secString = sec < 10 ? '0' + sec : sec;
-    return minString + ':' + secString;
+    if (this.props.duration) {
+      const totalTime = this.props.duration * value;
+      const min = Math.floor(totalTime / 60);
+      const sec = Math.floor(totalTime - min * 60);
+      const minString = min < 10 ? '0' + min : min;
+      const secString = sec < 10 ? '0' + sec : sec;
+      return minString + ':' + secString;
+    } else {
+      return '00:00';
+    }
   };
 }
 

--- a/src/components/sourcecast/SourcecastControlbar.tsx
+++ b/src/components/sourcecast/SourcecastControlbar.tsx
@@ -31,7 +31,13 @@ class SourcecastControlbar extends React.PureComponent<
   }
 
   public render() {
-    const PlayerPlayButton = controlButton('Play', IconNames.PLAY, this.handlePlayerPlaying);
+    const PlayerPlayButton = controlButton(
+      'Play',
+      IconNames.PLAY,
+      this.handlePlayerPlaying,
+      {},
+      !this.props.duration
+    );
     const PlayerPauseButton = controlButton('Pause', IconNames.PAUSE, this.handlePlayerPausing);
     return (
       <div className="Bar">

--- a/src/components/sourcecast/SourcereelControlbar.tsx
+++ b/src/components/sourcecast/SourcereelControlbar.tsx
@@ -162,6 +162,7 @@ class SourcereelControlbar extends React.PureComponent<
     handleTimerReset();
     clearInterval(this.state.updater!);
     this.setState({ duration: 0 });
+    this.recorder.stop();
     this.recorder.clear();
   };
 


### PR DESCRIPTION
- Fix `NaN:NaN` display when selecting new recordings
- Disable `Play` button when no recording is selected, to prevent unintended behaviours
- Fix bug where resetting of SourceReel does not stop recorder