### PR TITLE
bumping js-slang to 0.4.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-simple-import-sort": "^5.0.3",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.4.54",
+    "js-slang": "^0.4.55",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
     "moment": "^2.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8428,10 +8428,10 @@ js-slang@^0.4.52:
     source-map "^0.7.3"
     xmlhttprequest-ts "^1.0.1"
 
-js-slang@^0.4.54:
-  version "0.4.54"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.54.tgz#7c01352316c8133c26ef3bc1204311b879c9e041"
-  integrity sha512-SGDzcHsYkvpwbb6cVLAENwUn9KN4L2e0+Fotu00QzOzouNVKuEDyX8m8XKGP1mbOpLuwrsu9aYsFIdEOl9jLVQ==
+js-slang@^0.4.55:
+  version "0.4.55"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.55.tgz#c25111b9417bd785df8aaeddde7a83f368763f25"
+  integrity sha512-CqFO61kcnB6uHpiCjNLJe9YAx4VKb2yVuHNCCk/PMoTsWsd1yXlSwvLunly1vE0M9mmv46OEjx18HSzHpDxMGQ==
   dependencies:
     "@types/estree" "0.0.45"
     acorn "^7.3.1"


### PR DESCRIPTION
### Description

Bumping js-slang, which has various fixes for bugs and issues related to type inference.

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

For testing, see 
https://github.com/source-academy/js-slang/pull/674

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
- [ ] I have updated the documentation
