### PR TITLE
Record active tab change in sourcereel

### DIFF
--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -40,6 +40,7 @@ type DispatchProps = {
 
 type StateProps = {
   animate?: boolean;
+  selectedTabId?: SideContentType;
   defaultSelectedTabId?: SideContentType;
   renderActiveTabPanelOnly?: boolean;
   tabs: SideContentTab[];
@@ -79,6 +80,7 @@ class SideContent extends React.PureComponent<SideContentProps, {}> {
               onChange={changeTabsCallback}
               defaultSelectedTabId={this.props.defaultSelectedTabId}
               renderActiveTabPanelOnly={this.props.renderActiveTabPanelOnly}
+              selectedTabId={this.props.selectedTabId}
             >
               {tabs}
             </Tabs>

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -19,6 +19,7 @@ export enum SideContentType {
   introduction = 'introduction',
   inspector = 'inspector',
   questionOverview = 'question_overview',
+  sourcereel = 'sourcereel',
   substVisualizer = 'subst_visualiser',
   toneMatrix = 'tone_matrix'
 }

--- a/src/features/sourceRecorder/SourceRecorderTypes.ts
+++ b/src/features/sourceRecorder/SourceRecorderTypes.ts
@@ -1,5 +1,6 @@
 import { ExternalLibraryName } from '../../commons/application/types/ExternalTypes';
 import { Position } from '../../commons/editor/EditorTypes';
+import { SideContentType } from '../../commons/sideContent/SideContentTypes';
 
 export const SAVE_SOURCECAST_DATA = 'SAVE_SOURCECAST_DATA';
 export const SET_CURRENT_PLAYER_TIME = 'SET_CURRENT_PLAYER_TIME';
@@ -10,6 +11,7 @@ export const SET_SOURCECAST_PLAYBACK_DURATION = 'SET_SOURCECAST_PLAYBACK_DURATIO
 export const SET_SOURCECAST_PLAYBACK_STATUS = 'SET_SOURCECAST_PLAYBACK_STATUS';
 
 export type InputTypeShape = {
+  activeTabChange: SideContentType;
   chapterSelect: number;
   cursorPositionChange: Position;
   codeDelta: CodeDelta;

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -114,6 +114,7 @@ export type StateProps = {
   recordingStatus: RecordingStatus;
   replValue: string;
   timeElapsedBeforePause: number;
+  sideContentActiveTab: SideContentType;
   sideContentHeight?: number;
   sourcecastIndex: SourcecastData[] | null;
   sourceChapter: number;
@@ -124,6 +125,26 @@ export type StateProps = {
 class Sourcereel extends React.Component<SourcereelProps> {
   constructor(props: SourcereelProps) {
     super(props);
+  }
+
+  public componentDidUpdate(prevProps: SourcereelProps) {
+    const { inputToApply } = this.props;
+
+    if (!inputToApply || inputToApply === prevProps.inputToApply) {
+      return;
+    }
+
+    switch (inputToApply.type) {
+      case 'activeTabChange':
+        this.props.handleActiveTabChange(inputToApply.data);
+        break;
+      case 'chapterSelect':
+        this.props.handleChapterSelect(inputToApply.data);
+        break;
+      case 'externalLibrarySelect':
+        this.props.handleExternalSelect(inputToApply.data);
+        break;
+    }
   }
 
   public render() {
@@ -228,6 +249,19 @@ class Sourcereel extends React.Component<SourcereelProps> {
       handleEditorUpdateBreakpoints: this.props.handleEditorUpdateBreakpoints,
       handleRecordInput: this.props.handleRecordInput
     };
+
+    const activeTabChangeHandler = (activeTab: SideContentType) => {
+      this.props.handleActiveTabChange(activeTab);
+      if (this.props.recordingStatus !== RecordingStatus.recording) {
+        return;
+      }
+      this.props.handleRecordInput({
+        time: this.getTimerDuration(),
+        type: 'activeTabChange',
+        data: activeTab
+      });
+    };
+
     const workspaceProps: WorkspaceProps = {
       controlBarProps: {
         editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect],
@@ -249,10 +283,11 @@ class Sourcereel extends React.Component<SourcereelProps> {
       },
       sideContentHeight: this.props.sideContentHeight,
       sideContentProps: {
-        handleActiveTabChange: this.props.handleActiveTabChange,
+        handleActiveTabChange: activeTabChangeHandler,
+        selectedTabId: this.props.sideContentActiveTab,
         tabs: [
           {
-            label: 'Introduction',
+            label: 'Recording Panel',
             iconName: IconNames.COMPASS,
             body: (
               <div>
@@ -277,10 +312,11 @@ class Sourcereel extends React.Component<SourcereelProps> {
                   recordingStatus={this.props.recordingStatus}
                 />
               </div>
-            )
+            ),
+            id: SideContentType.sourcereel
           },
           {
-            label: 'Management',
+            label: 'Sourcecast Table',
             iconName: IconNames.EDIT,
             body: (
               <div>

--- a/src/pages/academy/sourcereel/SourcereelContainer.ts
+++ b/src/pages/academy/sourcereel/SourcereelContainer.ts
@@ -85,6 +85,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => 
   recordingStatus: state.workspaces.sourcereel.recordingStatus,
   replValue: state.workspaces.sourcereel.replValue,
   sideContentHeight: state.workspaces.sourcereel.sideContentHeight,
+  sideContentActiveTab: state.workspaces.sourcereel.sideContentActiveTab,
   sourcecastIndex: state.workspaces.sourcecast.sourcecastIndex,
   sourceChapter: state.workspaces.sourcereel.context.chapter,
   sourceVariant: state.workspaces.sourcereel.context.variant,

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -96,6 +96,7 @@ export type StateProps = {
   playbackData: PlaybackData;
   playbackStatus: PlaybackStatus;
   replValue: string;
+  sideContentActiveTab: SideContentType;
   sideContentHeight?: number;
   sourcecastIndex: SourcecastData[] | null;
   sourceChapter: number;
@@ -115,6 +116,9 @@ class Sourcecast extends React.Component<SourcecastProps> {
     }
 
     switch (inputToApply.type) {
+      case 'activeTabChange':
+        this.props.handleActiveTabChange(inputToApply.data);
+        break;
       case 'chapterSelect':
         this.props.handleChapterSelect(inputToApply.data);
         break;
@@ -216,9 +220,10 @@ class Sourcecast extends React.Component<SourcecastProps> {
       sideContentHeight: this.props.sideContentHeight,
       sideContentProps: {
         handleActiveTabChange: this.props.handleActiveTabChange,
+        selectedTabId: this.props.sideContentActiveTab,
         tabs: [
           {
-            label: 'Introduction',
+            label: 'Sourcecast Table',
             iconName: IconNames.COMPASS,
             body: (
               <div>

--- a/src/pages/sourcecast/SourcecastContainer.ts
+++ b/src/pages/sourcecast/SourcecastContainer.ts
@@ -74,6 +74,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => 
   playbackData: state.workspaces.sourcecast.playbackData,
   playbackStatus: state.workspaces.sourcecast.playbackStatus,
   replValue: state.workspaces.sourcecast.replValue,
+  sideContentActiveTab: state.workspaces.sourcecast.sideContentActiveTab,
   sideContentHeight: state.workspaces.sourcecast.sideContentHeight,
   sourcecastIndex: state.workspaces.sourcecast.sourcecastIndex,
   sourceChapter: state.workspaces.sourcecast.context.chapter,


### PR DESCRIPTION
### Description

- Allows recording of active tab change in sourcereel, as requested by Prof Martin.
- Fix the issue that chapter select and library select are not triggered when previewing sourcecast recordings.

Fixes # (issue)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Manually.

### Checklist

Please delete options that are not relevant.

- [X] I have tested this code
- [ ] I have updated the documentation
