### PR TITLE
Fix: 'try again' in comment results in error for Source 3 Non-Det

### DIFF
--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -615,8 +615,6 @@ export function* evalCode(
   function call_non_det() {
     return code.trim() === TRY_AGAIN
       ? call(resume, lastNonDetResult)
-      : code.includes(TRY_AGAIN) // defensive check: try-again should only be used on its own
-      ? { status: 'error' }
       : call(runInContext, code, context, {
           executionMethod: 'interpreter',
           originalMaxExecTime: execTime,


### PR DESCRIPTION
Including try again in a comment results in an error, for example:
```
// try again
```

This is due to a check which was introduced in order to prevent users from using try_again together with other statements, for example:
```
amb(1, 2); try_again;
```
However, the issue is that this check does not distinguish between commented and uncommented code.

Since the syntax has been changed from `try_again` to `try again`, this check is no longer necessary as a syntax error will be thrown for `try again`. This PR removes the check.