### PR TITLE
Temporary fix: add variant argument in application of createSlangContext

### DIFF
--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -124,7 +124,7 @@ export const externalBuiltIns = {
  * externalBuiltIns, such as display and prompt.
  */
 export function createContext<T>(chapter: number, externals: string[], externalContext: T) {
-  return createSlangContext<T>(chapter, externals, externalContext, externalBuiltIns);
+  return createSlangContext<T>(chapter, 'default', externals, externalContext, externalBuiltIns);
 }
 
 // Assumes that the grader doesn't need additional external libraries apart from the standard


### PR DESCRIPTION
In a [recent PR](https://github.com/source-academy/js-slang/pull/478) in js-slang, the signature of the `createContext` function was modified.

Specifically, we added a `variant` parameter in this function.
This breaks cadet-frontend on `sa_2021` branch, because cadet-frontend is now calling `createContext` with the wrong number of arguments.

This PR temporarily fixes this issue by adding a `default` argument in the call to `createContext`.
The eventual goal is for the `variant` to be obtained based on the option chosen in the chapter dropdown menu.