### PR TITLE
Add Features: Refactoring and Variable Highlighting

### DIFF
--- a/src/components/workspace/AceRange.tsx
+++ b/src/components/workspace/AceRange.tsx
@@ -1,0 +1,9 @@
+/***
+ * We need access to the Range class in the Ace Editor to create our own ranges, and
+ * this is the only way to do it.
+ */
+const ace = (() => {
+  return (window as any).ace;
+})() as any;
+const { Range } = ace.acequire('ace/range');
+export default Range;

--- a/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
+++ b/src/components/workspace/__tests__/__snapshots__/Editor.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Editor renders correctly 1`] = `
 "<HotKeys className=\\"Editor\\" handlers={{...}}>
   <div className=\\"row editor-react-ace\\">
-    <ReactAce className=\\"react-ace\\" commands={{...}} editorProps={{...}} markers={{...}} fontSize={17} height=\\"100%\\" highlightActiveLine={false} mode=\\"source1\\" onChange={[Function]} onValidate={[Function]} theme=\\"source\\" value=\\"\\" width=\\"100%\\" setOptions={{...}} name=\\"ace-editor\\" focus={false} enableSnippets={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} style={{...}} scrollMargin={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} placeholder={{...}} navigateToFileEnd={true} />
+    <ReactAce className=\\"react-ace\\" commands={{...}} editorProps={{...}} markers={{...}} fontSize={17} height=\\"100%\\" highlightActiveLine={false} mode=\\"source1\\" onChange={[Function]} onCursorChange={[Function]} onValidate={[Function]} theme=\\"source\\" value=\\"\\" width=\\"100%\\" setOptions={{...}} name=\\"ace-editor\\" focus={false} enableSnippets={false} showGutter={true} onPaste={{...}} onLoad={{...}} onScroll={{...}} minLines={{...}} maxLines={{...}} readOnly={false} showPrintMargin={true} tabSize={4} cursorStart={1} style={{...}} scrollMargin={{...}} wrapEnabled={false} enableBasicAutocompletion={false} enableLiveAutocompletion={false} placeholder={{...}} navigateToFileEnd={true} />
   </div>
 </HotKeys>"
 `;

--- a/src/styles/_variableHighlighting.scss
+++ b/src/styles/_variableHighlighting.scss
@@ -1,0 +1,6 @@
+.ace_variable_highlighting {
+  z-index: 4;
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px dashed rgba(255, 255, 255, 0.6);
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -30,5 +30,6 @@
 @import 'playground';
 @import 'sourcereel';
 @import 'sourcecast';
+@import 'variableHighlighting';
 @import 'workspaceGreen';
 @import 'workspace';


### PR DESCRIPTION
- `Cmd+M` / `Ctrl+M` will highlight all instances of the identifier that the cursor is currently at, after which typing a new name should simultaneously change all instances of that identifier. Pressing the `Esc` key will bring the editor back to having only one cursor. Alternatively, clicking anywhere on the editor will make the additional cursors disappear.

- Whenever the cursor moves or the code changes, a faint dashed box will surround all instances of it for easier identifying of which variable you are looking at.

![refactoring_demo](https://user-images.githubusercontent.com/20292565/77848581-52035680-71f8-11ea-8f7e-937021325387.gif)