### PR TITLE
Create sub-menu within source selection

### DIFF
--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -1,6 +1,6 @@
-import { Button, Classes, MenuItem } from '@blueprintjs/core';
+import { Button, Classes, MenuItem, Menu } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { ItemRenderer, Select } from '@blueprintjs/select';
+import { ItemRenderer, Select, ItemListRenderer } from '@blueprintjs/select';
 import * as React from 'react';
 
 import { Variant } from 'js-slang/dist/types';
@@ -29,6 +29,24 @@ export function ControlBarChapterSelect(props: ControlBarChapterSelectProps) {
       displayName: styliseChapter(lang.chapter, lang.variant)
     };
   });
+
+  const chapterListRenderer: ItemListRenderer<Chapter> = ({
+    items,
+    itemsParentRef,
+    query,
+    renderItem
+  }) => {
+    const defaultLangs = items.filter(item => item.variant === 'default').map(renderItem);
+    const variantLangs = items.filter(item => item.variant !== 'default').map(renderItem);
+    return (
+      <Menu ulRef={itemsParentRef}>
+        {defaultLangs}
+        <MenuItem active={false} key="variant-menu" text="Variant" icon="cog">
+          {variantLangs}
+        </MenuItem>
+      </Menu>
+    );
+  };
 
   const chapterRenderer: ItemRenderer<Chapter> = (lang, { handleClick }) => (
     <MenuItem
@@ -64,6 +82,7 @@ export function ControlBarChapterSelect(props: ControlBarChapterSelectProps) {
       items={chapters}
       onItemSelect={handleSelect}
       itemRenderer={chapterRenderer}
+      itemListRenderer={chapterListRenderer}
       filterable={false}
       disabled={disabled || false}
     >


### PR DESCRIPTION
### Description

Create a sub-menu that stores all the source language variants so that it is hidden by default.

Previously, 
![image](https://user-images.githubusercontent.com/50617144/87111832-e3c13c00-c29c-11ea-9041-a204620fee89.png)

With this PR,
![image](https://user-images.githubusercontent.com/50617144/87111859-f76ca280-c29c-11ea-829b-e8cc0be48cce.png)

Fixes #1242 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

All source language selection should behave the same; this is purely UI enhancements.

### Checklist

Please delete options that are not relevant.

- [X] I have tested this code
- [ ] I have updated the documentation
