### PR TITLE
Encode chapter and variant separately in Share URL

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -9,7 +9,7 @@ import Material from '../containers/material/MaterialContainer';
 import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import Sourcecast from '../containers/sourcecast/SourcecastContainer';
-import { languageURLNames, Role } from '../reducers/states';
+import { Role, sourceLanguages } from '../reducers/states';
 import { stringParamToInt } from '../utils/paramParseHelpers';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
 import Contributors from './contributors';
@@ -97,7 +97,7 @@ const toLogin = (props: IApplicationProps) => () => (
 const parsePlayground = (props: IApplicationProps) => {
   const prgrm = parsePrgrm(props);
   const chapter = parseChapter(props) || props.currentPlaygroundChapter;
-  const variant = parseVariant(props) || props.currentPlaygroundVariant;
+  const variant = parseVariant(props, chapter) || props.currentPlaygroundVariant;
   const externalLibraryName = parseExternalLibrary(props) || props.currentExternalLibrary;
   const execTime = parseExecTime(props);
   if (prgrm) {
@@ -120,9 +120,11 @@ const parsePrgrm = (props: RouteComponentProps<{}>) => {
 
 const parseChapter = (props: RouteComponentProps<{}>) => {
   const chapQuery = qs.parse(props.location.hash).chap;
+  // find a language with this chapter (if any)
+  const langWithMatchingChapter = sourceLanguages.find(language => language.chapter === chapQuery);
 
-  const chap: number = languageURLNames.has(chapQuery)
-    ? languageURLNames.get(chapQuery)!.chapter
+  const chap: number = langWithMatchingChapter
+    ? langWithMatchingChapter.chapter
     : chapQuery === undefined
     ? NaN
     : parseInt(chapQuery, 10);
@@ -130,12 +132,14 @@ const parseChapter = (props: RouteComponentProps<{}>) => {
   return chap ? chap : undefined;
 };
 
-const parseVariant = (props: RouteComponentProps<{}>) => {
-  const chapQuery = qs.parse(props.location.hash).chap;
+const parseVariant = (props: RouteComponentProps<{}>, chap: number) => {
+  const chapQuery = qs.parse(props.location.hash).variant;
+  // find a language with this variant and chapter (if any)
+  const matchingLang = sourceLanguages.find(
+    language => language.chapter === chap && language.variant === chapQuery
+  );
 
-  const variant: Variant = languageURLNames.has(chapQuery)
-    ? languageURLNames.get(chapQuery)!.variant
-    : 'default';
+  const variant: Variant = matchingLang ? matchingLang.variant : 'default';
 
   return variant;
 };

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -133,10 +133,10 @@ const parseChapter = (props: RouteComponentProps<{}>) => {
 };
 
 const parseVariant = (props: RouteComponentProps<{}>, chap: number) => {
-  const chapQuery = qs.parse(props.location.hash).variant;
+  const variantQuery = qs.parse(props.location.hash).variant;
   // find a language with this variant and chapter (if any)
   const matchingLang = sourceLanguages.find(
-    language => language.chapter === chap && language.variant === chapQuery
+    language => language.chapter === chap && language.variant === variantQuery
   );
 
   const variant: Variant = matchingLang ? matchingLang.variant : 'default';

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -237,21 +237,6 @@ const variantDisplay: Map<Variant, string> = new Map([
   ['non-det', 'Non-Det'],
   ['concurrent', 'Concurrent']
 ]);
-export const languageURLNames: Map<string, ISourceLanguage> = new Map([
-  ['3_Non_Det', { chapter: 3, variant: 'non-det' }],
-  ['3_Concurrent', { chapter: 3, variant: 'concurrent' }]
-]);
-
-export const urlName = (chapter: number, variant: Variant = 'default'): string => {
-  for (const name of languageURLNames.keys()) {
-    const language: ISourceLanguage = languageURLNames.get(name)!;
-    if (language.chapter === chapter && language.variant === variant) {
-      return name;
-    }
-  }
-
-  return chapter.toString();
-};
 
 export const styliseChapter = (chap: number, variant: Variant = 'default') => {
   let res = `Source \xa7${chap}`;

--- a/src/sagas/__tests__/playground.ts
+++ b/src/sagas/__tests__/playground.ts
@@ -1,3 +1,4 @@
+import { Variant } from 'js-slang/dist/types';
 import { compressToEncodedURIComponent } from 'lz-string';
 import * as qs from 'query-string';
 import { expectSaga } from 'redux-saga-test-plan';
@@ -77,11 +78,13 @@ describe('Playground saga tests', () => {
 
 function createQueryString(code: string, state: IState): string {
   const chapter: number = state.workspaces.playground.context.chapter;
+  const variant: Variant = state.workspaces.playground.context.variant;
   const external: ExternalLibraryName = state.workspaces.playground.externalLibrary;
   const execTime: number = state.workspaces.playground.execTime;
   const newQueryString: string = qs.stringify({
     prgrm: compressToEncodedURIComponent(code),
     chap: chapter,
+    variant,
     ext: external,
     exec: execTime
   });

--- a/src/sagas/playground.ts
+++ b/src/sagas/playground.ts
@@ -5,7 +5,7 @@ import { put, select, takeEvery } from 'redux-saga/effects';
 import * as actions from '../actions';
 import * as actionTypes from '../actions/actionTypes';
 import { ExternalLibraryName } from '../components/assessment/assessmentShape';
-import { defaultEditorValue, IState, urlName } from '../reducers/states';
+import { defaultEditorValue, IState } from '../reducers/states';
 
 import { Variant } from 'js-slang/dist/types';
 
@@ -28,16 +28,14 @@ function* updateQueryString() {
   const variant: Variant = yield select(
     (state: IState) => state.workspaces.playground.context.variant
   );
-
-  const languageUrlName: string = urlName(chapter, variant);
-
   const external: ExternalLibraryName = yield select(
     (state: IState) => state.workspaces.playground.externalLibrary
   );
   const execTime: number = yield select((state: IState) => state.workspaces.playground.execTime);
   const newQueryString: string = qs.stringify({
     prgrm: compressToEncodedURIComponent(codeString),
-    chap: languageUrlName,
+    chap: chapter,
+    variant,
     ext: external,
     exec: execTime
   });


### PR DESCRIPTION
Currently, when we create the Share URL for the Non-deterministic and Concurrent variants, we encode the chapter and variant information together in one string.

For example, if the playground was using `Source 3 Non-Det`, then then Share URL will look
like this `https://source-academy.github.io/playground#chap=3_Non_Det&exec=1000&ext=NONE&prgrm=IYWwRgFAjAlA3EA`

Note the string `#chap=3_Non_Det` in the URL.

Instead of this, we can encode the chapter and variant separately.
So, the url will look like: `https://source-academy.github.io/playground#chap=3&exec=1000&ext=NONE&prgrm=IYWwRgFAjAlA3EA&variant=non-det`

This PR reduces the steps needed to add a new language variant.
The Share URL will automatically support any language variants added into the `sourceLangauges` array in `src/reducers/states.ts`.

**Note: The `variant` field in the Share URL is optional**
If the URL does not have a `variant`, the playground will use the `default` variant.
This ensures the Share URL is backward compatible