### PR TITLE
Remove Print Margin for REPL

### DIFF
--- a/src/components/workspace/ReplInput.tsx
+++ b/src/components/workspace/ReplInput.tsx
@@ -85,6 +85,7 @@ class ReplInput extends React.PureComponent<IReplInputProps, {}> {
           fontSize={17}
           highlightActiveLine={false}
           showGutter={false}
+          showPrintMargin={false}
           setOptions={{
             fontFamily: "'Inconsolata', 'Consolas', monospace"
           }}


### PR DESCRIPTION
# Summary 

This PR fixes #1119, where the `printMargin` for the `REPL` is present. 

## Issue 
From a Student's POV, it does not make sense to have a 80 character limit indicated for the REPL. As a result, it should be removed. 

## Fix 
Under the `AceEditor` component of the `ReplInput`, just set `showPrintMargin={false}`
