### PR TITLE
3. Rename GameMap confusing terms

### DIFF
--- a/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
+++ b/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
@@ -4,7 +4,7 @@ import GameManager from 'src/features/game/scenes/gameManager/GameManager';
 
 import { Constants } from '../commons/CommonConstants';
 import { ItemId } from '../commons/CommonTypes';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import { ActivatableSprite, ActivateSpriteCallbacks } from '../objects/GameObjectTypes';
 import { StateChangeType, StateObserver } from '../state/GameStateTypes';
 import { mandatory } from '../utils/GameUtils';
@@ -39,15 +39,12 @@ class GameBoundingBoxManager implements StateObserver {
   public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
     const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
       locationId,
-      GameLocationAttr.boundingBoxes
+      GameItemType.boundingBoxes
     );
     const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
     if (hasUpdate && locationId === currLocationId) {
       // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(
-        locationId,
-        GameLocationAttr.boundingBoxes
-      );
+      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.boundingBoxes);
 
       // If the update is on the current location, we rerender to reflect the update
       if (id) {
@@ -69,7 +66,7 @@ class GameBoundingBoxManager implements StateObserver {
   public renderBBoxLayerContainer(locationId: LocationId): void {
     GameGlobalAPI.getInstance().clearSeveralLayers([Layer.BBox]);
     const bboxIdsToRender = GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.boundingBoxes,
+      GameItemType.boundingBoxes,
       locationId
     );
 

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -3,7 +3,7 @@ import GameGlobalAPI from 'src/features/game/scenes/gameManager/GameGlobalAPI';
 import { screenSize } from '../commons/CommonConstants';
 import { GamePosition, ItemId } from '../commons/CommonTypes';
 import { Layer } from '../layer/GameLayerTypes';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import GameManager from '../scenes/gameManager/GameManager';
 import { StateChangeType, StateObserver } from '../state/GameStateTypes';
 import { mandatory } from '../utils/GameUtils';
@@ -43,12 +43,12 @@ export default class CharacterManager implements StateObserver {
   public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
     const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
       locationId,
-      GameLocationAttr.characters
+      GameItemType.characters
     );
     const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
     if (hasUpdate && locationId === currLocationId) {
       // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameLocationAttr.characters);
+      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.characters);
 
       // If the update is on the current location, we rerender to reflect the update
       if (id) {
@@ -69,7 +69,7 @@ export default class CharacterManager implements StateObserver {
    */
   public renderCharacterLayerContainer(locationId: LocationId): void {
     const idsToRender = GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.characters,
+      GameItemType.characters,
       locationId
     );
 

--- a/src/features/game/dialogue/GameDialogueManager.ts
+++ b/src/features/game/dialogue/GameDialogueManager.ts
@@ -31,7 +31,7 @@ export default class DialogueManager {
 
   public initialise(gameManager: GameManager) {
     this.username = SourceAcademyGame.getInstance().getAccountInfo().name;
-    this.dialogueMap = gameManager.getCurrentCheckpoint().map.getDialogues();
+    this.dialogueMap = gameManager.getCurrentCheckpoint().map.getDialogueMap();
   }
 
   /**

--- a/src/features/game/location/GameMap.ts
+++ b/src/features/game/location/GameMap.ts
@@ -4,7 +4,7 @@ import { BBoxProperty } from '../boundingBoxes/GameBoundingBoxTypes';
 import { Character } from '../character/GameCharacterTypes';
 import { AssetKey, AssetPath, ItemId } from '../commons/CommonTypes';
 import { Dialogue } from '../dialogue/GameDialogueTypes';
-import { GameLocation, GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, GameLocation, LocationId } from '../location/GameMapTypes';
 import { GameMode } from '../mode/GameModeTypes';
 import { ObjectProperty } from '../objects/GameObjectTypes';
 import { mandatory } from '../utils/GameUtils';
@@ -30,7 +30,7 @@ class GameMap {
   private mapAssets: Map<AssetKey, AssetPath>;
 
   private locations: Map<LocationId, GameLocation>;
-  private talkTopics: Map<ItemId, Dialogue>;
+  private dialogues: Map<ItemId, Dialogue>;
   private objects: Map<ItemId, ObjectProperty>;
   private boundingBoxes: Map<ItemId, BBoxProperty>;
   private characters: Map<ItemId, Character>;
@@ -43,11 +43,12 @@ class GameMap {
     this.mapAssets = new Map<AssetKey, AssetPath>();
 
     this.locations = new Map<LocationId, GameLocation>();
-    this.talkTopics = new Map<ItemId, Dialogue>();
+    this.dialogues = new Map<ItemId, Dialogue>();
     this.objects = new Map<ItemId, ObjectProperty>();
     this.boundingBoxes = new Map<ItemId, BBoxProperty>();
     this.characters = new Map<ItemId, Character>();
     this.actions = new Map<ItemId, GameAction>();
+
     this.gameStartActions = [];
     this.checkpointCompleteActions = [];
   }
@@ -100,16 +101,16 @@ class GameMap {
     return this.locations;
   }
 
-  public getObjects(): Map<ItemId, ObjectProperty> {
+  public getObjectPropMap(): Map<ItemId, ObjectProperty> {
     return this.objects;
   }
 
-  public getBBoxes(): Map<ItemId, BBoxProperty> {
+  public getBBoxPropMap(): Map<ItemId, BBoxProperty> {
     return this.boundingBoxes;
   }
 
-  public getDialogues(): Map<ItemId, Dialogue> {
-    return this.talkTopics;
+  public getDialogueMap(): Map<ItemId, Dialogue> {
+    return this.dialogues;
   }
 
   public getCharacters(): Map<ItemId, Character> {
@@ -124,11 +125,11 @@ class GameMap {
     return this.soundAssets;
   }
 
-  public addItemToMap<T>(listName: GameLocationAttr, itemId: string, item: T) {
+  public setItemInMap(listName: GameItemType, itemId: string, item: any) {
     this[listName].set(itemId, item);
   }
 
-  public setItemAt<T>(locId: LocationId, listName: GameLocationAttr, itemId: string) {
+  public addItemToLocation(locId: LocationId, listName: GameItemType, itemId: string) {
     const location = this.getLocationAtId(locId);
     location[listName].add(itemId);
   }

--- a/src/features/game/location/GameMapTypes.ts
+++ b/src/features/game/location/GameMapTypes.ts
@@ -32,9 +32,10 @@ export type GameLocation = IGameActionable & {
   characters: Set<ItemId>;
 };
 
-export enum GameLocationAttr {
+export enum GameItemType {
   navigation = 'navigation',
   talkTopics = 'talkTopics',
+  dialogues = 'dialogues',
   objects = 'objects',
   boundingBoxes = 'boundingBoxes',
   characters = 'characters',

--- a/src/features/game/mode/menu/GameModeMenu.ts
+++ b/src/features/game/mode/menu/GameModeMenu.ts
@@ -6,7 +6,7 @@ import { screenCenter, screenSize } from '../../commons/CommonConstants';
 import { IGameUI } from '../../commons/CommonTypes';
 import { fadeAndDestroy } from '../../effects/FadeEffect';
 import { Layer } from '../../layer/GameLayerTypes';
-import { GameLocationAttr } from '../../location/GameMapTypes';
+import { GameItemType } from '../../location/GameMapTypes';
 import { createButton } from '../../utils/ButtonUtils';
 import { sleep } from '../../utils/GameUtils';
 import { calcTableFormatPos } from '../../utils/StyleUtils';
@@ -29,7 +29,7 @@ class GameModeMenu implements IGameUI {
     const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
     let latestModesInLoc = GameGlobalAPI.getInstance().getModesByLocId(currLocId);
     const talkTopics = GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.talkTopics,
+      GameItemType.talkTopics,
       currLocId
     );
 

--- a/src/features/game/mode/move/GameModeMove.ts
+++ b/src/features/game/mode/move/GameModeMove.ts
@@ -6,7 +6,7 @@ import { IGameUI } from '../../commons/CommonTypes';
 import { fadeAndDestroy } from '../../effects/FadeEffect';
 import { entryTweenProps, exitTweenProps } from '../../effects/FlyEffect';
 import { Layer } from '../../layer/GameLayerTypes';
-import { GameLocationAttr, LocationId } from '../../location/GameMapTypes';
+import { GameItemType, LocationId } from '../../location/GameMapTypes';
 import GameGlobalAPI from '../../scenes/gameManager/GameGlobalAPI';
 import { createButton } from '../../utils/ButtonUtils';
 import { sleep } from '../../utils/GameUtils';
@@ -41,7 +41,7 @@ class GameModeMove implements IGameUI {
    */
   private getLatestNavigations() {
     return GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.navigation,
+      GameItemType.navigation,
       GameGlobalAPI.getInstance().getCurrLocId()
     );
   }

--- a/src/features/game/mode/talk/GameModeTalk.ts
+++ b/src/features/game/mode/talk/GameModeTalk.ts
@@ -8,7 +8,7 @@ import { IGameUI, ItemId } from '../../commons/CommonTypes';
 import { fadeAndDestroy } from '../../effects/FadeEffect';
 import { entryTweenProps, exitTweenProps } from '../../effects/FlyEffect';
 import { Layer } from '../../layer/GameLayerTypes';
-import { GameLocationAttr } from '../../location/GameMapTypes';
+import { GameItemType } from '../../location/GameMapTypes';
 import { createButton } from '../../utils/ButtonUtils';
 import { mandatory, sleep } from '../../utils/GameUtils';
 import { calcTableFormatPos } from '../../utils/StyleUtils';
@@ -27,7 +27,7 @@ class GameModeTalk implements IGameUI {
    */
   private getLatestTalkTopics() {
     return GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.talkTopics,
+      GameItemType.talkTopics,
       GameGlobalAPI.getInstance().getCurrLocId()
     );
   }

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -5,7 +5,7 @@ import GameManager from 'src/features/game/scenes/gameManager/GameManager';
 import { Constants } from '../commons/CommonConstants';
 import { ItemId } from '../commons/CommonTypes';
 import GlowingImage from '../effects/GlowingObject';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import { StateChangeType, StateObserver } from '../state/GameStateTypes';
 import { mandatory } from '../utils/GameUtils';
 import { ActivatableSprite, ActivateSpriteCallbacks, ObjectProperty } from './GameObjectTypes';
@@ -46,12 +46,12 @@ class GameObjectManager implements StateObserver {
   public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
     const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
       locationId,
-      GameLocationAttr.objects
+      GameItemType.objects
     );
     const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
     if (hasUpdate && locationId === currLocationId) {
       // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameLocationAttr.objects);
+      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.objects);
 
       // If the update is on the current location, we rerender to reflect the update
       if (id) {
@@ -73,7 +73,7 @@ class GameObjectManager implements StateObserver {
   public renderObjectsLayerContainer(locationId: LocationId): void {
     GameGlobalAPI.getInstance().clearSeveralLayers([Layer.Objects]);
     const objIdsToRender = GameGlobalAPI.getInstance().getLocationAttr(
-      GameLocationAttr.objects,
+      GameItemType.objects,
       locationId
     );
 

--- a/src/features/game/parser/ActionParser.ts
+++ b/src/features/game/parser/ActionParser.ts
@@ -1,6 +1,6 @@
 import { GameAction, GameActionType } from '../action/GameActionTypes';
 import { ItemId } from '../commons/CommonTypes';
-import { GameLocationAttr } from '../location/GameMapTypes';
+import { GameItemType } from '../location/GameMapTypes';
 import StringUtils from '../utils/StringUtils';
 import ConditionParser from './ConditionParser';
 import Parser from './Parser';
@@ -43,11 +43,7 @@ export default class ActionParser {
       ).map(condition => ConditionParser.parse(condition));
     }
 
-    Parser.checkpoint.map.addItemToMap(
-      GameLocationAttr.actions,
-      gameAction.interactionId,
-      gameAction
-    );
+    Parser.checkpoint.map.setItemInMap(GameItemType.actions, gameAction.interactionId, gameAction);
 
     return gameAction.interactionId;
   }
@@ -78,7 +74,7 @@ export default class ActionParser {
     switch (gameActionType) {
       case GameActionType.ObtainCollectible:
         actionParamObj.id = Parser.validator.assertLocAttr(
-          GameLocationAttr.collectibles,
+          GameItemType.collectibles,
           actionParams[0],
           actionType
         );
@@ -100,7 +96,7 @@ export default class ActionParser {
         break;
       case GameActionType.BringUpDialogue:
         actionParamObj.id = Parser.validator.assertLocAttr(
-          GameLocationAttr.talkTopics,
+          GameItemType.talkTopics,
           actionParams[0],
           actionType
         );
@@ -131,7 +127,7 @@ export default class ActionParser {
         break;
       case GameActionType.AddPopup:
         actionParamObj.id = Parser.validator.assertLocAttr(
-          GameLocationAttr.objects,
+          GameItemType.objects,
           actionParams[0],
           actionType
         );
@@ -139,7 +135,7 @@ export default class ActionParser {
         break;
       case GameActionType.MakeObjectBlink:
         actionParamObj.id = Parser.validator.assertLocAttr(
-          GameLocationAttr.objects,
+          GameItemType.objects,
           actionParams[0],
           actionType
         );
@@ -147,7 +143,7 @@ export default class ActionParser {
         break;
       case GameActionType.MakeObjectGlow:
         actionParamObj.id = Parser.validator.assertLocAttr(
-          GameLocationAttr.objects,
+          GameItemType.objects,
           actionParams[0],
           actionType
         );

--- a/src/features/game/parser/BoundingBoxParser.ts
+++ b/src/features/game/parser/BoundingBoxParser.ts
@@ -1,5 +1,5 @@
 import { BBoxProperty } from '../boundingBoxes/GameBoundingBoxTypes';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import StringUtils from '../utils/StringUtils';
 import ActionParser from './ActionParser';
 import Parser from './Parser';
@@ -51,9 +51,9 @@ export default class BoundingBoxParser {
       interactionId: bboxId
     };
 
-    Parser.checkpoint.map.addItemToMap(GameLocationAttr.boundingBoxes, bboxId, bboxProperty);
+    Parser.checkpoint.map.setItemInMap(GameItemType.boundingBoxes, bboxId, bboxProperty);
     if (addToLoc) {
-      Parser.checkpoint.map.setItemAt(locationId, GameLocationAttr.boundingBoxes, bboxId);
+      Parser.checkpoint.map.addItemToLocation(locationId, GameItemType.boundingBoxes, bboxId);
     }
 
     return bboxProperty;

--- a/src/features/game/parser/CharacterParser.ts
+++ b/src/features/game/parser/CharacterParser.ts
@@ -1,6 +1,6 @@
 import { Character } from '../character/GameCharacterTypes';
 import { AssetKey, ItemId } from '../commons/CommonTypes';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import StringUtils from '../utils/StringUtils';
 import Parser from './Parser';
 import ParserConverter from './ParserConverter';
@@ -81,11 +81,11 @@ export default class CharacterParser {
     );
 
     // Add character to map
-    Parser.checkpoint.map.addItemToMap(GameLocationAttr.characters, id, character);
+    Parser.checkpoint.map.setItemInMap(GameItemType.characters, id, character);
 
     // Add character to location
     if (addToLoc) {
-      Parser.checkpoint.map.setItemAt(locationId, GameLocationAttr.characters, id);
+      Parser.checkpoint.map.addItemToLocation(locationId, GameItemType.characters, id);
     }
   }
 }

--- a/src/features/game/parser/DialogueParser.ts
+++ b/src/features/game/parser/DialogueParser.ts
@@ -1,5 +1,5 @@
 import { Dialogue, DialogueLine, PartName } from '../dialogue/GameDialogueTypes';
-import { GameLocationAttr } from '../location/GameMapTypes';
+import { GameItemType } from '../location/GameMapTypes';
 import { mapValues } from '../utils/GameUtils';
 import StringUtils from '../utils/StringUtils';
 import ActionParser from './ActionParser';
@@ -42,7 +42,7 @@ export default class DialogueParser {
     const content = this.parseDialogueContent(dialogueBody);
     const dialogue: Dialogue = { title, content };
 
-    Parser.checkpoint.map.addItemToMap(GameLocationAttr.talkTopics, dialogueId, dialogue);
+    Parser.checkpoint.map.setItemInMap(GameItemType.talkTopics, dialogueId, dialogue);
   }
 
   /**

--- a/src/features/game/parser/LocationParser.ts
+++ b/src/features/game/parser/LocationParser.ts
@@ -1,4 +1,4 @@
-import { GameLocation, GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, GameLocation, LocationId } from '../location/GameMapTypes';
 import { GameSoundType } from '../sound/GameSoundTypes';
 import StringUtils from '../utils/StringUtils';
 import ActionParser from './ActionParser';
@@ -60,7 +60,7 @@ export default class LocationParser {
         break;
       case 'talkTopics':
         const talkTopics = configValues;
-        Parser.validator.assertLocAttrs(GameLocationAttr.talkTopics, talkTopics);
+        Parser.validator.assertLocAttrs(GameItemType.talkTopics, talkTopics);
         location.talkTopics = new Set(talkTopics);
         break;
       default:

--- a/src/features/game/parser/ObjectParser.ts
+++ b/src/features/game/parser/ObjectParser.ts
@@ -1,4 +1,4 @@
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import { ObjectProperty } from '../objects/GameObjectTypes';
 import StringUtils from '../utils/StringUtils';
 import ActionParser from './ActionParser';
@@ -78,9 +78,9 @@ export default class ObjectParser {
 
     Parser.checkpoint.map.addMapAsset(this.objectAssetKey(shortPath), this.objectPath(shortPath));
 
-    Parser.checkpoint.map.addItemToMap(GameLocationAttr.objects, objectId, objectProperty);
+    Parser.checkpoint.map.setItemInMap(GameItemType.objects, objectId, objectProperty);
     if (addToLoc) {
-      Parser.checkpoint.map.setItemAt(locationId, GameLocationAttr.objects, objectId);
+      Parser.checkpoint.map.addItemToLocation(locationId, GameItemType.objects, objectId);
     }
 
     return objectProperty;

--- a/src/features/game/parser/ParserConverter.ts
+++ b/src/features/game/parser/ParserConverter.ts
@@ -1,6 +1,6 @@
 import { GameActionType } from '../action/GameActionTypes';
 import { GamePosition } from '../commons/CommonTypes';
-import { GameLocationAttr } from '../location/GameMapTypes';
+import { GameItemType } from '../location/GameMapTypes';
 import { GameMode } from '../mode/GameModeTypes';
 import { GameStateStorage, UserStateTypes } from '../state/GameStateTypes';
 
@@ -18,14 +18,14 @@ const stringToGameModeMap = {
 };
 
 const stringToLocAttrMap = {
-  navigation: GameLocationAttr.navigation,
-  talkTopics: GameLocationAttr.talkTopics,
-  objects: GameLocationAttr.objects,
-  boundingBoxes: GameLocationAttr.boundingBoxes,
-  characters: GameLocationAttr.characters,
-  actions: GameLocationAttr.actions,
-  bgmKey: GameLocationAttr.bgmKey,
-  collectibles: GameLocationAttr.collectibles
+  navigation: GameItemType.navigation,
+  talkTopics: GameItemType.talkTopics,
+  objects: GameItemType.objects,
+  boundingBoxes: GameItemType.boundingBoxes,
+  characters: GameItemType.characters,
+  actions: GameItemType.actions,
+  bgmKey: GameItemType.bgmKey,
+  collectibles: GameItemType.collectibles
 };
 
 const stringToActionTypeMap = {

--- a/src/features/game/parser/ParserValidator.ts
+++ b/src/features/game/parser/ParserValidator.ts
@@ -1,5 +1,5 @@
 import { ItemId } from '../commons/CommonTypes';
-import { GameLocationAttr } from '../location/GameMapTypes';
+import { GameItemType } from '../location/GameMapTypes';
 import { GameSoundType } from '../sound/GameSoundTypes';
 import Parser from './Parser';
 
@@ -35,11 +35,11 @@ type AssertionDetail = {
  * to check all the assertions made is true.
  */
 export default class ParserValidator {
-  private locAttrAssertions: Map<GameLocationAttr, AssertionDetail[]>;
+  private locAttrAssertions: Map<GameItemType, AssertionDetail[]>;
   private attrAssertions: Map<GameAttr, AssertionDetail[]>;
 
   constructor() {
-    this.locAttrAssertions = new Map<GameLocationAttr, AssertionDetail[]>();
+    this.locAttrAssertions = new Map<GameItemType, AssertionDetail[]>();
     this.attrAssertions = new Map<GameAttr, AssertionDetail[]>();
   }
 
@@ -53,7 +53,7 @@ export default class ParserValidator {
    * @param actionType Action type e.g. make_object_glow if the assertion
    *                   was made while parsing an action
    */
-  public assertLocAttr(locAttr: GameLocationAttr, itemId: ItemId, actionType?: string) {
+  public assertLocAttr(locAttr: GameItemType, itemId: ItemId, actionType?: string) {
     if (!this.locAttrAssertions.get(locAttr)) {
       this.locAttrAssertions.set(locAttr, []);
     }
@@ -75,7 +75,7 @@ export default class ParserValidator {
     return itemId;
   }
 
-  public assertLocAttrs(locAttr: GameLocationAttr, itemIds: ItemId[], actionType?: string) {
+  public assertLocAttrs(locAttr: GameItemType, itemIds: ItemId[], actionType?: string) {
     itemIds.forEach(itemId => this.assertLocAttr(locAttr, itemId, actionType));
   }
 
@@ -86,7 +86,7 @@ export default class ParserValidator {
 
   private verifyLocAttrAssertions() {
     this.locAttrAssertions.forEach(
-      (assertionDetails: AssertionDetail[], gameLocationAttr: GameLocationAttr) => {
+      (assertionDetails: AssertionDetail[], gameLocationAttr: GameItemType) => {
         assertionDetails.forEach((assertionDetail: AssertionDetail) => {
           const { itemId, actionType } = assertionDetail;
           if (!Parser.checkpoint.map[gameLocationAttr].has(itemId)) {

--- a/src/features/game/popUp/GamePopUpManager.ts
+++ b/src/features/game/popUp/GamePopUpManager.ts
@@ -117,7 +117,7 @@ class GamePopUpManager {
     const objectPropMap = GameGlobalAPI.getInstance()
       .getGameManager()
       .getCurrentCheckpoint()
-      .map.getObjects();
+      .map.getObjectPropMap();
     const objProp = objectPropMap.get(itemId);
     if (objProp) {
       return objProp.assetKey;

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -6,7 +6,7 @@ import { BBoxProperty } from '../../boundingBoxes/GameBoundingBoxTypes';
 import { GamePosition, ItemId } from '../../commons/CommonTypes';
 import { AssetKey } from '../../commons/CommonTypes';
 import { displayNotification } from '../../effects/Notification';
-import { GameLocation, GameLocationAttr, LocationId } from '../../location/GameMapTypes';
+import { GameItemType, GameLocation, LocationId } from '../../location/GameMapTypes';
 import { ActivateSpriteCallbacks, ObjectProperty } from '../../objects/GameObjectTypes';
 import { GamePhaseType } from '../../phase/GamePhaseTypes';
 import { SettingsJson } from '../../save/GameSaveTypes';
@@ -77,10 +77,7 @@ class GameGlobalAPI {
   //  Game Locations //
   /////////////////////
 
-  public hasLocationUpdateAttr(
-    locationId: LocationId,
-    attr?: GameLocationAttr
-  ): boolean | undefined {
+  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
     return this.getGameManager().stateManager.hasLocationUpdateAttr(locationId, attr);
   }
 
@@ -112,23 +109,19 @@ class GameGlobalAPI {
   //    Game Attr    //
   /////////////////////
 
-  public consumedLocationUpdate(locationId: LocationId, attr: GameLocationAttr) {
+  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
     return this.getGameManager().stateManager.consumedLocationUpdate(locationId, attr);
   }
 
-  public getLocationAttr(attr: GameLocationAttr, locationId: LocationId): ItemId[] {
+  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
     return this.getGameManager().stateManager.getLocationAttr(attr, locationId);
   }
 
-  public addLocationAttr(attr: GameLocationAttr, locationId: LocationId, attrElem: string): void {
+  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
     this.getGameManager().stateManager.addLocationAttr(attr, locationId, attrElem);
   }
 
-  public removeLocationAttr(
-    attr: GameLocationAttr,
-    locationId: LocationId,
-    attrElem: string
-  ): void {
+  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
     return this.getGameManager().stateManager.removeLocationAttr(attr, locationId, attrElem);
   }
 
@@ -285,7 +278,7 @@ class GameGlobalAPI {
   }
 
   public getDialogue(dialogueId: ItemId) {
-    return this.getGameManager().getCurrentCheckpoint().map.getDialogues().get(dialogueId);
+    return this.getGameManager().getCurrentCheckpoint().map.getDialogueMap().get(dialogueId);
   }
 
   /////////////////////

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -1,7 +1,7 @@
 import { BBoxProperty } from '../boundingBoxes/GameBoundingBoxTypes';
 import { ItemId } from '../commons/CommonTypes';
 import GameMap from '../location/GameMap';
-import { GameLocationAttr, LocationId } from '../location/GameMapTypes';
+import { GameItemType, LocationId } from '../location/GameMapTypes';
 import { GameMode } from '../mode/GameModeTypes';
 import GameObjective from '../objective/GameObjective';
 import { ObjectProperty } from '../objects/GameObjectTypes';
@@ -29,7 +29,7 @@ class GameStateManager implements StateSubject {
   private checkpointObjective: GameObjective;
 
   // Triggered Interactions
-  private locationHasUpdate: Map<string, Map<GameLocationAttr, boolean>>;
+  private locationHasUpdate: Map<string, Map<GameItemType, boolean>>;
   private triggeredInteractions: Map<ItemId, boolean>;
   private triggeredActions: ItemId[];
 
@@ -37,7 +37,7 @@ class GameStateManager implements StateSubject {
     this.subscribers = new Array<StateObserver>();
     this.gameMap = new GameMap();
     this.checkpointObjective = new GameObjective();
-    this.locationHasUpdate = new Map<string, Map<GameLocationAttr, boolean>>();
+    this.locationHasUpdate = new Map<string, Map<GameItemType, boolean>>();
     this.triggeredInteractions = new Map<ItemId, boolean>();
     this.triggeredActions = [];
   }
@@ -93,14 +93,14 @@ class GameStateManager implements StateSubject {
   ): void {
     switch (mode) {
       case GameMode.Explore:
-        this.updateLocationStateAttr(changeType, targetLocId, GameLocationAttr.boundingBoxes);
-        this.updateLocationStateAttr(changeType, targetLocId, GameLocationAttr.objects);
+        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.boundingBoxes);
+        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.objects);
         return;
       case GameMode.Move:
-        this.updateLocationStateAttr(changeType, targetLocId, GameLocationAttr.navigation);
+        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.navigation);
         return;
       case GameMode.Talk:
-        this.updateLocationStateAttr(changeType, targetLocId, GameLocationAttr.talkTopics);
+        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.talkTopics);
         return;
       default:
         return;
@@ -119,7 +119,7 @@ class GameStateManager implements StateSubject {
   private updateLocationStateAttr(
     changeType: StateChangeType,
     targetLocId: LocationId,
-    attr: GameLocationAttr,
+    attr: GameItemType,
     attrId?: string
   ): void {
     const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
@@ -148,8 +148,8 @@ class GameStateManager implements StateSubject {
 
     // Register every attribute of each location under the chapter
     this.gameMap.getLocations().forEach((_location, locationId) => {
-      this.locationHasUpdate.set(locationId, new Map<GameLocationAttr, boolean>());
-      Object.values(GameLocationAttr).forEach(value =>
+      this.locationHasUpdate.set(locationId, new Map<GameItemType, boolean>());
+      Object.values(GameItemType).forEach(value =>
         this.locationHasUpdate.get(locationId)!.set(value, false)
       );
     });
@@ -224,14 +224,14 @@ class GameStateManager implements StateSubject {
     if (mode) {
       switch (mode) {
         case GameMode.Explore:
-          this.hasLocationUpdateAttr(locationId, GameLocationAttr.boundingBoxes);
-          this.hasLocationUpdateAttr(locationId, GameLocationAttr.objects);
+          this.hasLocationUpdateAttr(locationId, GameItemType.boundingBoxes);
+          this.hasLocationUpdateAttr(locationId, GameItemType.objects);
           return;
         case GameMode.Move:
-          this.hasLocationUpdateAttr(locationId, GameLocationAttr.navigation);
+          this.hasLocationUpdateAttr(locationId, GameItemType.navigation);
           return;
         case GameMode.Talk:
-          this.hasLocationUpdateAttr(locationId, GameLocationAttr.talkTopics);
+          this.hasLocationUpdateAttr(locationId, GameItemType.talkTopics);
           return;
         default:
           return;
@@ -252,10 +252,7 @@ class GameStateManager implements StateSubject {
    * @param mode mode to check
    * @returns {boolean}
    */
-  public hasLocationUpdateAttr(
-    locationId: LocationId,
-    attr?: GameLocationAttr
-  ): boolean | undefined {
+  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
     this.gameMap.checkLocationExists(locationId);
     if (attr) {
       return this.locationHasUpdate.get(locationId)!.get(attr);
@@ -274,7 +271,7 @@ class GameStateManager implements StateSubject {
    * @param locationId location ID
    * @param attr attribute which update has been consumed
    */
-  public consumedLocationUpdate(locationId: LocationId, attr: GameLocationAttr) {
+  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
     this.gameMap.checkLocationExists(locationId);
     this.locationHasUpdate.get(locationId)!.set(attr, false);
   }
@@ -332,7 +329,7 @@ class GameStateManager implements StateSubject {
    * @param locationId id of location
    * @param {ItemId[]}
    */
-  public getLocationAttr(attr: GameLocationAttr, locationId: LocationId): ItemId[] {
+  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
     const location = this.gameMap.getLocationAtId(locationId);
     return Array.from(location[attr]) || [];
   }
@@ -344,7 +341,7 @@ class GameStateManager implements StateSubject {
    * @param locationId id of location
    * @param attrElem item ID to be added
    */
-  public addLocationAttr(attr: GameLocationAttr, locationId: LocationId, attrElem: string) {
+  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
     const location = this.gameMap.getLocationAtId(locationId);
     if (!location[attr]) location[attr] = new Set([]);
     location[attr].add(attrElem);
@@ -359,7 +356,7 @@ class GameStateManager implements StateSubject {
    * @param locationId id of location
    * @param attrElem item ID to be removed
    */
-  public removeLocationAttr(attr: GameLocationAttr, locationId: LocationId, attrElem: string) {
+  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
     const location = this.gameMap.getLocationAtId(locationId);
     if (!location[attr]) return;
     location[attr] = location[attr].filter((oldAttr: string) => oldAttr !== attrElem);
@@ -426,7 +423,7 @@ class GameStateManager implements StateSubject {
    * @returns {Map<ItemId, ObjectProperty>}
    */
   public getObjPropertyMap() {
-    return this.gameMap.getObjects();
+    return this.gameMap.getObjectPropMap();
   }
 
   /**
@@ -437,17 +434,12 @@ class GameStateManager implements StateSubject {
    * @param newObjProp new object property to replace the old one
    */
   public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
-    this.gameMap.addItemToMap(GameLocationAttr.objects, id, newObjProp);
+    this.gameMap.setItemInMap(GameItemType.objects, id, newObjProp);
 
     // Update every location that uses it
     this.gameMap.getLocations().forEach((location, locationId) => {
       if (location.objects && location.objects.has(id)) {
-        this.updateLocationStateAttr(
-          StateChangeType.Mutate,
-          locationId,
-          GameLocationAttr.objects,
-          id
-        );
+        this.updateLocationStateAttr(StateChangeType.Mutate, locationId, GameItemType.objects, id);
       }
     });
   }
@@ -462,7 +454,7 @@ class GameStateManager implements StateSubject {
    * @returns {Map<ItemId, BBoxProperty>}
    */
   public getBBoxPropertyMap() {
-    return this.gameMap.getBBoxes();
+    return this.gameMap.getBBoxPropMap();
   }
 
   /**
@@ -473,7 +465,7 @@ class GameStateManager implements StateSubject {
    * @param newBBoxProp new object property to replace the old one
    */
   public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
-    this.gameMap.addItemToMap(GameLocationAttr.boundingBoxes, id, newBBoxProp);
+    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newBBoxProp);
 
     // Update every location that uses it
     this.gameMap.getLocations().forEach((location, locationId) => {
@@ -481,7 +473,7 @@ class GameStateManager implements StateSubject {
         this.updateLocationStateAttr(
           StateChangeType.Mutate,
           locationId,
-          GameLocationAttr.boundingBoxes,
+          GameItemType.boundingBoxes,
           id
         );
       }


### PR DESCRIPTION
### Description

Rename some components of game map:

- SetItem/AddItemInLocation confusion had names that were the other way around
- Remove confusing generics `<T>` in game map function declaration
- Change function name for obtaining `Map<ItemId, Prop>` from GameMap to getDialogueMap(), getObjectPropMap()
- Change GameLocAttr to GameItemType. For better pronounceability and code readability (gets really confusing to read a code full of `attr`, `attr`)


Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist

Please delete options that are not relevant.

- [ ] I have tested this code
- [ ] I have updated the documentation
