### PR TITLE
Fix Saving of Source Version and External Library into Local Storage

### DIFF
--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -1,3 +1,5 @@
+import { Variant } from 'js-slang/dist/types';
+
 import { compressToUTF16 } from 'lz-string';
 import { createStore } from './createStore';
 import { ISavedState } from './localStorage';
@@ -12,7 +14,9 @@ const mockChangedStoredState: ISavedState = {
     name: 'Jeff'
   },
   playgroundEditorValue: 'Nihao everybody',
-  playgroundIsEditorAutorun: true
+  playgroundIsEditorAutorun: true, 
+  playgroundSourceChapter: 4,
+  playgroundSourceVariant: 'default' as Variant
 };
 
 const mockChangedState: IState = {

--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -15,9 +15,9 @@ const mockChangedStoredState: ISavedState = {
     name: 'Jeff'
   },
   playgroundEditorValue: 'Nihao everybody',
-  playgroundIsEditorAutorun: true, 
+  playgroundIsEditorAutorun: true,
   playgroundSourceChapter: 4,
-  playgroundSourceVariant: 'default' as Variant, 
+  playgroundSourceVariant: 'default' as Variant,
   playgroundExternalLibrary: 'NONE' as ExternalLibraryName
 };
 

--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -1,6 +1,7 @@
 import { Variant } from 'js-slang/dist/types';
 
 import { compressToUTF16 } from 'lz-string';
+import { ExternalLibraryName } from './components/assessment/assessmentShape';
 import { createStore } from './createStore';
 import { ISavedState } from './localStorage';
 import { defaultState, IState } from './reducers/states';
