### PR TITLE
Fix modal Blueprint components not closing correctly

### DIFF
--- a/src/components/assessment/AssessmentWorkspace.tsx
+++ b/src/components/assessment/AssessmentWorkspace.tsx
@@ -175,6 +175,7 @@ class AssessmentWorkspace extends React.Component<
         />
       );
     }
+
     const overlay = (
       <Dialog className="assessment-briefing" isOpen={this.state.showOverlay}>
         <Card>
@@ -189,12 +190,14 @@ class AssessmentWorkspace extends React.Component<
       </Dialog>
     );
 
+    const closeOverlay = () => this.setState({ showResetTemplateOverlay: false });
     const resetTemplateOverlay = (
       <Dialog
         className="assessment-reset"
         icon={IconNames.ERROR}
         isCloseButtonShown={true}
         isOpen={this.state.showResetTemplateOverlay}
+        onClose={closeOverlay}
         title="Confirmation: Reset editor?"
       >
         <div className={Classes.DIALOG_BODY}>
@@ -203,19 +206,14 @@ class AssessmentWorkspace extends React.Component<
         </div>
         <div className={Classes.DIALOG_FOOTER}>
           <ButtonGroup>
-            {controlButton(
-              'Cancel',
-              null,
-              () => this.setState({ showResetTemplateOverlay: false }),
-              {
-                minimal: false
-              }
-            )}
+            {controlButton('Cancel', null, closeOverlay, {
+              minimal: false
+            })}
             {controlButton(
               'Confirm',
               null,
               () => {
-                this.setState({ showResetTemplateOverlay: false });
+                closeOverlay();
                 this.props.handleEditorValueChange(
                   (this.props.assessment!.questions[questionId] as IProgrammingQuestion)
                     .solutionTemplate
@@ -228,6 +226,7 @@ class AssessmentWorkspace extends React.Component<
         </div>
       </Dialog>
     );
+
     /* If questionId is out of bounds, set it to the max. */
     const questionId =
       this.props.questionId >= this.props.assessment.questions.length

--- a/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -90,7 +90,7 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
 "<div className=\\"WorkspaceParent bp3-dark\\">
   <Blueprint3.Dialog className=\\"assessment-briefing\\" isOpen={true} canOutsideClickClose={true}>
     <Blueprint3.Card elevation={0} interactive={false}>
-      <Markdown content=\\"This is the closed mission briefing. The save button should not be there. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. \\" />
+      <Markdown content=\\"This is a closed mission. The save button should not be rendered.\\" />
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>

--- a/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -10,14 +10,14 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function: closeOverlay]} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
     </div>
     <div className=\\"bp3-dialog-footer\\">
       <Blueprint3.ButtonGroup>
-        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function: closeOverlay]}>
           Cancel
         </Blueprint3.Button>
         <Blueprint3.Button disabled={false} fill={false} intent=\\"danger\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
@@ -38,14 +38,14 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function: closeOverlay]} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
     </div>
     <div className=\\"bp3-dialog-footer\\">
       <Blueprint3.ButtonGroup>
-        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function: closeOverlay]}>
           Cancel
         </Blueprint3.Button>
         <Blueprint3.Button disabled={false} fill={false} intent=\\"danger\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
@@ -66,14 +66,14 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function: closeOverlay]} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
     </div>
     <div className=\\"bp3-dialog-footer\\">
       <Blueprint3.ButtonGroup>
-        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function: closeOverlay]}>
           Cancel
         </Blueprint3.Button>
         <Blueprint3.Button disabled={false} fill={false} intent=\\"danger\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
@@ -94,14 +94,14 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
       <Blueprint3.Button className=\\"assessment-briefing-button\\" onClick={[Function: onClick]} text=\\"Continue\\" />
     </Blueprint3.Card>
   </Blueprint3.Dialog>
-  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
+  <Blueprint3.Dialog className=\\"assessment-reset\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function: closeOverlay]} title=\\"Confirmation: Reset editor?\\" canOutsideClickClose={true}>
     <div className=\\"bp3-dialog-body\\">
       <Markdown content=\\"Are you sure you want to reset the template?\\" />
       <Markdown content=\\"*Note this will not affect the saved copy of your program, unless you save over it.*\\" />
     </div>
     <div className=\\"bp3-dialog-footer\\">
       <Blueprint3.ButtonGroup>
-        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>
+        <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function: closeOverlay]}>
           Cancel
         </Blueprint3.Button>
         <Blueprint3.Button disabled={false} fill={false} intent=\\"danger\\" minimal={false} className=\\"\\" type={[undefined]} onClick={[Function]}>

--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -96,7 +96,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            An Odessey to Runes (Duplicate)
+                                            An Odyssey to Runes Redux
                                           </h4>
                                         </Component>
                                       </div>
@@ -130,7 +130,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Max Grade: 3000
+                                        Max Grade: 12
                                       </h6>
                                     </Component>
                                   </div>
@@ -142,7 +142,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
+                                    <Markdown content=\\"This is a test for the UI of the unopened assessment overview. This links to mock Mission 1 in an unattempted state.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -201,7 +201,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
                                     <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
                                   </Connect(NotificationBadge)>
-                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
                                   <div className=\\"listing-header\\">
@@ -209,7 +209,151 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            Basic logic gates
+                                            A Sample Practical
+                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+                                                <Manager>
+                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
+                                                    <Reference innerRef={[Function: target]}>
+                                                      <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
+                                                        <Blueprint3.ResizeSensor onResize={[Function]}>
+                                                          <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
+                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
+                                                                <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                                  <desc>
+                                                                    lock
+                                                                  </desc>
+                                                                  <path d=\\"M13.96 7H12V3.95C12 1.77 10.21 0 8 0S4 1.77 4 3.95V7H1.96c-.55 0-.96.35-.96.9v6.91c0 .54.41 1.19.96 1.19h12c.55 0 1.04-.65 1.04-1.19V7.9c0-.55-.49-.9-1.04-.9zM6 7V3.95c0-1.09.9-1.97 2-1.97s2 .88 2 1.97V7H6z\\" fillRule=\\"evenodd\\" />
+                                                                </svg>
+                                                              </span>
+                                                            </Blueprint3.Icon>
+                                                          </span>
+                                                        </Blueprint3.ResizeSensor>
+                                                      </InnerReference>
+                                                    </Reference>
+                                                    <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                                                  </span>
+                                                </Manager>
+                                              </Blueprint3.Popover>
+                                            </Blueprint3.Tooltip>
+                                          </h4>
+                                        </Component>
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
+                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
+                                          <Blueprint3.Icon icon=\\"confirm\\">
+                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <desc>
+                                                  confirm
+                                                </desc>
+                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <span className=\\"bp3-button-text\\">
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
+                                          </span>
+                                          <Blueprint3.Icon icon={[undefined]} />
+                                        </button>
+                                      </Blueprint3.Button>
+                                    </div>
+                                  </div>
+                                  <div className=\\"listing-grade\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        Grade: 0 / 48
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-xp\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        XP: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-description\\">
+                                    <Markdown content=\\"This is a placeholder summary for a practical assessment. This links to mock Practical 4 in an unattempted state.\\">
+                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
+                                    </Markdown>
+                                  </div>
+                                  <div className=\\"listing-footer\\">
+                                    <Blueprint3.Text className=\\"listing-due-date\\">
+                                      <div className=\\"listing-due-date\\" title={[undefined]}>
+                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
+                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
+                                              <desc>
+                                                time
+                                              </desc>
+                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                            </svg>
+                                          </span>
+                                        </Blueprint3.Icon>
+                                        Due: 18th June, 13:24
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/practicals/8/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/8\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/practicals/8/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/8/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
+                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                        <desc>
+                                                          play
+                                                        </desc>
+                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
+                                                      </svg>
+                                                    </span>
+                                                  </Blueprint3.Icon>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </Blueprint3.Card>
+                          </div>
+                          <div>
+                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
+                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
+                                <div className=\\"col-xs-3 listing-picture\\">
+                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
+                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
+                                  </Connect(NotificationBadge)>
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=World&font=lobster\\" />
+                                </div>
+                                <div className=\\"col-xs-9 listing-text\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
+                                            Symphony of the Winds
                                           </h4>
                                         </Component>
                                       </div>
