### PR TITLE
Changed SubstVisualizer rendering time, bug fix

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -141,13 +141,6 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
   }
 
   public render() {
-    const substVisualizerTab: SideContentTab = {
-      label: 'Substituter',
-      iconName: IconNames.FLOW_REVIEW,
-      body: <SubstVisualizer content={this.processStepperOutput(this.props.output)} />,
-      id: SideContentType.substVisualizer
-    };
-
     const autorunButtons = (
       <AutorunButtons
         handleDebuggerPause={this.props.handleDebuggerPause}
@@ -286,7 +279,13 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
     }
 
     if (this.props.sourceChapter <= 2 && this.props.sourceVariant !== 'wasm') {
-      tabs.push(substVisualizerTab);
+      // Enable Subst Visualizer for Source 1 & 2
+      tabs.push({
+        label: 'Substituter',
+        iconName: IconNames.FLOW_REVIEW,
+        body: <SubstVisualizer content={this.processStepperOutput(this.props.output)} />,
+        id: SideContentType.substVisualizer
+      });
     }
 
     const workspaceProps: WorkspaceProps = {
@@ -423,6 +422,7 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
       editorOutput &&
       editorOutput.type === 'result' &&
       editorOutput.value instanceof Array &&
+      editorOutput.value[0] === Object(editorOutput.value[0]) &&
       isStepperOutput(editorOutput.value[0])
     ) {
       return editorOutput.value;


### PR DESCRIPTION
Another bug fix: type check isStepperOutput cannot be run on primitive values hence an extra check is added to ensure that the element in the output array is an object first

Declaration of substVisualiserTab is shifted to the moment it is pushed into the side content tab instead of at the top of the playground render() function in order to prevent the stepper from rendering regardless of source chapter