### PR TITLE
bumping js-slang to 0.4.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-simple-import-sort": "^5.0.3",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.4.53",
+    "js-slang": "^0.4.54",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
     "moment": "^2.27.0",

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -674,7 +674,7 @@ export function* evalCode(
     const oldErrors = context.errors;
     context.errors = [];
     const parsed = parse(code, context);
-    const typeErrors = parsed && typeCheck(validateAndAnnotate(parsed!, context))[1];
+    const typeErrors = parsed && typeCheck(validateAndAnnotate(parsed!, context), context)[1];
     context.errors = oldErrors;
     if (typeErrors && typeErrors.length > 0) {
       yield put(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8428,10 +8428,10 @@ js-slang@^0.4.52:
     source-map "^0.7.3"
     xmlhttprequest-ts "^1.0.1"
 
-js-slang@^0.4.53:
-  version "0.4.53"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.53.tgz#86cec1890cb0abf7b010a15d7ee9cdc1630091ef"
-  integrity sha512-tIDBsDtKLFlItPj02TifjcDxleiT3LQ5PG9ejKmiJNVXBgoEA6eh+bONViWS7/PkOCeRPsCue2VeMUJGCjAmPw==
+js-slang@^0.4.54:
+  version "0.4.54"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.54.tgz#7c01352316c8133c26ef3bc1204311b879c9e041"
+  integrity sha512-SGDzcHsYkvpwbb6cVLAENwUn9KN4L2e0+Fotu00QzOzouNVKuEDyX8m8XKGP1mbOpLuwrsu9aYsFIdEOl9jLVQ==
   dependencies:
     "@types/estree" "0.0.45"
     acorn "^7.3.1"


### PR DESCRIPTION
### Description

Bumps js-slang to 0.4.54. WIP, see Current Status below.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

You need to start the frontend and play with the type inferencer, manually, but using the keyboard shortcut in the editor.

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code


### Current status

This is a breaking change; we currently get this error:
```
/Users/henz/Documents/source-academy/cadet-frontend/src/commons/sagas/WorkspaceSaga.ts
TypeScript error in /Users/henz/Documents/source-academy/cadet-frontend/src/commons/sagas/WorkspaceSaga.ts(677,34):
Expected 2 arguments, but got 1.  TS2554

    675 |     context.errors = [];
    676 |     const parsed = parse(code, context);
  > 677 |     const typeErrors = parsed && typeCheck(validateAndAnnotate(parsed!, context))[1];
        |                                  ^
    678 |     context.errors = oldErrors;
    679 |     if (typeErrors && typeErrors.length > 0) {
    680 |       yield put(
```