### PR TITLE
Rewrite makeAjax to use XMLHTTPRequest

### DIFF
--- a/src/components/academy/game/story-manager/story-manager.js
+++ b/src/components/academy/game/story-manager/story-manager.js
@@ -122,12 +122,11 @@ export function loadStoryXML(storyXMLs, willSave, callback) {
     } else {
       // download the story
       downloadRequestSent[curId] = true;
-      const makeAjax = isTest => $.ajax({
-        type: 'GET',
-        url: (isTest ? Constants.storyXMLPathTest : Constants.storyXMLPathLive)
-          + curId + '.story.xml',
-        dataType: 'xml',
-        success: function(xml) {
+      const makeAjax = isTest => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', `${isTest ? Constants.storyXMLPathTest : Constants.storyXMLPathLive}${curId}.story.xml`);
+        xhr.addEventListener('load', () => {
+          var xml = xhr.responseXML;
           var story = xml.children[0];
           downloaded[curId] = story;
           // check and load dependencies
@@ -156,17 +155,17 @@ export function loadStoryXML(storyXMLs, willSave, callback) {
               callback();
             }
           }
-        },
-        error: isTest
-          ? () => {
-              console.log('Trying on live...');
-              makeAjax(false);
-            }
+        });
+        xhr.addEventListener('error', isTest ? () => {
+          console.log('Trying on live...');
+          makeAjax(false);
+        }
           : () => {
-            loadingOverlay.visible = false;
-            console.error('Cannot find story ' + curId);
-          }
-      });
+          loadingOverlay.visible = false;
+          console.error('Cannot find story ' + curId);
+        });
+        xhr.send();
+      }
       makeAjax(!isStudent());
       download(i + 1, storyXMLs, callback);
     }


### PR DESCRIPTION
### Description

This PR rewrites some code using jQuery ajax to use JavaScript's native `XMLHttpRequest`. This is the start of an effort to remove jQuery from the codebase (c.f. #1136 ).

We cannot remove jQuery just yet, because some libraries (soundToneMatrix, visualizer, create-initializer) still require it.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How to Test

1. Visit `/academy/game`.
2. The story should still load asynchronously.

### Checklist

- [X] I have tested this code
