### PR TITLE
Fix side content firing handleActiveTabChange on every re-render

### DIFF
--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -53,7 +53,7 @@ type StateProps = {
 };
 
 const SideContent = (props: SideContentProps) => {
-  const { tabs, handleActiveTabChange, defaultSelectedTabId } = props;
+  const { tabs, defaultSelectedTabId, handleActiveTabChange, onChange } = props;
   const [dynamicTabs, setDynamicTabs] = React.useState(tabs);
   const workspaces = useSelector((state: OverallState) => state.workspaces);
 
@@ -77,77 +77,80 @@ const SideContent = (props: SideContentProps) => {
   }, [tabs, debuggerContext]);
 
   /**
-   * Remove the 'side-content-tab-alert' class that causes tabs flash.
-   * To be run when tabs are changed.
-   * Currently this style is only used for the "Inspector" and "Env Visualizer" tabs.
-   */
-  const resetAlert = (prevTabId: TabId) => {
-    const iconId = generateIconId(prevTabId);
-    const icon = document.getElementById(iconId);
-
-    // The new selected tab will still have the "side-content-tab-alert" class, but the CSS hides it
-    if (icon) {
-      icon.classList.remove('side-content-tab-alert');
-    }
-  };
-
-  /**
-   * Generate an icon id given a TabId.
+   * Generates an icon id given a TabId.
    * Used to set and remove the 'side-content-tab-alert' style to the tabs.
    */
-  const generateIconId = (tabId: TabId) => {
-    return `${tabId}-icon`;
-  };
+  const generateIconId = (tabId: TabId) => `${tabId}-icon`;
 