@@ -16,7 +17,8 @@ const mockChangedStoredState: ISavedState = {
   playgroundEditorValue: 'Nihao everybody',
   playgroundIsEditorAutorun: true, 
   playgroundSourceChapter: 4,
-  playgroundSourceVariant: 'default' as Variant
+  playgroundSourceVariant: 'default' as Variant, 
+  playgroundExternalLibrary: 'NONE' as ExternalLibraryName
 };
 
 const mockChangedState: IState = {

--- a/src/createStore.test.ts
+++ b/src/createStore.test.ts
@@ -5,6 +5,7 @@ import { ExternalLibraryName } from './components/assessment/assessmentShape';
 import { createStore } from './createStore';
 import { ISavedState } from './localStorage';
 import { defaultState, IState } from './reducers/states';
+import { DEFAULT_SOURCE_CHAPTER } from './utils/constants';
 import { history } from './utils/history';
 
 const mockChangedStoredState: ISavedState = {
@@ -16,7 +17,7 @@ const mockChangedStoredState: ISavedState = {
   },
   playgroundEditorValue: 'Nihao everybody',
   playgroundIsEditorAutorun: true,
-  playgroundSourceChapter: 4,
+  playgroundSourceChapter: DEFAULT_SOURCE_CHAPTER,
   playgroundSourceVariant: 'default' as Variant,
   playgroundExternalLibrary: 'NONE' as ExternalLibraryName
 };

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -52,6 +52,9 @@ export function createStore(history: History): Store<IState> {
           isEditorAutorun: loadedStore.playgroundIsEditorAutorun
             ? loadedStore.playgroundIsEditorAutorun
             : defaultState.workspaces.playground.isEditorAutorun,
+          externalLibrary: loadedStore.playgroundExternalLibrary
+            ? loadedStore.playgroundExternalLibrary
+            : defaultState.workspaces.playground.externalLibrary,
           context: {
             ...defaultState.workspaces.playground.context, 
             chapter: loadedStore.playgroundSourceChapter
@@ -60,7 +63,7 @@ export function createStore(history: History): Store<IState> {
             variant: loadedStore.playgroundSourceVariant
               ? loadedStore.playgroundSourceVariant
               : defaultState.workspaces.playground.context.variant
-          }
+          }, 
         }
       }
     };

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -56,14 +56,14 @@ export function createStore(history: History): Store<IState> {
             ? loadedStore.playgroundExternalLibrary
             : defaultState.workspaces.playground.externalLibrary,
           context: {
-            ...defaultState.workspaces.playground.context, 
+            ...defaultState.workspaces.playground.context,
             chapter: loadedStore.playgroundSourceChapter
               ? loadedStore.playgroundSourceChapter
               : defaultState.workspaces.playground.context.chapter,
             variant: loadedStore.playgroundSourceVariant
               ? loadedStore.playgroundSourceVariant
               : defaultState.workspaces.playground.context.variant
-          }, 
+          }
         }
       }
     };

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -51,7 +51,16 @@ export function createStore(history: History): Store<IState> {
             : defaultState.workspaces.playground.editorValue,
           isEditorAutorun: loadedStore.playgroundIsEditorAutorun
             ? loadedStore.playgroundIsEditorAutorun
-            : defaultState.workspaces.playground.isEditorAutorun
+            : defaultState.workspaces.playground.isEditorAutorun,
+          context: {
+            ...defaultState.workspaces.playground.context, 
+            chapter: loadedStore.playgroundSourceChapter
+              ? loadedStore.playgroundSourceChapter
+              : defaultState.workspaces.playground.context.chapter,
+            variant: loadedStore.playgroundSourceVariant
+              ? loadedStore.playgroundSourceVariant
+              : defaultState.workspaces.playground.context.variant
+          }
         }
       }
     };

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -12,7 +12,8 @@ const mockShortDefaultState: ISavedState = {
   playgroundEditorValue: defaultState.workspaces.playground.editorValue,
   playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun,
   playgroundSourceChapter: defaultState.workspaces.playground.context.chapter,
-  playgroundSourceVariant: defaultState.workspaces.playground.context.variant
+  playgroundSourceVariant: defaultState.workspaces.playground.context.variant, 
+  playgroundExternalLibrary: defaultState.workspaces.playground.externalLibrary
 };
 
 describe('loadStoredState() function', () => {

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -12,7 +12,7 @@ const mockShortDefaultState: ISavedState = {
   playgroundEditorValue: defaultState.workspaces.playground.editorValue,
   playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun,
   playgroundSourceChapter: defaultState.workspaces.playground.context.chapter,
-  playgroundSourceVariant: defaultState.workspaces.playground.context.variant, 
+  playgroundSourceVariant: defaultState.workspaces.playground.context.variant,
   playgroundExternalLibrary: defaultState.workspaces.playground.externalLibrary
 };
 

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -10,7 +10,9 @@ const mockShortDefaultState: ISavedState = {
     name: defaultState.session.name
   },
   playgroundEditorValue: defaultState.workspaces.playground.editorValue,
-  playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun
+  playgroundIsEditorAutorun: defaultState.workspaces.playground.isEditorAutorun,
+  playgroundSourceChapter: defaultState.workspaces.playground.context.chapter,
+  playgroundSourceVariant: defaultState.workspaces.playground.context.variant
 };
 
 describe('loadStoredState() function', () => {

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,3 +1,5 @@
+import { Variant } from 'js-slang/dist/types';
+
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 
 import { ISessionState, IState } from './reducers/states';
@@ -7,6 +9,8 @@ export type ISavedState = {
   session: Partial<ISessionState>;
   playgroundEditorValue: string | null;
   playgroundIsEditorAutorun: boolean;
+  playgroundSourceChapter: number;
+  playgroundSourceVariant: Variant;
 };
 
 export const loadStoredState = (): ISavedState | undefined => {
@@ -32,7 +36,9 @@ export const saveState = (state: IState) => {
         name: state.session.name
       },
       playgroundEditorValue: state.workspaces.playground.editorValue,
-      playgroundIsEditorAutorun: state.workspaces.playground.isEditorAutorun
+      playgroundIsEditorAutorun: state.workspaces.playground.isEditorAutorun,
+      playgroundSourceChapter: state.workspaces.playground.context.chapter,
+      playgroundSourceVariant: state.workspaces.playground.context.variant
     };
     const serialized = compressToUTF16(JSON.stringify(stateToBeSaved));
     localStorage.setItem('storedState', serialized);

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -40,7 +40,7 @@ export const saveState = (state: IState) => {
       playgroundEditorValue: state.workspaces.playground.editorValue,
       playgroundIsEditorAutorun: state.workspaces.playground.isEditorAutorun,
       playgroundSourceChapter: state.workspaces.playground.context.chapter,
-      playgroundSourceVariant: state.workspaces.playground.context.variant, 
+      playgroundSourceVariant: state.workspaces.playground.context.variant,
       playgroundExternalLibrary: state.workspaces.playground.externalLibrary
     };
     const serialized = compressToUTF16(JSON.stringify(stateToBeSaved));

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -2,6 +2,7 @@ import { Variant } from 'js-slang/dist/types';
 
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 
+import { ExternalLibraryName } from './components/assessment/assessmentShape';
 import { ISessionState, IState } from './reducers/states';
 import { showWarningMessage } from './utils/notification';
 
@@ -11,6 +12,7 @@ export type ISavedState = {
   playgroundIsEditorAutorun: boolean;
   playgroundSourceChapter: number;
   playgroundSourceVariant: Variant;
+  playgroundExternalLibrary: ExternalLibraryName;
 };
 
 export const loadStoredState = (): ISavedState | undefined => {
@@ -38,7 +40,8 @@ export const saveState = (state: IState) => {
       playgroundEditorValue: state.workspaces.playground.editorValue,
       playgroundIsEditorAutorun: state.workspaces.playground.isEditorAutorun,
       playgroundSourceChapter: state.workspaces.playground.context.chapter,
-      playgroundSourceVariant: state.workspaces.playground.context.variant
+      playgroundSourceVariant: state.workspaces.playground.context.variant, 
+      playgroundExternalLibrary: state.workspaces.playground.externalLibrary
     };
     const serialized = compressToUTF16(JSON.stringify(stateToBeSaved));
     localStorage.setItem('storedState', serialized);


### PR DESCRIPTION
# Summary 

This fixes #929, where the Source Version and External Library does not save. As a result, you need to re-set the Source chapter and library each time.

## Issue 

Under `localStorage`, it is clear that the following attributes are not saved or loaded. 

1. `sourceChapter` 
2. `sourceVariant` 
3. `externalLibraryName` 

As a result, we just need to add these attributes to be processed. 

## Fix 

Mentioned as Above. 