@@ -250,12 +394,129 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 0 / 200
+                                        XP: 0 / 666
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality.\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview. This links to mock Mission 7 in an unattempted state, **thus the mission briefing is displayed**.\\">
+                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
+                                    </Markdown>
+                                  </div>
+                                  <div className=\\"listing-footer\\">
+                                    <Blueprint3.Text className=\\"listing-due-date\\">
+                                      <div className=\\"listing-due-date\\" title={[undefined]}>
+                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
+                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
+                                              <desc>
+                                                time
+                                              </desc>
+                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                            </svg>
+                                          </span>
+                                        </Blueprint3.Icon>
+                                        Due: 21st April, 07:59
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/7/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/7\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/7/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/7/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
+                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                        <desc>
+                                                          play
+                                                        </desc>
+                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
+                                                      </svg>
+                                                    </span>
+                                                  </Blueprint3.Icon>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </Blueprint3.Card>
+                          </div>
+                          <div>
+                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
+                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
+                                <div className=\\"col-xs-3 listing-picture\\">
+                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
+                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
+                                  </Connect(NotificationBadge)>
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
+                                </div>
+                                <div className=\\"col-xs-9 listing-text\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
+                                            Basic Logic
+                                          </h4>
+                                        </Component>
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
+                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
+                                          <Blueprint3.Icon icon=\\"confirm\\">
+                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <desc>
+                                                  confirm
+                                                </desc>
+                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <span className=\\"bp3-button-text\\">
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
+                                          </span>
+                                          <Blueprint3.Icon icon={[undefined]} />
+                                        </button>
+                                      </Blueprint3.Button>
+                                    </div>
+                                  </div>
+                                  <div className=\\"listing-grade\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        Grade: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-xp\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        XP: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-description\\">
+                                    <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality. This links to mock Path 6 in an unattempted state, **thus the path briefing is displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -326,34 +587,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            A sample Practical
-                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
-                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
-                                                <Manager>
-                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
-                                                    <Reference innerRef={[Function: target]}>
-                                                      <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
-                                                        <Blueprint3.ResizeSensor onResize={[Function]}>
-                                                          <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
-                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
-                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
-                                                                <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                                  <desc>
-                                                                    lock
-                                                                  </desc>
-                                                                  <path d=\\"M13.96 7H12V3.95C12 1.77 10.21 0 8 0S4 1.77 4 3.95V7H1.96c-.55 0-.96.35-.96.9v6.91c0 .54.41 1.19.96 1.19h12c.55 0 1.04-.65 1.04-1.19V7.9c0-.55-.49-.9-1.04-.9zM6 7V3.95c0-1.09.9-1.97 2-1.97s2 .88 2 1.97V7H6z\\" fillRule=\\"evenodd\\" />
-                                                                </svg>
-                                                              </span>
-                                                            </Blueprint3.Icon>
-                                                          </span>
-                                                        </Blueprint3.ResizeSensor>
-                                                      </InnerReference>
-                                                    </Reference>
-                                                    <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
-                                                  </span>
-                                                </Manager>
-                                              </Blueprint3.Popover>
-                                            </Blueprint3.Tooltip>
+                                            A Sample Sidequest
                                           </h4>
                                         </Component>
                                       </div>
@@ -387,136 +621,19 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Grade: 0 / 7
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        XP: 0 / 725
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
-                                    </Markdown>
-                                  </div>
-                                  <div className=\\"listing-footer\\">
-                                    <Blueprint3.Text className=\\"listing-due-date\\">
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
-                                              <desc>
-                                                time
-                                              </desc>
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint3.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint3.Text>
-                                    <div className=\\"listing-button\\">
-                                      <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                          <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
-                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
-                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                  <Blueprint3.Icon icon=\\"play\\">
-                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
-                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                        <desc>
-                                                          play
-                                                        </desc>
-                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
-                                                      </svg>
-                                                    </span>
-                                                  </Blueprint3.Icon>
-                                                  <span className=\\"bp3-button-text\\">
-                                                    <span className=\\"custom-hidden-xxxs\\">
-                                                      Attempt
-                                                    </span>
-                                                    <span className=\\"custom-hidden-xxs\\" />
-                                                  </span>
-                                                  <Blueprint3.Icon icon={[undefined]} />
-                                                </button>
-                                              </Blueprint3.Button>
-                                            </a>
-                                          </Link>
-                                        </Route>
-                                      </NavLink>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </Blueprint3.Card>
-                          </div>
-                          <div>
-                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
-                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
-                                <div className=\\"col-xs-3 listing-picture\\">
-                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
-                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
-                                  </Connect(NotificationBadge)>
-                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
-                                </div>
-                                <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"listing-header\\">
-                                    <Blueprint3.Text ellipsize={true}>
-                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
-                                        <Component className=\\"listing-title\\">
-                                          <h4 className=\\"bp3-heading listing-title\\">
-                                            A sample Sidequest
-                                          </h4>
-                                        </Component>
-                                      </div>
-                                    </Blueprint3.Text>
-                                    <div className=\\"listing-button\\">
-                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
-                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
-                                          <Blueprint3.Icon icon=\\"confirm\\">
-                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
-                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                <desc>
-                                                  confirm
-                                                </desc>
-                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
-                                              </svg>
-                                            </span>
-                                          </Blueprint3.Icon>
-                                          <span className=\\"bp3-button-text\\">
-                                            <span className=\\"custom-hidden-xxxs\\">
-                                              Finalize
-                                            </span>
-                                            <span className=\\"custom-hidden-xxs\\">
-                                               Submission
-                                            </span>
-                                          </span>
-                                          <Blueprint3.Icon icon={[undefined]} />
-                                        </button>
-                                      </Blueprint3.Button>
-                                    </div>
-                                  </div>
-                                  <div className=\\"listing-grade\\">
-                                    <Component>
-                                      <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
-                                      </h6>
-                                    </Component>
-                                  </div>
-                                  <div className=\\"listing-xp\\">
-                                    <Component>
-                                      <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
-                                      </h6>
-                                    </Component>
-                                  </div>
-                                  <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
+                                    <Markdown content=\\"This is a placeholder quest summary. This links to mock Sidequest 3 in an unattempted state, **thus the sidequest briefing is displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -621,19 +738,19 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 3 / 3000
+                                        Grade: 0 / 11
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 2 / 1000
+                                        XP: 0 / 1050
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview. This links to mock Sidequest 3 in an attempted state, **thus the sidequest briefing is not displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -654,10 +771,10 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                       </div>
                                     </Blueprint3.Text>
                                     <div className=\\"listing-button\\">
-                                      <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                          <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
+                                      <NavLink to=\\"/academy/quests/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/quests/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/2/0\\">
                                               <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
                                                 <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                                   <Blueprint3.Icon icon=\\"play\\">
@@ -706,7 +823,7 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            An Odessey to Runes
+                                            An Odyssey to Runes
                                           </h4>
                                         </Component>
                                       </div>
