### PR TITLE
Fix Close Buttons for Popup Dialogs

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -193,7 +193,7 @@ class AssessmentWorkspace extends React.Component<
       <Dialog
         className="assessment-reset"
         icon={IconNames.ERROR}
-        isCloseButtonShown={false}
+        isCloseButtonShown={true}
         isOpen={this.state.showResetTemplateOverlay}
         title="Confirmation: Reset editor?"
       >

--- a/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -10,7 +10,7 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
@@ -38,7 +38,7 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
@@ -66,7 +66,7 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
@@ -94,7 +94,7 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />

--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -37,8 +37,8 @@ exports[`Assessment page "loading" content renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -843,8 +843,8 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -890,8 +890,8 @@ exports[`Assessment page with 0 missions renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -1726,8 +1726,8 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={false} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -211,7 +211,7 @@ class Assessment extends React.Component<IAssessmentProps, State> {
       <Dialog
         className="betcha-dialog"
         icon={IconNames.ERROR}
-        isCloseButtonShown={false}
+        isCloseButtonShown={true}
         isOpen={this.state.betchaAssessment !== null}
         title="Betcha: Early Submission"
       >

--- a/src/components/dropdown/About.tsx
+++ b/src/components/dropdown/About.tsx
@@ -13,7 +13,7 @@ const About: React.SFC<DialogProps> = props => (
   <Dialog
     className="about"
     icon={IconNames.HELP}
-    isCloseButtonShown={false}
+    isCloseButtonShown={true}
     isOpen={props.isOpen}
     onClose={props.onClose}
     title="About"

--- a/src/components/dropdown/Help.tsx
+++ b/src/components/dropdown/Help.tsx
@@ -13,7 +13,7 @@ const Help: React.SFC<DialogProps> = props => (
   <Dialog
     className="help"
     icon={IconNames.ERROR}
-    isCloseButtonShown={false}
+    isCloseButtonShown={true}
     isOpen={props.isOpen}
     onClose={props.onClose}
     title="Help"

--- a/src/components/missionControl/EditingWorkspace.tsx
+++ b/src/components/missionControl/EditingWorkspace.tsx
@@ -235,7 +235,7 @@ class AssessmentWorkspace extends React.Component<AssessmentWorkspaceProps, ISta
     <Dialog
       className="assessment-reset"
       icon={IconNames.ERROR}
-      isCloseButtonShown={false}
+      isCloseButtonShown={true}
       isOpen={this.state.showResetTemplateOverlay}
       title="Confirmation: Reset editor?"
     >

--- a/src/components/missionControl/editingWorkspaceSideContent/ManageQuestionTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/ManageQuestionTab.tsx
@@ -143,7 +143,7 @@ export class ManageQuestionTab extends React.Component<IProps, IState> {
     <Dialog
       className="assessment-reset"
       icon={IconNames.ERROR}
-      isCloseButtonShown={false}
+      isCloseButtonShown={true}
       isOpen={this.state.showSaveOverlay}
       title="Confirmation: Save unsaved changes?"
     >


### PR DESCRIPTION
# Summary 

This PR fixes #1118, where the close button does not appear for certain pop-up `Dialog`s. 

## Issue 
Under `Dialog`, one can toggle the close button to appear using the flag `isCloseButtonShown`. However, it seems that there is an inconsistency within the code base, where some close buttons are **shown** and some close buttons are **not**. 

Furthermore, from a UX point of view, it confuses the user as the user will not know how to escape out of the popup `Dialog`. As a result, they might be stuck. 

## Fix 
Set **all** `isCloseButtonShown` to `true` as of now. 
