### PR TITLE
Reset errors after validateAndAnnotate instead

### DIFF
--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -705,8 +705,8 @@ export function* evalCode(
     const oldErrors = context.errors;
     context.errors = [];
     const parsed = parse(code, context);
-    context.errors = oldErrors;
     const typeErrors = parsed && typeCheck(validateAndAnnotate(parsed!, context))[1];
+    context.errors = oldErrors;
     if (typeErrors && typeErrors.length > 0) {
       yield put(
         actions.sendReplInputToOutput('Hints:\n' + parseError(typeErrors), workspaceLocation)


### PR DESCRIPTION
validateAndAnnotate can also produce errors,
causing duplicate errors.

Example:
![image](https://user-images.githubusercontent.com/3646725/82993772-b5143c80-a033-11ea-8702-62f00c533ac2.png)