-  const renderTab = (tab: SideContentTab, workspaceLocation?: WorkspaceLocation) => {
-    const iconSize = 20;
-    const tabId = tab.id === undefined ? tab.label : tab.id;
-    const tabTitle: JSX.Element = (
-      <Tooltip content={tab.label}>
-        <div className="side-content-tooltip" id={generateIconId(tabId)}>
-          <Icon icon={tab.iconName} iconSize={iconSize} />
-        </div>
-      </Tooltip>
-    );
+  const renderedTabs = React.useMemo(() => {
+    const renderTab = (tab: SideContentTab, workspaceLocation?: WorkspaceLocation) => {
+      const iconSize = 20;
+      const tabId = tab.id === undefined ? tab.label : tab.id;
+      const tabTitle: JSX.Element = (
+        <Tooltip content={tab.label}>
+          <div className="side-content-tooltip" id={generateIconId(tabId)}>
+            <Icon icon={tab.iconName} iconSize={iconSize} />
+          </div>
+        </Tooltip>
+      );
 
-    const tabBody: JSX.Element = workspaceLocation
-      ? {
-          ...tab.body,
-          props: {
-            ...tab.body.props,
-            workspaceLocation
+      const tabBody: JSX.Element = workspaceLocation
+        ? {
+            ...tab.body,
+            props: {
+              ...tab.body.props,
+              workspaceLocation
+            }
           }
+        : tab.body;
+      const tabPanel: JSX.Element = <div className="side-content-text">{tabBody}</div>;
+
+      return (
+        <Tab
+          key={tabId}
+          id={tabId}
+          title={tabTitle}
+          panel={tabPanel}
+          disabled={tab.disabled}
+          className="side-content-tab"
+        />
+      );
+    };
+
+    return dynamicTabs.map(tab => renderTab(tab, props.workspaceLocation));
+  }, [dynamicTabs, props.workspaceLocation]);
+
+  const changeTabsCallback = React.useCallback(
+    (
+      newTabId: SideContentType,
+      prevTabId: SideContentType,
+      event: React.MouseEvent<HTMLElement>
+    ): void => {
+      /**
+       * Remove the 'side-content-tab-alert' class that causes tabs flash.
+       * To be run when tabs are changed.
+       * Currently this style is only used for the "Inspector" and "Env Visualizer" tabs.
+       */
+      const resetAlert = (prevTabId: TabId) => {
+        const iconId = generateIconId(prevTabId);
+        const icon = document.getElementById(iconId);
+
+        // The new selected tab will still have the "side-content-tab-alert" class, but the CSS hides it
+        if (icon) {
+          icon.classList.remove('side-content-tab-alert');
         }
-      : tab.body;
-    const tabPanel: JSX.Element = <div className="side-content-text">{tabBody}</div>;
+      };
 
-    return (
-      <Tab
-        key={tabId}
-        id={tabId}
-        title={tabTitle}
-        panel={tabPanel}
-        disabled={tab.disabled}
-        className="side-content-tab"
-      />
-    );
-  };
-
-  const renderedTabs = dynamicTabs.map(tab => renderTab(tab, props.workspaceLocation));
-
-  const changeTabsCallback = (
-    newTabId: SideContentType,
-    prevTabId: SideContentType,
-    event: React.MouseEvent<HTMLElement>
-  ): void => {
-    props.handleActiveTabChange(newTabId);
-    if (props.onChange === undefined) {
-      resetAlert(prevTabId);
-    } else {
-      props.onChange(newTabId, prevTabId, event);
-      resetAlert(prevTabId);
-    }
-  };
+      handleActiveTabChange(newTabId);
+      if (onChange === undefined) {
+        resetAlert(prevTabId);
+      } else {
+        onChange(newTabId, prevTabId, event);
+        resetAlert(prevTabId);
+      }
+    },
+    [handleActiveTabChange, onChange]
+  );
 
   return (
     <div className="side-content">

--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -57,6 +57,12 @@ const SideContent = (props: SideContentProps) => {
   const [dynamicTabs, setDynamicTabs] = React.useState(tabs);
   const workspaces = useSelector((state: OverallState) => state.workspaces);
 
+  React.useEffect(() => {
+    // Set initial sideContentActiveTab for this workspace
+    handleActiveTabChange(defaultSelectedTabId ? defaultSelectedTabId : tabs[0].id!);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Fetch debuggerContext from store
   let debuggerContext: DebuggerContext;
   if (props.workspaceLocation) {
@@ -142,11 +148,6 @@ const SideContent = (props: SideContentProps) => {
       resetAlert(prevTabId);
     }
   };
-
-  React.useEffect(() => {
-    // Set initial sideContentActiveTab for this workspace
-    handleActiveTabChange(defaultSelectedTabId ? defaultSelectedTabId : tabs[0].id!);
-  }, [defaultSelectedTabId, handleActiveTabChange, tabs]);
 
   return (
     <div className="side-content">


### PR DESCRIPTION
## [Bugfix] Fix side content firing handleActiveTabChange on every re-render
Summary: Fixes issue #1369.

### Changelog
- Modify the `handleActiveTabChange` effect to only set the initial active tab once when the component mounts
  - This effect was migrated from the `componentDidMount` lifecycle method, which only runs once during component mounting
  - Since `tabs` is in its dependency array and changes every re-render, this effect runs every re-render and sets the active tab in the Redux store to the default tab, overriding the active tab set by the tab change callback - this is clearly unintended
  - This requires the empty dependency array `[]`, and follows the recommendations set out in the React documentation [here](https://reactjs.org/docs/hooks-reference.html#useeffect) for `React.useEffect`
- Memoise the rendered side-content tabs and tab change callback
  - This avoids re-rendering the side-content tabs if both the rendered tabs (`dynamicTabs`) and workspace has not changed, predicated on the parent workspace having memoised the base tabs (`tabs` prop)
    - For example, typing into the REPL should not lead to the side-content tabs re-rendering
    - This behaviour is currently limited to only the Playground, which has been refactored to memoise the base tabs passed to `SideContent`
  - The definition of some pure functions, e.g. `renderTab`, have been moved into the corresponding effects to minimise their scope and avoid unnecessary re-computation on each re-render

### Verification instructions
1. Navigate to any assessment or submission, then proceed to any **programming** (not MCQ) question
2. Bring up the side-content Autograder (airplane icon), and evaluate the editor's contents (click the `Run` button or press Shift-Enter), and verify that all the testcases are run
   - The Autograder requires the value of the active tab in that workspace to be `SideContentType.autograder` for it to run all testcases, showing the active tab is updated correctly
   - Alternatively, you can log the value of `activeTab` below to verify it matches the currently selected tab
    https://github.com/source-academy/cadet-frontend/blob/8f617f50885e1f282f7ede6a9fc2379372614c58/src/commons/sagas/WorkspaceSaga.ts#L710-L716

Last updated 21 July 2020, 5:00PM