### PR TITLE
add type inference display.

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -303,6 +303,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         handleDeclarationNavigate: this.props.handleDeclarationNavigate,
         handleEditorEval: this.props.handleEditorEval,
         handleEditorValueChange: this.props.handleEditorValueChange,
+        handleReplValueChange: this.props.handleReplValueChange,
         handlePromptAutocomplete: this.props.handlePromptAutocomplete,
         handleFinishInvite: this.props.handleFinishInvite,
         sharedbAceInitValue: this.props.sharedbAceInitValue,

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -387,8 +387,7 @@ class Editor extends React.PureComponent<IEditorProps, {}> {
     }, 10);
   };
 
-  private handleTypeInferenceDisplay = () : void => {
-
+  private handleTypeInferenceDisplay = (): void => {
     // declare constants
     const chapter = this.props.sourceChapter;
     const code = this.props.editorValue;
@@ -396,28 +395,35 @@ class Editor extends React.PureComponent<IEditorProps, {}> {
     const pos = editor.getCursorPosition();
     const token = editor.session.getTokenAt(pos.row, pos.column);
 
-
     // comment out everyline of the inference string returned by getTypeInformation
-    const commentEveryLine = (str : string) => {
+    const commentEveryLine = (str: string) => {
       const arr = str.split('\n');
-      return arr.filter(st => st !== '').map(st => '// ' + st).join('\n');
+      return arr
+        .filter(st => st !== '')
+        .map(st => '// ' + st)
+        .join('\n');
     };
 
     // display the information
     if (this.props.handleReplValueChange) {
       if (pos && token) {
-        const str = getTypeInformation(code, createContext(chapter), {line: pos.row + 1, column: pos.column}, token.value);
+        const str = getTypeInformation(
+          code,
+          createContext(chapter),
+          { line: pos.row + 1, column: pos.column },
+          token.value
+        );
         const output = commentEveryLine(str);
         if (str.length > 0) {
           this.props.handleReplValueChange(output);
         } else {
-          this.props.handleReplValueChange("// type information not found");
+          this.props.handleReplValueChange('// type information not found');
         }
       } else {
-        this.props.handleReplValueChange("// invalid token. Please put cursor on an identifier.");
+        this.props.handleReplValueChange('// invalid token. Please put cursor on an identifier.');
       }
     }
-  }
+  };
 
   private handleGutterClick = (e: any) => {
     const target = e.domEvent.target;

--- a/src/components/workspace/Editor.tsx
+++ b/src/components/workspace/Editor.tsx
@@ -6,7 +6,7 @@ import sharedbAce from 'sharedb-ace';
 import { require as acequire } from 'ace-builds';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/ext-searchbox';
-import { createContext, getAllOccurrencesInScope, getScope } from 'js-slang';
+import { createContext, getAllOccurrencesInScope, getScope, getTypeInformation } from 'js-slang';
 import { HighlightRulesSelector, ModeSelector } from 'js-slang/dist/editors/ace/modes/source';
 import 'js-slang/dist/editors/ace/theme/source';
 import { Variant } from 'js-slang/dist/types';
@@ -36,6 +36,7 @@ export interface IEditorProps {
   handleDeclarationNavigate: (cursorPosition: IPosition) => void;
   handleEditorEval: () => void;
   handleEditorValueChange: (newCode: string) => void;
+  handleReplValueChange?: (newCode: string) => void;
   handleEditorUpdateBreakpoints: (breakpoints: string[]) => void;
   handleFinishInvite?: () => void;
   handlePromptAutocomplete: (row: number, col: number, callback: any) => void;
@@ -238,6 +239,14 @@ class Editor extends React.PureComponent<IEditorProps, {}> {
                   mac: 'Command-Shift-H'
                 },
                 exec: this.handleHighlightScope
+              },
+              {
+                name: 'TypeInferenceDisplay',
+                bindKey: {
+                  win: 'Ctrl-Shift-M',
+                  mac: 'Command-Shift-M'
+                },
+                exec: this.handleTypeInferenceDisplay
               }
             ]}
             editorProps={{
@@ -377,6 +386,38 @@ class Editor extends React.PureComponent<IEditorProps, {}> {
       this.markerIds = markerIds;
     }, 10);
   };
+
+  private handleTypeInferenceDisplay = () : void => {
+
+    // declare constants
+    const chapter = this.props.sourceChapter;
+    const code = this.props.editorValue;
+    const editor = (this.AceEditor.current as any).editor;
+    const pos = editor.getCursorPosition();
+    const token = editor.session.getTokenAt(pos.row, pos.column);
+
+
+    // comment out everyline of the inference string returned by getTypeInformation
+    const commentEveryLine = (str : string) => {
+      const arr = str.split('\n');
+      return arr.filter(st => st !== '').map(st => '// ' + st).join('\n');
+    };
+
+    // display the information
+    if (this.props.handleReplValueChange) {
+      if (pos && token) {
+        const str = getTypeInformation(code, createContext(chapter), {line: pos.row + 1, column: pos.column}, token.value);
+        const output = commentEveryLine(str);
+        if (str.length > 0) {
+          this.props.handleReplValueChange(output);
+        } else {
+          this.props.handleReplValueChange("// type information not found");
+        }
+      } else {
+        this.props.handleReplValueChange("// invalid token. Please put cursor on an identifier.");
+      }
+    }
+  }
 
   private handleGutterClick = (e: any) => {
     const target = e.domEvent.target;


### PR DESCRIPTION
Put the cursor at a variable, and the type inference will be displayed inside repl.
![image](https://user-images.githubusercontent.com/50571615/79681768-50550d80-824f-11ea-81ce-f973ddcbedcd.png)

![image](https://user-images.githubusercontent.com/50571615/79681763-4501e200-824f-11ea-8ec7-e5b94f88298f.png)

If cursor is not at a name, there will be cursor position error
![image](https://user-images.githubusercontent.com/50571615/79681783-72e72680-824f-11ea-8d44-eabaaa317519.png)
![image](https://user-images.githubusercontent.com/50571615/79681784-75e21700-824f-11ea-92a5-77cfd2ae4229.png)

If the program is syntactically incorrect, the error will also be displayed.
![image](https://user-images.githubusercontent.com/50571615/79681798-90b48b80-824f-11ea-8360-d2f18c1a2437.png)
![image](https://user-images.githubusercontent.com/50571615/79681799-9316e580-824f-11ea-8e1a-b704f6523057.png)