@@ -740,19 +857,19 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 2 / 3000
+                                        Grade: 0 / 9
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 1 / 1000
+                                        XP: 0 / 400
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview, with a long assessment summary using Markdown for formatting. This links to mock Mission 1 in a completed state.\\\\n\\\\n**NOTE**:\\\\n- Please refer to the following [link](https://www.google.com) for help.\\\\n- The **actual submission deadline** of this mission is __tomorrow__, unless you have *previously requested* for an extension.\\\\n- To submit, please make sure you have saved your work for every task/question, and then click \`Finalize Submission\` on this page.\\\\n\\\\n##### The following hint may be useful:\\\\n\`\`\`javascript\\\\nconst identity = x => x;\\\\n\`\`\`\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -949,7 +1066,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            An Odessey to Runes (Duplicate)
+                                            An Odyssey to Runes Redux
                                           </h4>
                                         </Component>
                                       </div>
@@ -983,7 +1100,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Max Grade: 3000
+                                        Max Grade: 12
                                       </h6>
                                     </Component>
                                   </div>
@@ -995,7 +1112,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0\\">
+                                    <Markdown content=\\"This is a test for the UI of the unopened assessment overview. This links to mock Mission 1 in an unattempted state.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -1084,7 +1201,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
                                     <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
                                   </Connect(NotificationBadge)>
-                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
                                 </div>
                                 <div className=\\"col-xs-9 listing-text\\">
                                   <div className=\\"listing-header\\">
@@ -1092,7 +1209,151 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            Basic logic gates
+                                            A Sample Practical
+                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+                                                <Manager>
+                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
+                                                    <Reference innerRef={[Function: target]}>
+                                                      <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
+                                                        <Blueprint3.ResizeSensor onResize={[Function]}>
+                                                          <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
+                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
+                                                                <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                                  <desc>
+                                                                    lock
+                                                                  </desc>
+                                                                  <path d=\\"M13.96 7H12V3.95C12 1.77 10.21 0 8 0S4 1.77 4 3.95V7H1.96c-.55 0-.96.35-.96.9v6.91c0 .54.41 1.19.96 1.19h12c.55 0 1.04-.65 1.04-1.19V7.9c0-.55-.49-.9-1.04-.9zM6 7V3.95c0-1.09.9-1.97 2-1.97s2 .88 2 1.97V7H6z\\" fillRule=\\"evenodd\\" />
+                                                                </svg>
+                                                              </span>
+                                                            </Blueprint3.Icon>
+                                                          </span>
+                                                        </Blueprint3.ResizeSensor>
+                                                      </InnerReference>
+                                                    </Reference>
+                                                    <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                                                  </span>
+                                                </Manager>
+                                              </Blueprint3.Popover>
+                                            </Blueprint3.Tooltip>
+                                          </h4>
+                                        </Component>
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
+                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
+                                          <Blueprint3.Icon icon=\\"confirm\\">
+                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <desc>
+                                                  confirm
+                                                </desc>
+                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <span className=\\"bp3-button-text\\">
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
+                                          </span>
+                                          <Blueprint3.Icon icon={[undefined]} />
+                                        </button>
+                                      </Blueprint3.Button>
+                                    </div>
+                                  </div>
+                                  <div className=\\"listing-grade\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        Grade: 0 / 48
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-xp\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        XP: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-description\\">
+                                    <Markdown content=\\"This is a placeholder summary for a practical assessment. This links to mock Practical 4 in an unattempted state.\\">
+                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
+                                    </Markdown>
+                                  </div>
+                                  <div className=\\"listing-footer\\">
+                                    <Blueprint3.Text className=\\"listing-due-date\\">
+                                      <div className=\\"listing-due-date\\" title={[undefined]}>
+                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
+                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
+                                              <desc>
+                                                time
+                                              </desc>
+                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                            </svg>
+                                          </span>
+                                        </Blueprint3.Icon>
+                                        Due: 18th June, 13:24
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/practicals/8/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/8\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/practicals/8/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/8/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
+                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                        <desc>
+                                                          play
+                                                        </desc>
+                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
+                                                      </svg>
+                                                    </span>
+                                                  </Blueprint3.Icon>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </Blueprint3.Card>
+                          </div>
+                          <div>
+                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
+                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
+                                <div className=\\"col-xs-3 listing-picture\\">
+                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
+                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
+                                  </Connect(NotificationBadge)>
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=World&font=lobster\\" />
+                                </div>
+                                <div className=\\"col-xs-9 listing-text\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
+                                            Symphony of the Winds
                                           </h4>
                                         </Component>
                                       </div>
@@ -1133,12 +1394,129 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 0 / 200
+                                        XP: 0 / 666
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality.\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview. This links to mock Mission 7 in an unattempted state, **thus the mission briefing is displayed**.\\">
+                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
+                                    </Markdown>
+                                  </div>
+                                  <div className=\\"listing-footer\\">
+                                    <Blueprint3.Text className=\\"listing-due-date\\">
+                                      <div className=\\"listing-due-date\\" title={[undefined]}>
+                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
+                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
+                                              <desc>
+                                                time
+                                              </desc>
+                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                            </svg>
+                                          </span>
+                                        </Blueprint3.Icon>
+                                        Due: 21st April, 07:59
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <NavLink to=\\"/academy/missions/7/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/7\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/missions/7/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/7/0\\">
+                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
+                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
+                                                  <Blueprint3.Icon icon=\\"play\\">
+                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
+                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                        <desc>
+                                                          play
+                                                        </desc>
+                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
+                                                      </svg>
+                                                    </span>
+                                                  </Blueprint3.Icon>
+                                                  <span className=\\"bp3-button-text\\">
+                                                    <span className=\\"custom-hidden-xxxs\\">
+                                                      Attempt
+                                                    </span>
+                                                    <span className=\\"custom-hidden-xxs\\" />
+                                                  </span>
+                                                  <Blueprint3.Icon icon={[undefined]} />
+                                                </button>
+                                              </Blueprint3.Button>
+                                            </a>
+                                          </Link>
+                                        </Route>
+                                      </NavLink>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </Blueprint3.Card>
+                          </div>
+                          <div>
+                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
+                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
+                                <div className=\\"col-xs-3 listing-picture\\">
+                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
+                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
+                                  </Connect(NotificationBadge)>
+                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto\\" />
+                                </div>
+                                <div className=\\"col-xs-9 listing-text\\">
+                                  <div className=\\"listing-header\\">
+                                    <Blueprint3.Text ellipsize={true}>
+                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
+                                        <Component className=\\"listing-title\\">
+                                          <h4 className=\\"bp3-heading listing-title\\">
+                                            Basic Logic
+                                          </h4>
+                                        </Component>
+                                      </div>
+                                    </Blueprint3.Text>
+                                    <div className=\\"listing-button\\">
+                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
+                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
+                                          <Blueprint3.Icon icon=\\"confirm\\">
+                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                                <desc>
+                                                  confirm
+                                                </desc>
+                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <span className=\\"bp3-button-text\\">
+                                            <span className=\\"custom-hidden-xxxs\\">
+                                              Finalize
+                                            </span>
+                                            <span className=\\"custom-hidden-xxs\\">
+                                               Submission
+                                            </span>
+                                          </span>
+                                          <Blueprint3.Icon icon={[undefined]} />
+                                        </button>
+                                      </Blueprint3.Button>
+                                    </div>
+                                  </div>
+                                  <div className=\\"listing-grade\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        Grade: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-xp\\">
+                                    <Component>
+                                      <h6 className=\\"bp3-heading\\">
+                                        XP: 0 / 0
+                                      </h6>
+                                    </Component>
+                                  </div>
+                                  <div className=\\"listing-description\\">
+                                    <Markdown content=\\"This mock path serves as a demonstration of the support provided for mock programming path functionality. This links to mock Path 6 in an unattempted state, **thus the path briefing is displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -1209,34 +1587,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            A sample Practical
-                                            <Blueprint3.Tooltip className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
-                                              <Blueprint3.Popover interactionKind=\\"hover-target\\" className=\\"listing-title-tooltip\\" content=\\"This assessment is password-protected.\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} position=\\"auto\\" targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
-                                                <Manager>
-                                                  <span className=\\"bp3-popover-wrapper listing-title-tooltip\\">
-                                                    <Reference innerRef={[Function: target]}>
-                                                      <InnerReference setReferenceNode={[Function]} innerRef={[Function: target]}>
-                                                        <Blueprint3.ResizeSensor onResize={[Function]}>
-                                                          <span onBlur={[Function]} onFocus={[Function]} onMouseEnter={[Function]} onMouseLeave={[Function]} className=\\"bp3-popover-target\\">
-                                                            <Blueprint3.Icon icon=\\"lock\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
-                                                              <span icon=\\"lock\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-lock\\" title={[undefined]}>
-                                                                <svg fill={[undefined]} data-icon=\\"lock\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                                  <desc>
-                                                                    lock
-                                                                  </desc>
-                                                                  <path d=\\"M13.96 7H12V3.95C12 1.77 10.21 0 8 0S4 1.77 4 3.95V7H1.96c-.55 0-.96.35-.96.9v6.91c0 .54.41 1.19.96 1.19h12c.55 0 1.04-.65 1.04-1.19V7.9c0-.55-.49-.9-1.04-.9zM6 7V3.95c0-1.09.9-1.97 2-1.97s2 .88 2 1.97V7H6z\\" fillRule=\\"evenodd\\" />
-                                                                </svg>
-                                                              </span>
-                                                            </Blueprint3.Icon>
-                                                          </span>
-                                                        </Blueprint3.ResizeSensor>
-                                                      </InnerReference>
-                                                    </Reference>
-                                                    <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
-                                                  </span>
-                                                </Manager>
-                                              </Blueprint3.Popover>
-                                            </Blueprint3.Tooltip>
+                                            A Sample Sidequest
                                           </h4>
                                         </Component>
                                       </div>
@@ -1270,136 +1621,19 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Grade: 0 / 7
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        XP: 0 / 725
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
-                                      <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
-                                    </Markdown>
-                                  </div>
-                                  <div className=\\"listing-footer\\">
-                                    <Blueprint3.Text className=\\"listing-due-date\\">
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint3.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" className=\\"bp3-icon bp3-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\">
-                                              <desc>
-                                                time
-                                              </desc>
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint3.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint3.Text>
-                                    <div className=\\"listing-button\\">
-                                      <NavLink to=\\"/academy/practicals/5/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/practicals\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                          <Link to=\\"/academy/practicals/5/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/practicals/5/0\\">
-                                              <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
-                                                <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
-                                                  <Blueprint3.Icon icon=\\"play\\">
-                                                    <span icon=\\"play\\" className=\\"bp3-icon bp3-icon-play\\" title={[undefined]}>
-                                                      <svg fill={[undefined]} data-icon=\\"play\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                        <desc>
-                                                          play
-                                                        </desc>
-                                                        <path d=\\"M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 005 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z\\" fillRule=\\"evenodd\\" />
-                                                      </svg>
-                                                    </span>
-                                                  </Blueprint3.Icon>
-                                                  <span className=\\"bp3-button-text\\">
-                                                    <span className=\\"custom-hidden-xxxs\\">
-                                                      Attempt
-                                                    </span>
-                                                    <span className=\\"custom-hidden-xxs\\" />
-                                                  </span>
-                                                  <Blueprint3.Icon icon={[undefined]} />
-                                                </button>
-                                              </Blueprint3.Button>
-                                            </a>
-                                          </Link>
-                                        </Route>
-                                      </NavLink>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </Blueprint3.Card>
-                          </div>
-                          <div>
-                            <Blueprint3.Card className=\\"row listing\\" elevation={1} interactive={false}>
-                              <div className=\\"bp3-card bp3-elevation-1 row listing\\">
-                                <div className=\\"col-xs-3 listing-picture\\">
-                                  <Connect(NotificationBadge) className=\\"badge\\" notificationFilter={[Function]} large={true}>
-                                    <NotificationBadge className=\\"badge\\" notificationFilter={[Function]} large={true} notifications={{...}} handleAcknowledgeNotifications={[Function]} />
-                                  </Connect(NotificationBadge)>
-                                  <img className=\\"cover-image-not_attempted\\" src=\\"https://fakeimg.pl/350x200/?text=Hello\\" />
-                                </div>
-                                <div className=\\"col-xs-9 listing-text\\">
-                                  <div className=\\"listing-header\\">
-                                    <Blueprint3.Text ellipsize={true}>
-                                      <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
-                                        <Component className=\\"listing-title\\">
-                                          <h4 className=\\"bp3-heading listing-title\\">
-                                            A sample Sidequest
-                                          </h4>
-                                        </Component>
-                                      </div>
-                                    </Blueprint3.Text>
-                                    <div className=\\"listing-button\\">
-                                      <Blueprint3.Button disabled={true} icon=\\"confirm\\" intent=\\"none\\" minimal={true} onClick={[Function: onClick]}>
-                                        <button type=\\"button\\" disabled={true} onClick={[undefined]} className=\\"bp3-button bp3-disabled bp3-minimal\\" onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={-1}>
-                                          <Blueprint3.Icon icon=\\"confirm\\">
-                                            <span icon=\\"confirm\\" className=\\"bp3-icon bp3-icon-confirm\\" title={[undefined]}>
-                                              <svg fill={[undefined]} data-icon=\\"confirm\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                                                <desc>
-                                                  confirm
-                                                </desc>
-                                                <path d=\\"M8.7 4.29a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l2 2c.18.18.43.29.71.29s.53-.11.71-.29l5-5a1.003 1.003 0 00-1.42-1.42l-4.29 4.3L8.7 4.29zm5.22 3.01c.03.23.07.45.07.69 0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6c.81 0 1.59.17 2.3.46l1.5-1.5A7.998 7.998 0 00-.01 7.99c0 4.42 3.58 8 8 8s8-3.58 8-8c0-.83-.13-1.64-.36-2.39l-1.71 1.7z\\" fillRule=\\"evenodd\\" />
-                                              </svg>
-                                            </span>
-                                          </Blueprint3.Icon>
-                                          <span className=\\"bp3-button-text\\">
-                                            <span className=\\"custom-hidden-xxxs\\">
-                                              Finalize
-                                            </span>
-                                            <span className=\\"custom-hidden-xxs\\">
-                                               Submission
-                                            </span>
-                                          </span>
-                                          <Blueprint3.Icon icon={[undefined]} />
-                                        </button>
-                                      </Blueprint3.Button>
-                                    </div>
-                                  </div>
-                                  <div className=\\"listing-grade\\">
-                                    <Component>
-                                      <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
-                                      </h6>
-                                    </Component>
-                                  </div>
-                                  <div className=\\"listing-xp\\">
-                                    <Component>
-                                      <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
-                                      </h6>
-                                    </Component>
-                                  </div>
-                                  <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
+                                    <Markdown content=\\"This is a placeholder quest summary. This links to mock Sidequest 3 in an unattempted state, **thus the sidequest briefing is displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -1504,19 +1738,19 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 3 / 3000
+                                        Grade: 0 / 11
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 2 / 1000
+                                        XP: 0 / 1050
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview. This links to mock Sidequest 3 in an attempted state, **thus the sidequest briefing is not displayed**.\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>
@@ -1537,10 +1771,10 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                       </div>
                                     </Blueprint3.Text>
                                     <div className=\\"listing-button\\">
-                                      <NavLink to=\\"/academy/missions/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
-                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                          <Link to=\\"/academy/missions/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
-                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/missions/2/0\\">
+                                      <NavLink to=\\"/academy/quests/2/0\\" activeClassName=\\"active\\" aria-current=\\"page\\">
+                                        <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/2\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                          <Link to=\\"/academy/quests/2/0\\" className={[undefined]} style={[undefined]} aria-current={{...}} replace={false}>
+                                            <a className={[undefined]} style={[undefined]} aria-current={{...}} onClick={[Function]} href=\\"/academy/quests/2/0\\">
                                               <Blueprint3.Button icon=\\"play\\" minimal={true} onClick={[Function: onClick]}>
                                                 <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-minimal\\" disabled={[undefined]} onKeyDown={[Function]} onKeyUp={[Function]} tabIndex={[undefined]}>
                                                   <Blueprint3.Icon icon=\\"play\\">
@@ -1589,7 +1823,7 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                       <div className=\\"bp3-text-overflow-ellipsis\\" title={[undefined]}>
                                         <Component className=\\"listing-title\\">
                                           <h4 className=\\"bp3-heading listing-title\\">
-                                            An Odessey to Runes
+                                            An Odyssey to Runes
                                           </h4>
                                         </Component>
                                       </div>
@@ -1623,19 +1857,19 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 2 / 3000
+                                        Grade: 0 / 9
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 1 / 1000
+                                        XP: 0 / 400
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-description\\">
-                                    <Markdown content=\\"\\\\n*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\\\\nincididunt ut labore et dolore magna aliqua.\\\\n\\\\n\`\`\`\\\\nconst a = 5;\\\\n\`\`\`\\\\n\\\\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium\\\\n_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore\\\\n[veritatis et quasi architecto](google.com) beatae vitae dicta sunt\\\\n\`explicabo\`.\\\\n\\\\n\\">
+                                    <Markdown content=\\"This shows the UI of an opened assessment overview, with a long assessment summary using Markdown for formatting. This links to mock Mission 1 in a completed state.\\\\n\\\\n**NOTE**:\\\\n- Please refer to the following [link](https://www.google.com) for help.\\\\n- The **actual submission deadline** of this mission is __tomorrow__, unless you have *previously requested* for an extension.\\\\n- To submit, please make sure you have saved your work for every task/question, and then click \`Finalize Submission\` on this page.\\\\n\\\\n##### The following hint may be useful:\\\\n\`\`\`javascript\\\\nconst identity = x => x;\\\\n\`\`\`\\">
                                       <div className=\\"md bp3-running-text\\" dangerouslySetInnerHTML={{...}} />
                                     </Markdown>
                                   </div>

--- a/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/assessment/__tests__/__snapshots__/index.tsx.snap
@@ -37,8 +37,8 @@ exports[`Assessment page "loading" content renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -960,8 +960,8 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -1007,8 +1007,8 @@ exports[`Assessment page with 0 missions renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>
@@ -1960,8 +1960,8 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
               </div>
             </div>
           </ContentDisplay>
-          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
-            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
+          <Blueprint3.Dialog className=\\"betcha-dialog\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true}>
+            <Blueprint3.Overlay className=\\"bp3-overlay-scroll-container\\" icon=\\"error\\" isCloseButtonShown={true} isOpen={false} onClose={[Function]} title=\\"Betcha: Early Submission\\" canOutsideClickClose={true} hasBackdrop={true} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true} />
           </Blueprint3.Dialog>
         </div>
       </Assessment>

--- a/src/components/assessment/index.tsx
+++ b/src/components/assessment/index.tsx
@@ -213,6 +213,7 @@ class Assessment extends React.Component<IAssessmentProps, State> {
         icon={IconNames.ERROR}
         isCloseButtonShown={true}
         isOpen={this.state.betchaAssessment !== null}
+        onClose={this.setBetchaAssessmentNull}
         title="Betcha: Early Submission"
       >
         <div className={Classes.DIALOG_BODY}>

--- a/src/components/dropdown/Profile.tsx
+++ b/src/components/dropdown/Profile.tsx
@@ -175,8 +175,6 @@ class Profile extends React.Component<ProfileProps, {}> {
     return (
       <Drawer
         className="profile"
-        canEscapeKeyClose={true}
-        canOutsideClickClose={true}
         icon={IconNames.USER}
         isCloseButtonShown={true}
         isOpen={this.props.isOpen}

--- a/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
+++ b/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
@@ -65,12 +65,12 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                           </div>
                           <div className=\\"profile-progress\\">
                             <div className=\\"profile-grade\\">
-                              <Blueprint3.Spinner className=\\"profile-spinner progress-steelblue\\" size={144} value={1}>
+                              <Blueprint3.Spinner className=\\"profile-spinner progress-steelblue\\" size={144} value={0.8181818181818182}>
                                 <div className=\\"bp3-spinner bp3-no-spin profile-spinner progress-steelblue\\">
                                   <div className=\\"bp3-spinner-animation\\">
                                     <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
                                       <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
-                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={0} />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={50.90909090909091} />
                                     </svg>
                                   </div>
                                 </div>
@@ -79,22 +79,22 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 Grade
                               </div>
                               <div className=\\"total-value\\">
-                                0.00
+                                0.82
                                  / 
-                                0.00
+                                1.00
                               </div>
                               <div className=\\"percentage\\">
-                                100.00
+                                81.82
                                 %
                               </div>
                             </div>
                             <div className=\\"profile-xp\\">
-                              <Blueprint3.Spinner className=\\"profile-spinner progress-deepskyblue\\" size={144} value={0.62}>
-                                <div className=\\"bp3-spinner bp3-no-spin profile-spinner progress-deepskyblue\\">
+                              <Blueprint3.Spinner className=\\"profile-spinner progress-skyblue\\" size={144} value={0.4383966244725738}>
+                                <div className=\\"bp3-spinner bp3-no-spin profile-spinner progress-skyblue\\">
                                   <div className=\\"bp3-spinner-animation\\">
                                     <svg width={144} height={144} strokeWidth=\\"2.78\\" viewBox=\\"3.61 3.61 92.78 92.78\\">
                                       <path className=\\"bp3-spinner-track\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" />
-                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={106.4} />
+                                      <path className=\\"bp3-spinner-head\\" d=\\"M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90\\" pathLength={280} strokeDasharray=\\"280 280\\" strokeDashoffset={157.2489451476793} />
                                     </svg>
                                   </div>
                                 </div>
@@ -103,12 +103,12 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 XP
                               </div>
                               <div className=\\"total-value\\">
-                                1550
+                                1039
                                  / 
-                                2500
+                                2370
                               </div>
                               <div className=\\"percentage\\">
-                                62.00
+                                43.84
                                 %
                               </div>
                             </div>
@@ -119,7 +119,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/missions\\\\\\\\/4\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/missions/4/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
                                     <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/missions/4/0\\">
-                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"flame\\" title=\\"A closed Mission\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"flame\\" title=\\"A Closed Mission\\">
                                         <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
                                           <Blueprint3.Icon icon=\\"flame\\" iconSize={20}>
                                             <span icon=\\"flame\\" className=\\"bp3-icon bp3-icon-flame\\" title={[undefined]}>
@@ -133,7 +133,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                           </Blueprint3.Icon>
                                           <Component>
                                             <h4 className=\\"bp3-heading\\">
-                                              A closed Mission
+                                              A Closed Mission
                                             </h4>
                                           </Component>
                                           <div className=\\"grade-details\\">
@@ -141,11 +141,11 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               Grade
                                             </div>
                                             <div className=\\"value\\">
-                                              2700
+                                              9
                                                / 
-                                              3000
+                                              11
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={0.9}>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={0.8181818181818182}>
                                               <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-steelblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
@@ -156,11 +156,11 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               XP
                                             </div>
                                             <div className=\\"value\\">
-                                              800
+                                              468
                                                / 
-                                              1000
+                                              420
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={0.8}>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-steelblue\\" stripes={false} value={1}>
                                               <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-steelblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
@@ -200,55 +200,11 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                               XP
                                             </div>
                                             <div className=\\"value\\">
-                                              500
+                                              0
                                                / 
-                                              1000
+                                              850
                                             </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-deepskyblue\\" stripes={false} value={0.5}>
-                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-deepskyblue\\">
-                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
-                                              </div>
-                                            </Blueprint3.ProgressBar>
-                                          </div>
-                                        </div>
-                                      </Blueprint3.Callout>
-                                    </a>
-                                  </Link>
-                                </Route>
-                              </NavLink>
-                            </ProfileCard>
-                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
-                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/quests/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
-                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
-                                  <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
-                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/quests/5/0\\">
-                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Closed (fully graded) Sidequest\\">
-                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
-                                          <Blueprint3.Icon icon=\\"lightbulb\\" iconSize={20}>
-                                            <span icon=\\"lightbulb\\" className=\\"bp3-icon bp3-icon-lightbulb\\" title={[undefined]}>
-                                              <svg fill={[undefined]} data-icon=\\"lightbulb\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
-                                                <desc>
-                                                  lightbulb
-                                                </desc>
-                                                <path d=\\"M6.33 13.39c0 .34.27.61.6.61h6.13c.33 0 .6-.27.6-.61C14.03 9.78 16 9.4 16 6.09 16 2.72 13.31 0 10 0S4 2.72 4 6.09c0 3.31 1.97 3.69 2.33 7.3zM13 15H7c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1zm-1 3H8c-.55 0-1 .45-1 1s.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1z\\" fillRule=\\"evenodd\\" />
-                                              </svg>
-                                            </span>
-                                          </Blueprint3.Icon>
-                                          <Component>
-                                            <h4 className=\\"bp3-heading\\">
-                                              Closed (fully graded) Sidequest
-                                            </h4>
-                                          </Component>
-                                          <div className=\\"xp-details\\">
-                                            <div className=\\"title\\">
-                                              XP
-                                            </div>
-                                            <div className=\\"value\\">
-                                              150
-                                               / 
-                                              500
-                                            </div>
-                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-skyblue\\" stripes={false} value={0.3}>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-skyblue\\" stripes={false} value={0}>
                                               <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-skyblue\\">
                                                 <div className=\\"bp3-progress-meter\\" style={{...}} />
                                               </div>
@@ -266,7 +222,7 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                 <Route path=\\"\\\\\\\\/academy\\\\\\\\/quests\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/academy/quests/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
                                     <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/quests/5/0\\">
-                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Ungraded assessment\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"lightbulb\\" title=\\"Closed (partially graded) Sidequest\\">
                                         <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
                                           <Blueprint3.Icon icon=\\"lightbulb\\" iconSize={20}>
                                             <span icon=\\"lightbulb\\" className=\\"bp3-icon bp3-icon-lightbulb\\" title={[undefined]}>
@@ -280,7 +236,51 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
                                           </Blueprint3.Icon>
                                           <Component>
                                             <h4 className=\\"bp3-heading\\">
-                                              Ungraded assessment
+                                              Closed (partially graded) Sidequest
+                                            </h4>
+                                          </Component>
+                                          <div className=\\"xp-details\\">
+                                            <div className=\\"title\\">
+                                              XP
+                                            </div>
+                                            <div className=\\"value\\">
+                                              471
+                                               / 
+                                              1100
+                                            </div>
+                                            <Blueprint3.ProgressBar animate={false} className=\\"value-bar progress-skyblue\\" stripes={false} value={0.42818181818181816}>
+                                              <div className=\\"bp3-progress-bar bp3-no-animation bp3-no-stripes value-bar progress-skyblue\\">
+                                                <div className=\\"bp3-progress-meter\\" style={{...}} />
+                                              </div>
+                                            </Blueprint3.ProgressBar>
+                                          </div>
+                                        </div>
+                                      </Blueprint3.Callout>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </ProfileCard>
+                            <ProfileCard item={{...}} getFrac={[Function: getFrac]} parseColour={[Function: parseColour]} renderIcon={[Function: renderIcon]}>
+                              <NavLink className=\\"profile-summary-navlink\\" target=\\"_blank\\" to=\\"/academy/paths/5/0\\" activeClassName=\\"profile-summary-navlink\\" aria-current=\\"page\\">
+                                <Route path=\\"\\\\\\\\/academy\\\\\\\\/paths\\\\\\\\/5\\\\\\\\/0\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
+                                  <Link to=\\"/academy/paths/5/0\\" className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" replace={false}>
+                                    <a className=\\"profile-summary-navlink\\" style={[undefined]} aria-current={{...}} target=\\"_blank\\" onClick={[Function]} href=\\"/academy/paths/5/0\\">
+                                      <Blueprint3.Callout className=\\"profile-summary-callout\\" icon=\\"predictive-analysis\\" title=\\"Ungraded Assessment\\">
+                                        <div className=\\"bp3-callout bp3-callout-icon profile-summary-callout\\">
+                                          <Blueprint3.Icon icon=\\"predictive-analysis\\" iconSize={20}>
+                                            <span icon=\\"predictive-analysis\\" className=\\"bp3-icon bp3-icon-predictive-analysis\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"predictive-analysis\\" width={20} height={20} viewBox=\\"0 0 20 20\\">
+                                                <desc>
+                                                  predictive-analysis
+                                                </desc>
+                                                <path d=\\"M20 8.01c0-1.26-.61-2.43-1.61-3.12C17.86 2.5 15.8.79 13.4.79c-.58 0-1.14.1-1.69.29A3.533 3.533 0 009.17 0C8.05 0 7 .55 6.32 1.45c-.15-.02-.3-.03-.45-.03-1.63 0-3.03 1.12-3.46 2.71C.97 4.65 0 6.05 0 7.66c0 .48.09.95.26 1.4-.17.44-.26.91-.26 1.39 0 1.38.72 2.64 1.89 3.29.67.7 1.59 1.09 2.54 1.09.61 0 1.19-.15 1.71-.45.68.82 1.68 1.3 2.73 1.3.66 0 1.28-.18 1.83-.52.61.49 1.34.81 2.11.91 1.3 1.43 2.3 3.28 2.31 3.3 0 0 .35.61.33.61.96-.01 1.77-.2 1.64-1.3.01.02-.92-2.89-.92-2.89.52-.26.94-.69 1.21-1.23 1.12-.66 1.84-1.91 1.84-3.26 0-.3-.03-.6-.1-.89.57-.64.88-1.51.88-2.4zm-1.54 1.28l-.18-.2-.77-.84c-.33-.37-.67-1.17-.73-1.73 0 0-.13-1.25-.13-1.26-.06-.74-1.17-.73-1.13.14 0 .02.13 1.26.13 1.26.04.36.15.77.3 1.17-.08-.01-.15-.02-.22-.02 0 0-2.57-.12-2.57-.13-.73-.03-.89 1.22-.05 1.25l2.57.13c.53.03 1.29.37 1.61.72l.61.67.02.06c.1.27.14.55.14.83 0 .93-.51 1.77-1.34 2.18l-.2.1-.09.23c-.19.48-.6.82-1.1.93l-.67.14.87 2.75c-.48-.76-1.19-1.79-2.02-2.67l-.15-.16-.21-.02c-.51-.04-.99-.21-1.42-.48l1.7-1.48c.44-.39 1.04-.55 1.24-.49 0 0 .78.22.78.23.78.2 1.03-.92.29-1.21l-.78-.23c-.69-.2-1.67.22-2.24.72l-1.91 1.66-.39.32c-.44.36-.93.55-1.5.55-.8 0-1.54-.41-1.97-1.07v-1.88c0-.5.21-.98.34-1.07 0 0 .65-.43.64-.43.87-.69.21-1.57-.64-1.14 0-.01-.65.43-.65.43-.31.2-.54.56-.7.97-.13-.13-.28-.25-.43-.35 0 0-1.91-1.26-1.91-1.28-.81-.56-1.5.63-.61 1.11 0-.02 1.89 1.28 1.89 1.28.46.31.77.97.77 1.36v.84c-.43.24-.78.36-1.24.36-.67 0-1.31-.29-1.77-.79l-.07-.08-.09-.05a2.425 2.425 0 01-1.31-2.16c0-.38.09-.74.25-1.08l.15-.31-.14-.33c-.17-.34-.25-.7-.25-1.08 0-1.13.76-2.1 1.85-2.37l.39-.09.07-.43a2.41 2.41 0 012.39-2.05c.19 0 .39.02.58.07l.4.1.22-.38A2.41 2.41 0 019.17 1.3c.55 0 1.08.19 1.5.53l-.44.45-.01-.01-.31.31c-.41.35-.92.53-1.11.5 0 0-.84-.13-.84-.14-.83-.15-1.09 1.08-.18 1.29.01 0 .84.14.84.14.03 0 .06 0 .09.01-.14.46-.18.96-.12 1.4 0 0 .21 1.24.19 1.23.13.65 1.32.44 1.16-.22 0-.01-.19-1.23-.19-1.23-.07-.48.15-1.19.45-1.5l.48-.5c.07-.06.13-.12.19-.18l.93-.95c.5-.23 1.04-.34 1.59-.34 1.93 0 3.57 1.4 3.89 3.34l.05.31.26.15a2.445 2.445 0 01.87 3.4z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint3.Icon>
+                                          <Component>
+                                            <h4 className=\\"bp3-heading\\">
+                                              Ungraded Assessment
                                             </h4>
                                           </Component>
                                           <div className=\\"xp-details\\">

--- a/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
+++ b/src/components/dropdown/__tests__/__snapshots__/Profile.tsx.snap
@@ -4,8 +4,8 @@ exports[`Profile renders correctly when there are closed assessments 1`] = `
 "<MemoryRouter initialEntries={{...}}>
   <Router history={{...}}>
     <Profile name=\\"yeeet\\" role=\\"staff\\" assessmentOverviews={{...}} isOpen={true} handleAssessmentOverviewFetch={[Function: handleAssessmentOverviewFetch]} onClose={[Function: onClose]}>
-      <Blueprint3.Drawer className=\\"profile\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false}>
-        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
+      <Blueprint3.Drawer className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" canOutsideClickClose={true} style={{...}} vertical={false}>
+        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" canOutsideClickClose={true} style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
           <Blueprint3.Portal className={[undefined]} container={{...}}>
             <Portal containerInfo={{...}}>
               <TransitionGroup appear={true} className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" component=\\"div\\" onKeyDown={[Function]} childFactory={[Function: childFactory]}>
@@ -325,8 +325,8 @@ exports[`Profile renders correctly when there are no closed assessments 1`] = `
 "<MemoryRouter initialEntries={{...}}>
   <Router history={{...}}>
     <Profile name=\\"yeet\\" role=\\"student\\" assessmentOverviews={{...}} isOpen={true} handleAssessmentOverviewFetch={[Function: handleAssessmentOverviewFetch]} onClose={[Function: onClose]}>
-      <Blueprint3.Drawer className=\\"profile\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false}>
-        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" canEscapeKeyClose={true} canOutsideClickClose={true} icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
+      <Blueprint3.Drawer className=\\"profile\\" icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" canOutsideClickClose={true} style={{...}} vertical={false}>
+        <Blueprint3.Overlay className=\\"bp3-overlay-container\\" icon=\\"user\\" isCloseButtonShown={true} isOpen={true} onClose={[Function: onClose]} title=\\"User Profile\\" position=\\"left\\" size=\\"30%\\" canOutsideClickClose={true} style={{...}} vertical={false} autoFocus={true} backdropProps={{...}} canEscapeKeyClose={true} enforceFocus={true} hasBackdrop={true} lazy={true} transitionDuration={300} transitionName=\\"bp3-overlay\\" usePortal={true}>
           <Blueprint3.Portal className={[undefined]} container={{...}}>
             <Portal containerInfo={{...}}>
               <TransitionGroup appear={true} className=\\"bp3-overlay bp3-overlay-open bp3-overlay-container\\" component=\\"div\\" onKeyDown={[Function]} childFactory={[Function: childFactory]}>

--- a/src/mocks/assessmentAPI.ts
+++ b/src/mocks/assessmentAPI.ts
@@ -17,14 +17,14 @@ const mockUnopenedAssessmentsOverviews: IAssessmentOverview[] = [
     category: AssessmentCategories.Mission,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/300/',
-    grade: 1,
+    grade: 0,
     id: 1,
-    maxGrade: 3000,
+    maxGrade: 12,
     maxXp: 1000,
     openAt: '2038-06-18T05:24:26.026Z',
-    title: 'An Odessey to Runes (Duplicate)',
+    title: 'An Odyssey to Runes Redux',
     shortSummary:
-      'This is a test for the UI of the unopened assessment overview. It links to the mock Mission 0',
+      'This is a test for the UI of the unopened assessment overview. This links to mock Mission 1 in an unattempted state.',
     status: AssessmentStatuses.not_attempted,
     story: 'mission-1',
     xp: 0,
@@ -37,63 +37,60 @@ const mockOpenedAssessmentsOverviews: IAssessmentOverview[] = [
     category: AssessmentCategories.Mission,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/300/',
-    grade: 2,
+    grade: 0,
     id: 1,
-    maxGrade: 3000,
-    maxXp: 1000,
+    maxGrade: 9,
+    maxXp: 400,
     openAt: '2018-06-18T05:24:26.026Z',
-    title: 'An Odessey to Runes',
-    shortSummary: `
-*Lorem ipsum* dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-incididunt ut labore et dolore magna aliqua.
+    title: 'An Odyssey to Runes',
+    shortSummary: `This shows the UI of an opened assessment overview, with a long assessment summary using Markdown for formatting. This links to mock Mission 1 in a completed state.
 
-\`\`\`
-const a = 5;
-\`\`\`
+**NOTE**:
+- Please refer to the following [link](https://www.google.com) for help.
+- The **actual submission deadline** of this mission is __tomorrow__, unless you have *previously requested* for an extension.
+- To submit, please make sure you have saved your work for every task/question, and then click \`Finalize Submission\` on this page.
 
-Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium
-_doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore
-[veritatis et quasi architecto](google.com) beatae vitae dicta sunt
-\`explicabo\`.
-
-`,
+##### The following hint may be useful:
+\`\`\`javascript
+const identity = x => x;
+\`\`\``,
     status: AssessmentStatuses.attempted,
     story: 'mission-1',
-    xp: 1,
+    xp: 0,
     gradingStatus: GradingStatuses.none
   },
   {
-    category: AssessmentCategories.Mission,
+    category: AssessmentCategories.Sidequest,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=World&font=lobster',
-    grade: 3,
+    grade: 0,
     id: 2,
-    maxGrade: 3000,
-    maxXp: 1000,
+    maxGrade: 11,
+    maxXp: 1050,
     openAt: '2018-07-18T05:24:26.026Z',
     title: 'The Secret to Streams',
     shortSummary:
-      'Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.',
+      'This shows the UI of an opened assessment overview. This links to mock Sidequest 3 in an attempted state, **thus the sidequest briefing is not displayed**.',
     status: AssessmentStatuses.attempting,
     story: 'mission-2',
-    xp: 2,
+    xp: 0,
     gradingStatus: GradingStatuses.none
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=Hello',
-    grade: 4,
+    grade: 0,
     id: 3,
-    maxGrade: 3000,
-    maxXp: 1000,
+    maxGrade: 7,
+    maxXp: 725,
     openAt: '2018-07-18T05:24:26.026Z',
-    title: 'A sample Sidequest',
+    title: 'A Sample Sidequest',
     shortSummary:
-      'Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.',
+      'This is a placeholder quest summary. This links to mock Sidequest 3 in an unattempted state, **thus the sidequest briefing is displayed**.',
     status: AssessmentStatuses.not_attempted,
     story: 'sidequest-2.1',
-    xp: 3,
+    xp: 0,
     gradingStatus: GradingStatuses.none
   },
   {
@@ -103,11 +100,11 @@ _doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore
     grade: 0,
     id: 6,
     maxGrade: 0,
-    maxXp: 200,
+    maxXp: 0,
     openAt: '2018-01-01T00:00:00.000Z',
-    title: 'Basic logic gates',
+    title: 'Basic Logic',
     shortSummary:
-      'This mock path serves as a demonstration of the support provided for mock programming path functionality.',
+      'This mock path serves as a demonstration of the support provided for mock programming path functionality. This links to mock Path 6 in an unattempted state, **thus the path briefing is displayed**.',
     status: AssessmentStatuses.not_attempted,
     story: null,
     xp: 0,
@@ -117,19 +114,36 @@ _doloremque laudantium_, totam rem aperiam, eaque ipsa quae ab illo inventore
     category: AssessmentCategories.Practical,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=Hello',
-    grade: 4,
-    id: 5,
-    maxGrade: 3000,
-    maxXp: 1000,
+    grade: 0,
+    id: 8,
+    maxGrade: 48,
+    maxXp: 0,
     openAt: '2018-07-18T05:24:26.026Z',
-    title: 'A sample Practical',
+    title: 'A Sample Practical',
     shortSummary:
-      'Once upon a time, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec vulputate sapien. Fusce vel lacus fermentum, efficitur ipsum.',
+      'This is a placeholder summary for a practical assessment. This links to mock Practical 4 in an unattempted state.',
     status: AssessmentStatuses.not_attempted,
     story: 'sidequest-2.1',
-    xp: 3,
+    xp: 0,
     gradingStatus: GradingStatuses.none,
     private: true
+  },
+  {
+    category: AssessmentCategories.Mission,
+    closeAt: '2069-04-20T23:59:59.999Z',
+    coverImage: 'https://fakeimg.pl/350x200/?text=World&font=lobster',
+    grade: 0,
+    id: 7,
+    maxGrade: 0,
+    maxXp: 666,
+    openAt: '2020-03-21T00:00:00.000Z',
+    title: 'Symphony of the Winds',
+    shortSummary:
+      'This shows the UI of an opened assessment overview. This links to mock Mission 7 in an unattempted state, **thus the mission briefing is displayed**.',
+    status: AssessmentStatuses.not_attempted,
+    story: null,
+    xp: 0,
+    gradingStatus: GradingStatuses.none
   }
 ];
 
@@ -138,55 +152,55 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
     category: AssessmentCategories.Mission,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
-    grade: 2700,
+    grade: 9,
     id: 4,
-    maxGrade: 3000,
-    maxXp: 1000,
+    maxGrade: 11,
+    maxXp: 420,
     openAt: '2007-07-18T05:24:26.026Z',
-    title: 'A closed Mission',
+    title: 'A Closed Mission',
     shortSummary:
-      'This is a test for the grading status tooltip when the assessment is partially graded (undergoing manual grading). It should render as an orange clock.',
+      'This is a test for the grading status tooltip when the assessment is fully graded. It should render as a green tick. This links to the mock Mission 2 in a completed state.',
     status: AssessmentStatuses.submitted,
-    story: 'mission-3',
-    xp: 800,
-    gradingStatus: GradingStatuses.grading
+    story: null,
+    xp: 468,
+    gradingStatus: GradingStatuses.graded
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 1950,
+    grade: 0,
     id: 5,
-    maxGrade: 3000,
-    maxXp: 1000,
+    maxGrade: 13,
+    maxXp: 850,
     openAt: '2007-07-18T05:24:26.026Z',
     title: 'Closed (not graded) Sidequest',
     shortSummary:
-      'This is a test for the grading status tooltip when the assessment is not graded. It should render as a red cross.',
+      'This is a test for the grading status tooltip when the assessment is not graded. It should render as a red cross. This links to the mock Sidequest 5 in a completed state.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 500,
+    xp: 0,
     gradingStatus: GradingStatuses.none
   },
   {
     category: AssessmentCategories.Sidequest,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
-    grade: 300,
+    grade: 6,
     id: 5,
-    maxGrade: 700,
-    maxXp: 500,
+    maxGrade: 14,
+    maxXp: 1100,
     openAt: '2007-07-18T05:24:26.026Z',
-    title: 'Closed (fully graded) Sidequest',
+    title: 'Closed (partially graded) Sidequest',
     shortSummary:
-      'This is a test for the grading status tooltip when the assessment is fully graded. It should render as a green tick. This sidequest links to the mock Sidequest 4.',
+      'This is a test for the grading status tooltip when the assessment is partially graded (undergoing manual grading). It should render as an orange clock. This links to the mock Sidequest 5 in a completed state.',
     status: AssessmentStatuses.submitted,
     story: null,
-    xp: 150,
-    gradingStatus: GradingStatuses.graded
+    xp: 471,
+    gradingStatus: GradingStatuses.grading
   },
   {
-    category: AssessmentCategories.Sidequest,
+    category: AssessmentCategories.Path,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
     grade: 0,
@@ -194,9 +208,9 @@ const mockClosedAssessmentOverviews: IAssessmentOverview[] = [
     maxGrade: 0,
     maxXp: 0,
     openAt: '2007-07-18T05:24:26.026Z',
-    title: 'Ungraded assessment',
+    title: 'Ungraded Assessment',
     shortSummary:
-      'This is a test for the grading status tooltip when the assessment does not require manual grading (e.g. paths and contests). It should render as a blue disable sign. This sidequest links to the mock Sidequest 4.',
+      'This is a test for the grading status tooltip when the assessment does not require manual grading (e.g. paths and contests). It should render as a blue disable sign. This links to the mock Sidequest 5 in a completed state.',
     status: AssessmentStatuses.submitted,
     story: null,
     xp: 100,
@@ -844,7 +858,7 @@ const __NOR_AND = (x, y) => {
  */
 export const mockAssessments: IAssessment[] = [
   {
-    category: 'Mission',
+    category: AssessmentCategories.Mission,
     id: 1,
     longSummary:
       'This is the mission briefing. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. ',
@@ -853,7 +867,7 @@ export const mockAssessments: IAssessment[] = [
     title: 'An Odessey to Runes'
   },
   {
-    category: 'Mission',
+    category: AssessmentCategories.Mission,
     id: 2,
     longSummary:
       'This is the mission briefing. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. ',
@@ -885,13 +899,12 @@ sapien
 \`\`\``,
     missionPDF: 'www.google.com',
     questions: mockAssessmentQuestions,
-    title: 'A sample Sidequest'
+    title: 'A Sample Sidequest'
   },
   {
     category: AssessmentCategories.Mission,
     id: 4,
-    longSummary:
-      'This is the closed mission briefing. The save button should not be there. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. ',
+    longSummary: 'This is a closed mission. The save button should not be rendered.',
     missionPDF: 'www.google.com',
     questions: mockClosedAssessmentQuestions,
     title: 'A Closed Mission'
@@ -900,7 +913,7 @@ sapien
     category: AssessmentCategories.Sidequest,
     id: 5,
     longSummary:
-      'This is the closed sidequest briefing. The save button should not exist. This is a placeholder sidequest for testing rendering of grading statuses.',
+      'This is the closed sidequest briefing. The save button should not be there. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra, sem scelerisque ultricies ullamcorper, sem nibh sollicitudin enim, at ultricies sem orci eget odio. Pellentesque varius et mauris quis vestibulum. Etiam in egestas dolor. Nunc consectetur, sapien sodales accumsan convallis, lectus mi tempus ipsum, vel ornare metus turpis sed justo. Vivamus at tellus sed ex convallis commodo at in lectus. Pellentesque pharetra pulvinar sapien pellentesque facilisis. Curabitur efficitur malesuada urna sed aliquam. Quisque massa metus, aliquam in sagittis non, cursus in sem. Morbi vel nunc at nunc pharetra lobortis. Aliquam feugiat ultricies ipsum vel sollicitudin. Vivamus nulla massa, hendrerit sit amet nibh quis, porttitor convallis nisi. ',
     missionPDF: 'www.google.com',
     questions: mockClosedAssessmentQuestions,
     title: 'A Closed Sidequest'
@@ -908,13 +921,39 @@ sapien
   {
     category: AssessmentCategories.Path,
     id: 6,
-    longSummary: `### Basic logic gates
+    longSummary: `### Basic Logic Gates
 
 This path is intended to demonstrate concepts from the lecture **Logic Circuits**. You are strongly encouraged to attempt this path to check your understanding, prior to the next Studio session. For this, you will be granted a small amount of XP!
 
 The path comprises 4 questions and is fully autograded and guided, and there are **no private test cases** - there will be no manual review by default. Please consult your Avenger if you require assistance!</TEXT>`,
     missionPDF: 'www.google.com',
     questions: mockPathQuestions,
-    title: 'A sample guided path'
+    title: 'A Sample Guided Path'
+  },
+  {
+    category: AssessmentCategories.Mission,
+    id: 7,
+    longSummary: `###This is a long sidequest briefing for testing purposes!
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Metus aliquam eleifend mi in. Enim nulla aliquet porttitor lacus luctus accumsan tortor. Vitae purus faucibus ornare suspendisse sed nisi lacus sed viverra. Neque volutpat ac tincidunt vitae semper quis lectus nulla. In hac habitasse platea dictumst vestibulum rhoncus. Nisl vel pretium lectus quam id leo in. Diam donec adipiscing tristique risus. Accumsan tortor posuere ac ut consequat. Felis bibendum ut tristique et egestas quis ipsum. Mi eget mauris pharetra et ultrices. Ornare aenean euismod elementum nisi. Sem viverra aliquet eget sit amet tellus. Massa enim nec dui nunc mattis enim ut tellus elementum. Venenatis cras sed felis eget velit aliquet sagittis id. Placerat duis ultricies lacus sed turpis tincidunt id. Eu lobortis elementum nibh tellus molestie nunc.
+
+Enim eu turpis egestas pretium. Pharetra convallis posuere morbi leo urna molestie at elementum eu. Sed enim ut sem viverra aliquet eget sit amet. Ligula ullamcorper malesuada proin libero nunc consequat interdum. Dignissim suspendisse in est ante in nibh mauris. Urna id volutpat lacus laoreet non curabitur gravida arcu ac. Nibh mauris cursus mattis molestie a iaculis at. Elit at imperdiet dui accumsan sit. Nibh venenatis cras sed felis. Ut tristique et egestas quis ipsum suspendisse ultrices gravida. Natoque penatibus et magnis dis parturient montes nascetur ridiculus. Eget aliquet nibh praesent tristique magna sit amet purus gravida. Pretium nibh ipsum consequat nisl vel pretium. Mattis vulputate enim nulla aliquet porttitor lacus. Quis varius quam quisque id diam. Ut sem viverra aliquet eget sit amet tellus. Purus non enim praesent elementum facilisis leo vel fringilla est. Tellus id interdum velit laoreet. Sed felis eget velit aliquet sagittis id consectetur.
+
+Facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum. Mi tempus imperdiet nulla malesuada. Sagittis aliquam malesuada bibendum arcu. Lobortis feugiat vivamus at augue eget arcu. Urna neque viverra justo nec ultrices dui sapien eget mi. Quisque non tellus orci ac auctor augue mauris augue neque. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque. Etiam dignissim diam quis enim lobortis scelerisque fermentum dui. Nunc sed blandit libero volutpat sed cras ornare arcu. Aenean euismod elementum nisi quis. Duis at consectetur lorem donec massa sapien faucibus. Justo donec enim diam vulputate. Velit ut tortor pretium viverra suspendisse. Tellus rutrum tellus pellentesque eu. Phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada. Ut placerat orci nulla pellentesque dignissim. Vitae tempus quam pellentesque nec nam aliquam sem et. Praesent semper feugiat nibh sed pulvinar. Netus et malesuada fames ac turpis egestas maecenas. Nisi lacus sed viverra tellus. Pharetra vel turpis nunc eget lorem dolor sed viverra ipsum. Dui sapien eget mi proin sed libero. Habitant morbi tristique senectus et netus et malesuada. In hendrerit gravida rutrum quisque. Nisi quis eleifend quam adipiscing vitae proin sagittis nisl rhoncus.`,
+    missionPDF: 'www.google.com',
+    questions: mockAssessmentQuestions,
+    title: 'Symphony of the Winds'
+  },
+  {
+    category: AssessmentCategories.Practical,
+    id: 8,
+    longSummary: `### Instructions (please read carefully)
+- You are allowed X minutes for this Practical Assessment.
+- This is an open-book assessment. Any written or printed material, or material and programs stored on the Source Academy may be used as reference material.`,
+    missionPDF: 'www.google.com',
+    questions: mockAssessmentQuestions,
+    title: 'A Sample Practical'
   }
 ];

--- a/src/mocks/userAPI.ts
+++ b/src/mocks/userAPI.ts
@@ -1,4 +1,5 @@
-import { Notification } from '../components/notification/notificationShape';
+import { AssessmentCategories } from '../components/assessment/assessmentShape';
+import { Notification, NotificationTypes } from '../components/notification/notificationShape';
 
 /**
  * Deprecated, check backend for roles
@@ -62,51 +63,58 @@ export const mockFetchStudentInfo = (accessToken: string): StudentInfo[] | null 
 export const mockNotifications: Notification[] = [
   {
     id: 1,
-    type: 'new',
-    assessment_id: 2,
-    assessment_type: 'Mission',
+    type: NotificationTypes.deadline,
+    assessment_id: 3,
+    assessment_type: AssessmentCategories.Sidequest,
     assessment_title: 'The Secret to Streams'
   },
   {
     id: 2,
-    type: 'new',
-    assessment_id: 3,
-    assessment_type: 'Sidequest',
-    assessment_title: 'A sample Sidequest'
+    type: NotificationTypes.autograded,
+    assessment_id: 4,
+    assessment_type: AssessmentCategories.Mission,
+    assessment_title: 'A Closed Mission'
   },
   {
     id: 3,
-    type: 'autograded',
+    type: NotificationTypes.graded,
     assessment_id: 4,
-    assessment_type: 'Mission',
+    assessment_type: AssessmentCategories.Mission,
     assessment_title: 'A Closed Mission'
   },
   {
     id: 4,
-    type: 'graded',
-    assessment_id: 4,
-    assessment_type: 'Mission',
-    assessment_title: 'A Closed Mission'
+    type: NotificationTypes.new,
+    assessment_id: 6,
+    assessment_type: AssessmentCategories.Path,
+    assessment_title: 'Basic Logic'
   },
   {
     id: 5,
-    type: 'submitted',
-    submission_id: 1,
-    assessment_type: 'Mission',
-    assessment_title: 'Mission 0'
+    type: NotificationTypes.new,
+    assessment_id: 7,
+    assessment_type: AssessmentCategories.Mission,
+    assessment_title: 'Symphony of the Winds'
   },
   {
     id: 6,
-    type: 'submitted',
-    submission_id: 2,
-    assessment_type: 'Mission',
-    assessment_title: 'Mission 1'
+    type: NotificationTypes.submitted,
+    submission_id: 1,
+    assessment_type: AssessmentCategories.Mission,
+    assessment_title: 'Mission 0'
   },
   {
     id: 7,
-    type: 'submitted',
+    type: NotificationTypes.submitted,
+    submission_id: 2,
+    assessment_type: AssessmentCategories.Mission,
+    assessment_title: 'Mission 1'
+  },
+  {
+    id: 8,
+    type: NotificationTypes.submitted,
     submission_id: 3,
-    assessment_type: 'Mission',
+    assessment_type: AssessmentCategories.Mission,
     assessment_title: 'Mission 0'
   }
 ];

--- a/src/styles/_commons.scss
+++ b/src/styles/_commons.scss
@@ -34,29 +34,22 @@
 }
 
 /*
-  Force Blueprint Dialog to scroll on focus
+  Breaks IE11 compatability to address inaccessible scrollbar issue
+  of the BlueprintJS Dialog component at:
+  https://github.com/palantir/blueprint/issues/1008
 
-  Note: there should exist a better fix, as the Blueprint Dialog behaves
-  properly on the official demo/documentation website
-  https://blueprintjs.com/docs/#core/components/dialog
+  Follows a working recommendation proposed by a PR in that thread at:
+  https://github.com/palantir/blueprint/pull/3403
 */
-.#{$ns}-dialog-container {
-  pointer-events: all;
-}
+.#{$ns}-overlay {
+  .#{$ns}-overlay-backdrop {
+    position: sticky;
+    height: 100%;
+    width: 100%;
+  }
 
-/*
-  Temporary fix for this issue: https://github.com/palantir/blueprint/issues/1008
-
-  (when Blueprint Dialog is open, browser scroll bar is not clickable)
-*/
-.#{$ns}-overlay-backdrop {
-  display: none;
-}
-
-.#{$ns}-overlay-open {
-  background-color: rgba(16, 22, 26, 0.7);
-
-  &.#{$ns}-toast-container {
-    background-color: unset;
+  .#{$ns}-dialog-container {
+    position: absolute;
+    top: 0;
   }
 }


### PR DESCRIPTION
## UI/UX: Fix modal Blueprint components not closing correctly
Summary: Fixes issue #1147 introduced by PR #874, by introducing a better fix for the original issue addressed in PR #863 that led to PR #874. **This PR breaks compatibility with Internet Explorer 11**.

### Description
Modal Blueprint components such as `Dialog` or `Alert` are used extensively across the Academy to render content atop the base application, such as for user prompts (e.g. confirmation prompts) and notices (e.g. assessment briefings, warning messages). These components rely upon the low-level Blueprint `Overlay` component to be mounted and rendered atop the base page's DOM tree.

Specifically, the assessment briefing displayed to a student when they first view an assessment uses the `Dialog` component. Typically, the length of the assessment briefing is sufficient for the `Dialog` component to exceed the height of the browser window, which causes a vertical scrollbar to be rendered (see below example).

![image](https://user-images.githubusercontent.com/44989315/83165328-f0039680-a13f-11ea-8160-1e1252441006.png)

This vertical scrollbar renders at the level of the parent `Overlay` component `<div>`, which lies beneath both the overlay backdrop `<div>` and the full-width `Dialog` component `<div>`. As a result, this vertical scrollbar is blocked by the `Dialog` component `<div>` and can not be used to scroll the dialog. This is in fact a bug in Blueprint itself, tracked by issue https://github.com/palantir/blueprint/issues/1008. Whilst a reliable fix for the bug exists, it would break IE11 compatibility and thus will not be implemented by Blueprint.

PR #863 thus applied the hotfix suggested by https://github.com/palantir/blueprint/issues/1008#issuecomment-403207576 from the Blueprint issue, which disables the overlay backdrop (responsible for the gray tint over the rest of the Academy) and applies the gray tint directly to the `Overlay` component `<div>` itself. However, this has two undesirable side-effects:
- it causes all other overlay components to render with the gray background tint, for which another hotfix was introduced in #874
- it prevents the user from closing any modal components by clicking outside of the overlay element, as the overlay backdrop cannot catch the `click` mouse event to close the modal component

This hotfix, whilst sufficient during the teaching semester, is not a reliable long-term solution - even necessitating the PR #1120 to address further issues with `Dialog` prompts. I propose an alternative fix instead, which makes use of the [`sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value for the CSS `position` property, **which is not supported by IE11**. This should be fine, since the Academy officially only supports the Firefox and Chrome browsers.

The fix is as follows:
- the overlay backdrop is tethered to the top of the page (viewport) with sticky positioning, and its width and height artificially set to 100% to span the full height and width of the page
  - this ensures the overlay backdrop continues to apply the gray tint over the Academy whilst the user scrolls the dialog
  - this allows the overlay backdrop to detect when it is clicked and close its associated modal component
- the full-width `Dialog` `<div>` is absolutely positioned with an offset of 0 from the top of the page (since no ancestor element of it is positioned)
  - the parent `Overlay` `<div>` continues to render the scrollbar due to the height of the content in the dialog
  - the full-width Dialog `<div>` however is removed from the document flow, preventing it from blocking the scrollbar

#### Potential for Regressions
The main concern with this fix is the possibility of introducing regressions in any Blueprint components which indirectly use an `Overlay`. The ones in use in the Academy are:
- `Alert` - unsubmission confirmation prompt in Grading page
- `Dialog` - assessment briefings and most user prompts, e.g editor reset prompt
- `Drawer` - Profile component
- `Popover` - notifications badge or the drop-down in the header bar
- `Toast` - for showing warning or error messages, e.g. to provide feedback to students in Paths
- `Tooltip` - hover-based prompts, e.g. grade and XP breakdown tooltips in Grading page, info tooltip for Run button in Playground

**I have verified that this fix resolves all the issues raised in #863, #874, #1120 and #1147 and does not result in unintended changes to the behaviour of these overlay components used elsewhere in the Academy.**

### Changelog
- Remove unnecessary props from the Blueprint `Drawer` component used in the Profile component
- Reverts the hotfixes applied in PRs #863, #874
  - This fixes modal Blueprint components not closing when the user clicks outside of the overlay element
- Applies a new CSS fix to the `Overlay` and `Dialog` components to allow the user to scroll long dialogs with the browser scrollbar and the mouse scrollwheel
  - This preserves the user's ability to scroll the dialog with the arrow keys or Page Up/Page Down keys
- Update mock assessment overviews, assessments and notifications and corresponding snapshots
  - A mock Mission *Symphony of the Winds* was added to use a long mission briefing to demonstrate the fix
- Fix the assessment betcha and editor reset dialogs not closing when the close button in the dialog's header is clicked due to a missing `onClose` prop

### Verification instructions
Please test on both **Firefox** (v70 or later) and **Chrome** (v75 or later):
1. Configure the SA front-end to use the mock backend by setting `USE_BACKEND` to `FALSE` in `.env`
2. Login to SA and navigate to *Missions*, then select the mock mission *Symphony of the Winds*
3. Attempt to scroll the mission briefing dialog in multiple ways - all of these should succeed:
    - Using the browser scrollbar
    - Using the mouse scrollwheel, with the mouse focused on or off the dialog
    - Using the arrow or Page Up/Page Down keys, with the mouse focused on or off the dialog
    - Using swiping touch gestures if using a tablet or touchscreen device
4. Now verify that the two Blueprint components `Dialog` and `Drawer` correctly close by default when the user clicks outside of the overlay element - suggested ones:
    - `Dialog`: *About* or *Help* dialogs from the dropdown menu, assessment betcha or editor reset dialogs
    - `Drawer`: *Profile* component from the dropdown menu

Additionally, you may want to manually verify that no regressions have occurred in any of the overlay Blueprint components used in the Academy - please refer to the list above.

Last updated 30 May 2020, 5:30AM