### PR TITLE
4. Managers - no more initialise

### DIFF
--- a/src/features/game/action/GameActionExecuter.ts
+++ b/src/features/game/action/GameActionExecuter.ts
@@ -22,10 +22,10 @@ export default class GameActionExecuter {
 
     switch (actionType) {
       case GameActionType.AddItem:
-        globalAPI.addLocationAttr(actionParams.attr, actionParams.locationId, actionParams.id);
+        globalAPI.addItem(actionParams.attr, actionParams.locationId, actionParams.id);
         return;
       case GameActionType.RemoveItem:
-        globalAPI.removeLocationAttr(actionParams.attr, actionParams.locationId, actionParams.id);
+        globalAPI.removeItem(actionParams.attr, actionParams.locationId, actionParams.id);
         return;
       case GameActionType.AddLocationMode:
         globalAPI.addLocationMode(actionParams.locationId, actionParams.mode);

--- a/src/features/game/action/GameActionManager.ts
+++ b/src/features/game/action/GameActionManager.ts
@@ -1,26 +1,14 @@
 import { ItemId } from '../commons/CommonTypes';
 import GameGlobalAPI from '../scenes/gameManager/GameGlobalAPI';
-import GameManager from '../scenes/gameManager/GameManager';
-import { mandatory } from '../utils/GameUtils';
 import ActionConditionChecker from './GameActionConditionChecker';
 import GameActionExecuter from './GameActionExecuter';
-import { ActionCondition, GameAction } from './GameActionTypes';
+import { ActionCondition } from './GameActionTypes';
 
 /**
  * This class manages all game actions, and is called whenever
  * entities need to perform actions.
  */
 export default class GameActionManager {
-  private actionMap: Map<ItemId, GameAction>;
-
-  constructor() {
-    this.actionMap = new Map<ItemId, GameAction>();
-  }
-
-  public initialise(gameManager: GameManager) {
-    this.actionMap = gameManager.getStateManager().getGameMap().getActions();
-  }
-
   /**
    * Process an array of actions, denoted by their IDs,
    * but only replays those actions that have no visible effects
@@ -30,7 +18,7 @@ export default class GameActionManager {
   public async fastForwardGameActions(actionIds?: ItemId[]): Promise<void> {
     if (!actionIds) return;
     for (const actionId of actionIds) {
-      const { actionType, actionParams } = this.getActionFromId(actionId);
+      const { actionType, actionParams } = GameGlobalAPI.getInstance().getActionById(actionId);
       await GameActionExecuter.executeGameAction(actionType, actionParams, true);
     }
   }
@@ -62,7 +50,7 @@ export default class GameActionManager {
       actionConditions,
       isRepeatable,
       interactionId
-    } = this.getActionFromId(actionId);
+    } = GameGlobalAPI.getInstance().getActionById(actionId);
     if (await this.checkCanPlayAction(isRepeatable, interactionId, actionConditions)) {
       await GameActionExecuter.executeGameAction(actionType, actionParams);
       GameGlobalAPI.getInstance().triggerInteraction(actionId);
@@ -91,6 +79,4 @@ export default class GameActionManager {
       (await ActionConditionChecker.checkAllConditionsSatisfied(actionConditions))
     );
   }
-
-  private getActionFromId = (actionId: ItemId) => mandatory(this.actionMap.get(actionId));
 }

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -4,7 +4,7 @@ import { screenSize } from '../commons/CommonConstants';
 import { GamePosition, ItemId } from '../commons/CommonTypes';
 import { Layer } from '../layer/GameLayerTypes';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
-import { StateChangeType, StateObserver } from '../state/GameStateTypes';
+import { StateObserver } from '../state/GameStateTypes';
 import { resize } from '../utils/SpriteUtils';
 import CharConstants from './GameCharacterConstants';
 
@@ -12,44 +12,11 @@ import CharConstants from './GameCharacterConstants';
  * Manager for rendering characters in the location.
  */
 export default class CharacterManager implements StateObserver {
-  public observerId: string;
   private characterSpriteMap: Map<ItemId, Phaser.GameObjects.Image>;
 
   constructor() {
-    this.observerId = 'GameCharacterManager';
     this.characterSpriteMap = new Map<ItemId, Phaser.GameObjects.Image>();
-    GameGlobalAPI.getInstance().subscribeState(this);
-  }
-
-  /**
-   * Part of observer pattern. Receives notification from GameStateManager.
-   *
-   * On notify, will rerender all the characters on the location to reflect
-   * the update to the state if applicable.
-   *
-   * @param changeType type of change
-   * @param locationId id of the location being updated
-   * @param id id of item being updated
-   */
-  public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
-      locationId,
-      GameItemType.characters
-    );
-    const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
-    if (hasUpdate && locationId === currLocationId) {
-      // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.characters);
-
-      // If the update is on the current location, we rerender to reflect the update
-      if (id) {
-        // If Id is provided, we only need to address the specific character
-        this.handleCharacterChange(changeType, id);
-      } else {
-        // Else, rerender the whole layer
-        this.renderCharacterLayerContainer(locationId);
-      }
-    }
+    GameGlobalAPI.getInstance().watchGameItemType(GameItemType.characters, this);
   }
 
   /**
@@ -101,36 +68,18 @@ export default class CharacterManager implements StateObserver {
   }
 
   /**
-   * Handle change of a specific character ID.
-   *
-   * @param changeType type of change
-   * @param id id of affected character
-   */
-  private handleCharacterChange(changeType: StateChangeType, id: ItemId) {
-    switch (changeType) {
-      case StateChangeType.Add:
-        return this.handleAdd(id);
-      case StateChangeType.Mutate:
-        return this.handleMutate(id);
-      case StateChangeType.Delete:
-        return this.handleDelete(id);
-    }
-  }
-
-  /**
    * Add the character, specified by the ID, into the scene
    * and keep track of it within the mapping.
    *
-   * Throws error if the  character is not available
-   * in the mapping.
-   *
    * @param id id of character
+   * @return {boolean} true if successful, false otherwise
+
    */
-  private handleAdd(id: ItemId) {
+  public handleAdd(id: ItemId): boolean {
     const characterSprite = this.createCharacterSprite(id);
     GameGlobalAPI.getInstance().addContainerToLayer(Layer.Character, characterSprite);
     this.characterSpriteMap.set(id, characterSprite);
-    return characterSprite;
+    return true;
   }
 
   /**
@@ -139,21 +88,28 @@ export default class CharacterManager implements StateObserver {
    * Internally, will delete and re-add the character with
    * the updated property.
    *
-   * @param id id of characer
+   * @param id id of character
+   * @return {boolean} true if successful, false otherwise
+
    */
-  private handleMutate(id: ItemId) {
-    this.handleDelete(id);
-    this.handleAdd(id);
+  public handleMutate(id: ItemId): boolean {
+    return this.handleDelete(id) && this.handleAdd(id);
   }
 
   /**
    * Delete the character of the given id, if
    * applicable.
    *
-   * @param id id of the bbox
+   * @param id id of the character
+   *  @return {boolean} true if successful, false otherwise
    */
-  private handleDelete(id: ItemId) {
+  public handleDelete(id: ItemId) {
     const char = this.characterSpriteMap.get(id);
-    if (char) char.destroy();
+    if (char) {
+      this.characterSpriteMap.delete(id);
+      char.destroy();
+      return true;
+    }
+    return false;
   }
 }

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -18,9 +18,6 @@ export default class CharacterManager implements StateObserver {
   constructor() {
     this.observerId = 'GameCharacterManager';
     this.characterSpriteMap = new Map<ItemId, Phaser.GameObjects.Image>();
-  }
-
-  public initialise() {
     GameGlobalAPI.getInstance().subscribeState(this);
   }
 

--- a/src/features/game/dialogue/GameDialogueManager.ts
+++ b/src/features/game/dialogue/GameDialogueManager.ts
@@ -14,19 +14,9 @@ import DialogueSpeakerRenderer from './GameDialogueSpeakerRenderer';
  * whenever players click on the dialogue box
  */
 export default class DialogueManager {
-  private username: string;
-
   private speakerRenderer?: DialogueSpeakerRenderer;
   private dialogueRenderer?: DialogueRenderer;
   private dialogueGenerator?: DialogueGenerator;
-
-  constructor() {
-    this.username = '';
-  }
-
-  public initialise() {
-    this.username = SourceAcademyGame.getInstance().getAccountInfo().name;
-  }
 
   /**
    * @param dialogueId the dialogue Id of the dialogue you want to play
@@ -38,7 +28,7 @@ export default class DialogueManager {
 
     this.dialogueRenderer = new DialogueRenderer(textTypeWriterStyle);
     this.dialogueGenerator = new DialogueGenerator(dialogue.content);
-    this.speakerRenderer = new DialogueSpeakerRenderer(this.username);
+    this.speakerRenderer = new DialogueSpeakerRenderer();
 
     GameGlobalAPI.getInstance().addContainerToLayer(
       Layer.Dialogue,
@@ -67,7 +57,7 @@ export default class DialogueManager {
 
   private async showNextLine(resolve: () => void) {
     const { line, speakerDetail, actionIds } = this.getDialogueGenerator().generateNextLine();
-    const lineWithName = line.replace('{name}', this.username);
+    const lineWithName = line.replace('{name}', this.getUsername());
     this.getDialogueRenderer().changeText(lineWithName);
     this.getSpeakerRenderer().changeSpeakerTo(speakerDetail);
     await GameGlobalAPI.getInstance().processGameActionsInSamePhase(actionIds);
@@ -77,4 +67,6 @@ export default class DialogueManager {
   private getDialogueGenerator = () => this.dialogueGenerator as DialogueGenerator;
   private getDialogueRenderer = () => this.dialogueRenderer as DialogueRenderer;
   private getSpeakerRenderer = () => this.speakerRenderer as DialogueSpeakerRenderer;
+
+  public getUsername = () => SourceAcademyGame.getInstance().getAccountInfo().name;
 }

--- a/src/features/game/dialogue/GameDialogueSpeakerRenderer.ts
+++ b/src/features/game/dialogue/GameDialogueSpeakerRenderer.ts
@@ -4,6 +4,7 @@ import { screenCenter, screenSize } from '../commons/CommonConstants';
 import { GamePosition, ItemId } from '../commons/CommonTypes';
 import { Layer } from '../layer/GameLayerTypes';
 import GameGlobalAPI from '../scenes/gameManager/GameGlobalAPI';
+import SourceAcademyGame from '../SourceAcademyGame';
 import StringUtils from '../utils/StringUtils';
 import { createBitmapText } from '../utils/TextUtils';
 import DialogueConstants, { speakerTextStyle } from './GameDialogueConstants';
@@ -15,11 +16,6 @@ import DialogueConstants, { speakerTextStyle } from './GameDialogueConstants';
  */
 export default class DialogueSpeakerRenderer {
   private currentSpeakerId?: string;
-  private username: string;
-
-  constructor(username: string) {
-    this.username = username;
-  }
 
   /**
    * Changes the speaker shown in the speaker box and the speaker rendered on screen
@@ -53,7 +49,7 @@ export default class DialogueSpeakerRenderer {
   private drawSpeakerBox(speakerId: ItemId) {
     const speakerContainer =
       speakerId === 'you'
-        ? this.createSpeakerBox(this.username, GamePosition.Right)
+        ? this.createSpeakerBox(this.getUsername(), GamePosition.Right)
         : this.createSpeakerBox(
             GameGlobalAPI.getInstance().getCharacterById(speakerId).name,
             GamePosition.Left
@@ -100,4 +96,6 @@ export default class DialogueSpeakerRenderer {
     speakerText.text = StringUtils.capitalize(text);
     return container;
   }
+
+  public getUsername = () => SourceAcademyGame.getInstance().getAccountInfo().name;
 }

--- a/src/features/game/location/GameMap.ts
+++ b/src/features/game/location/GameMap.ts
@@ -117,7 +117,7 @@ class GameMap {
     return this.characters;
   }
 
-  public getActions(): Map<ItemId, GameAction> {
+  public getActionMap(): Map<ItemId, GameAction> {
     return this.actions;
   }
 

--- a/src/features/game/mode/menu/GameModeMenu.ts
+++ b/src/features/game/mode/menu/GameModeMenu.ts
@@ -27,7 +27,7 @@ class GameModeMenu implements IGameUI {
    */
   private getLatestLocationModes() {
     const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
-    let latestModesInLoc = GameGlobalAPI.getInstance().getModesByLocId(currLocId);
+    let latestModesInLoc = GameGlobalAPI.getInstance().getLocationModes(currLocId);
     const talkTopics = GameGlobalAPI.getInstance().getLocationAttr(
       GameItemType.talkTopics,
       currLocId

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -27,9 +27,6 @@ class GameObjectManager implements StateObserver {
   constructor() {
     this.observerId = 'GameObjectManager';
     this.objects = new Map<ItemId, ActivatableSprite>();
-  }
-
-  public initialise() {
     GameGlobalAPI.getInstance().subscribeState(this);
   }
 

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -1,13 +1,11 @@
 import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import GameGlobalAPI from 'src/features/game/scenes/gameManager/GameGlobalAPI';
-import GameManager from 'src/features/game/scenes/gameManager/GameManager';
 
 import { Constants } from '../commons/CommonConstants';
 import { ItemId } from '../commons/CommonTypes';
 import GlowingImage from '../effects/GlowingObject';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
-import { StateChangeType, StateObserver } from '../state/GameStateTypes';
-import { mandatory } from '../utils/GameUtils';
+import { StateObserver } from '../state/GameStateTypes';
 import { ActivatableSprite, ActivateSpriteCallbacks, ObjectProperty } from './GameObjectTypes';
 
 /**
@@ -21,44 +19,11 @@ import { ActivatableSprite, ActivateSpriteCallbacks, ObjectProperty } from './Ga
  * It is a subject/listener of GameStateManager.
  */
 class GameObjectManager implements StateObserver {
-  public observerId: string;
   private objects: Map<ItemId, ActivatableSprite>;
 
   constructor() {
-    this.observerId = 'GameObjectManager';
     this.objects = new Map<ItemId, ActivatableSprite>();
-    GameGlobalAPI.getInstance().subscribeState(this);
-  }
-
-  /**
-   * Part of observer pattern. Receives notification from GameStateManager.
-   *
-   * On notify, will rerender objects on the location to reflect
-   * the update to the state if applicable.
-   *
-   * @param changeType type of change
-   * @param locationId id of the location being updated
-   * @param id id of item being updated
-   */
-  public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
-      locationId,
-      GameItemType.objects
-    );
-    const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
-    if (hasUpdate && locationId === currLocationId) {
-      // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.objects);
-
-      // If the update is on the current location, we rerender to reflect the update
-      if (id) {
-        // If Id is provided, we only need to address the specific object
-        this.handleObjectChange(changeType, id);
-      } else {
-        // Else, rerender the whole layer
-        this.renderObjectsLayerContainer(locationId);
-      }
-    }
+    GameGlobalAPI.getInstance().watchGameItemType(GameItemType.objects, this);
   }
 
   /**
@@ -146,13 +111,10 @@ class GameObjectManager implements StateObserver {
    *               onOut?: (id?: ItemId) => void
    *             }
    *
-   * @param gameManager game manager
    * @param objectProperty object property to be used
    */
-  private createObject(
-    gameManager: GameManager,
-    objectProperty: ObjectProperty
-  ): ActivatableSprite {
+  private createObject(objectProperty: ObjectProperty): ActivatableSprite {
+    const gameManager = GameGlobalAPI.getInstance().getGameManager();
     const { assetKey, x, y, width, height, actionIds, interactionId } = objectProperty;
     const object = new GlowingImage(gameManager, x, y, assetKey, width, height);
 
@@ -183,44 +145,21 @@ class GameObjectManager implements StateObserver {
   }
 
   /**
-   * Handle change of a specific object ID.
-   *
-   * @param changeType type of change
-   * @param id id of affected object
-   */
-  private handleObjectChange(changeType: StateChangeType, id: ItemId) {
-    switch (changeType) {
-      case StateChangeType.Add:
-        return this.handleAdd(id);
-      case StateChangeType.Mutate:
-        return this.handleMutate(id);
-      case StateChangeType.Delete:
-        return this.handleDelete(id);
-    }
-  }
-
-  /**
    * Add the object, specified by the ID, into the scene
    * and keep track of it within the mapping.
    *
-   * Throws error if the object property is not available
-   * in the mapping.
-   *
    * @param id id of object
+   * @return {boolean} true if successful, false otherwise
    */
-  private handleAdd(id: ItemId) {
-    const gameManager = GameGlobalAPI.getInstance().getGameManager();
-    const objectPropMap = GameGlobalAPI.getInstance().getObjPropertyMap();
-
-    const objectProp = mandatory(objectPropMap.get(id));
-    const object = this.createObject(gameManager, objectProp);
+  public handleAdd(id: ItemId): boolean {
+    const objectProp = GameGlobalAPI.getInstance().getObjectById(id);
+    const object = this.createObject(objectProp);
     GameGlobalAPI.getInstance().addContainerToLayer(
       Layer.Objects,
       (object.sprite as GlowingImage).getContainer()
     );
     this.objects.set(id, object);
-
-    return object;
+    return true;
   }
 
   /**
@@ -230,10 +169,10 @@ class GameObjectManager implements StateObserver {
    * the updated property.
    *
    * @param id id of object
+   * @return {boolean} true if successful, false otherwise
    */
-  private handleMutate(id: ItemId) {
-    this.handleDelete(id);
-    this.handleAdd(id);
+  public handleMutate(id: ItemId): boolean {
+    return this.handleDelete(id) && this.handleAdd(id);
   }
 
   /**
@@ -241,10 +180,16 @@ class GameObjectManager implements StateObserver {
    * applicable.
    *
    * @param id id of the object
+   * @return {boolean} true if successful, false otherwise
    */
-  private handleDelete(id: ItemId) {
+  public handleDelete(id: ItemId): boolean {
     const object = this.objects.get(id);
-    if (object) (object.sprite as GlowingImage).getContainer().destroy();
+    if (object) {
+      this.objects.delete(id);
+      (object.sprite as GlowingImage).getContainer().destroy();
+      return true;
+    }
+    return false;
   }
 }
 

--- a/src/features/game/parser/DialogueParser.ts
+++ b/src/features/game/parser/DialogueParser.ts
@@ -42,6 +42,10 @@ export default class DialogueParser {
     const content = this.parseDialogueContent(dialogueBody);
     const dialogue: Dialogue = { title, content };
 
+    if (!dialogue.title) {
+      dialogue.title = StringUtils.toCapitalizedWords(dialogueId);
+    }
+
     Parser.checkpoint.map.setItemInMap(GameItemType.dialogues, dialogueId, dialogue);
   }
 

--- a/src/features/game/save/GameSaveHelper.ts
+++ b/src/features/game/save/GameSaveHelper.ts
@@ -19,7 +19,7 @@ export function gameStateToJson(
 ): FullSaveState {
   const gameManager = GameGlobalAPI.getInstance().getGameManager();
   const gameStateManager = gameManager.getStateManager();
-  const userStateManager = gameManager.userStateManager;
+  const userStateManager = gameManager.getUserStateManager();
   const phaseManager = gameManager.phaseManager;
 
   return {

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -1,10 +1,13 @@
 import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import { GameMode } from 'src/features/game/mode/GameModeTypes';
 
+import { GameAction } from '../../action/GameActionTypes';
 import { SoundAsset } from '../../assets/AssetsTypes';
 import { BBoxProperty } from '../../boundingBoxes/GameBoundingBoxTypes';
+import { Character } from '../../character/GameCharacterTypes';
 import { GamePosition, ItemId } from '../../commons/CommonTypes';
 import { AssetKey } from '../../commons/CommonTypes';
+import { Dialogue } from '../../dialogue/GameDialogueTypes';
 import { displayNotification } from '../../effects/Notification';
 import { GameItemType, GameLocation, LocationId } from '../../location/GameMapTypes';
 import { ActivateSpriteCallbacks, ObjectProperty } from '../../objects/GameObjectTypes';
@@ -57,12 +60,16 @@ class GameGlobalAPI {
     return this.getGameManager().getStateManager().getGameMap().getLocationAtId(locationId);
   }
 
+  public async changeLocationTo(locationName: string) {
+    await this.getGameManager().changeLocationTo(locationName);
+  }
+
   /////////////////////
   //    Game Mode    //
   /////////////////////
 
-  public getModesByLocId(locationId: LocationId): GameMode[] {
-    return this.getGameManager().getStateManager().getLocationMode(locationId);
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return this.getGameManager().getStateManager().getLocationModes(locationId);
   }
 
   public addLocationMode(locationId: LocationId, mode: GameMode): void {
@@ -71,22 +78,6 @@ class GameGlobalAPI {
 
   public removeLocationMode(locationId: LocationId, mode: GameMode): void {
     this.getGameManager().getStateManager().removeLocationMode(locationId, mode);
-  }
-
-  /////////////////////
-  //  Game Locations //
-  /////////////////////
-
-  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
-    return this.getGameManager().getStateManager().hasLocationUpdateAttr(locationId, attr);
-  }
-
-  public hasLocationUpdateMode(locationId: LocationId, mode?: GameMode): boolean | undefined {
-    return this.getGameManager().getStateManager().hasLocationUpdateMode(locationId, mode);
-  }
-
-  public async changeLocationTo(locationName: string) {
-    await this.getGameManager().changeLocationTo(locationName);
   }
 
   /////////////////////
@@ -106,35 +97,27 @@ class GameGlobalAPI {
   }
 
   /////////////////////
-  //    Game Attr    //
+  //    Game Items   //
   /////////////////////
+
+  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
+    this.getGameManager().getStateManager().watchGameItemType(gameItemType, stateObserver);
+  }
 
   public getGameMap() {
     return this.getGameManager().getStateManager().getGameMap();
   }
 
-  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
-    return this.getGameManager().getStateManager().consumedLocationUpdate(locationId, attr);
+  public getLocationAttr(gameItemType: GameItemType, locationId: LocationId): ItemId[] {
+    return this.getGameManager().getStateManager().getLocationAttr(gameItemType, locationId);
   }
 
-  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
-    return this.getGameManager().getStateManager().getLocationAttr(attr, locationId);
+  public addItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId): void {
+    this.getGameManager().getStateManager().addItem(gameItemType, locationId, itemId);
   }
 
-  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
-    this.getGameManager().getStateManager().addLocationAttr(attr, locationId, attrElem);
-  }
-
-  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
-    return this.getGameManager().getStateManager().removeLocationAttr(attr, locationId, attrElem);
-  }
-
-  public subscribeState(observer: StateObserver) {
-    this.getGameManager().getStateManager().subscribe(observer);
-  }
-
-  public unsubscribeState(observer: StateObserver) {
-    this.getGameManager().getStateManager().unsubscribe(observer);
+  public removeItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId): void {
+    return this.getGameManager().getStateManager().removeItem(gameItemType, locationId, itemId);
   }
 
   /////////////////////
@@ -147,10 +130,6 @@ class GameGlobalAPI {
 
   public makeObjectBlink(objectId: ItemId, turnOn: boolean) {
     this.getGameManager().getObjectManager().makeObjectBlink(objectId, turnOn);
-  }
-
-  public getObjPropertyMap() {
-    return this.getGameManager().getStateManager().getObjPropertyMap();
   }
 
   public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
@@ -168,10 +147,6 @@ class GameGlobalAPI {
   /////////////////////
   //    Game BBox    //
   /////////////////////
-
-  public getBBoxPropertyMap() {
-    return this.getGameManager().getStateManager().getBBoxPropertyMap();
-  }
 
   public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
     this.getGameManager().getStateManager().setBBoxProperty(id, newBBoxProp);
@@ -417,16 +392,24 @@ class GameGlobalAPI {
   //  Item retrieval //
   /////////////////////
 
-  public getDialogueById(dialogueId: ItemId) {
+  public getDialogueById(dialogueId: ItemId): Dialogue {
     return mandatory(this.getGameMap().getDialogueMap().get(dialogueId));
   }
 
-  public getCharacterById(characterId: ItemId) {
+  public getCharacterById(characterId: ItemId): Character {
     return mandatory(this.getGameMap().getCharacterMap().get(characterId));
   }
 
-  public getActionById(actionId: ItemId) {
+  public getActionById(actionId: ItemId): GameAction {
     return mandatory(this.getGameMap().getActionMap().get(actionId));
+  }
+
+  public getObjectById(objectId: ItemId): ObjectProperty {
+    return mandatory(this.getGameMap().getObjectPropMap().get(objectId));
+  }
+
+  public getBBoxById(bboxId: ItemId): BBoxProperty {
+    return mandatory(this.getGameMap().getBBoxPropMap().get(bboxId));
   }
 }
 

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -142,11 +142,11 @@ class GameGlobalAPI {
   /////////////////////
 
   public makeObjectGlow(objectId: ItemId, turnOn: boolean) {
-    this.getGameManager().objectManager.makeObjectGlow(objectId, turnOn);
+    this.getGameManager().getObjectManager().makeObjectGlow(objectId, turnOn);
   }
 
   public makeObjectBlink(objectId: ItemId, turnOn: boolean) {
-    this.getGameManager().objectManager.makeObjectBlink(objectId, turnOn);
+    this.getGameManager().getObjectManager().makeObjectBlink(objectId, turnOn);
   }
 
   public getObjPropertyMap() {
@@ -158,11 +158,11 @@ class GameGlobalAPI {
   }
 
   public enableObjectAction(callbacks: ActivateSpriteCallbacks) {
-    this.getGameManager().objectManager.enableObjectAction(callbacks);
+    this.getGameManager().getObjectManager().enableObjectAction(callbacks);
   }
 
   public disableObjectAction() {
-    this.getGameManager().objectManager.disableObjectAction();
+    this.getGameManager().getObjectManager().disableObjectAction();
   }
 
   /////////////////////
@@ -178,11 +178,11 @@ class GameGlobalAPI {
   }
 
   public enableBBoxAction(callbacks: ActivateSpriteCallbacks) {
-    this.getGameManager().boundingBoxManager.enableBBoxAction(callbacks);
+    this.getGameManager().getBBoxManager().enableBBoxAction(callbacks);
   }
 
   public disableBBoxAction() {
-    this.getGameManager().boundingBoxManager.disableBBoxAction();
+    this.getGameManager().getBBoxManager().disableBBoxAction();
   }
 
   /////////////////////
@@ -210,11 +210,11 @@ class GameGlobalAPI {
   /////////////////////
 
   public addToUserStateList(listName: UserStateTypes, id: string): void {
-    this.getGameManager().userStateManager.addToList(listName, id);
+    this.getGameManager().getUserStateManager().addToList(listName, id);
   }
 
   public async existsInUserStateList(listName: UserStateTypes, id: string): Promise<boolean> {
-    return await this.getGameManager().userStateManager.doesIdExistInList(listName, id);
+    return await this.getGameManager().getUserStateManager().doesIdExistInList(listName, id);
   }
 
   /////////////////////
@@ -259,12 +259,12 @@ class GameGlobalAPI {
 
   public async processGameActions(actionIds: ItemId[] | undefined) {
     await this.getGameManager().phaseManager.pushPhase(GamePhaseType.Sequence);
-    await this.getGameManager().actionManager.processGameActions(actionIds);
+    await this.getGameManager().getActionManager().processGameActions(actionIds);
     await this.getGameManager().phaseManager.popPhase();
   }
 
   public async processGameActionsInSamePhase(actionIds: ItemId[] | undefined) {
-    await this.getGameManager().actionManager.processGameActions(actionIds);
+    await this.getGameManager().getActionManager().processGameActions(actionIds);
   }
 
   /////////////////////
@@ -273,16 +273,12 @@ class GameGlobalAPI {
 
   public async showDialogue(dialogueId: ItemId) {
     await this.getGameManager().phaseManager.pushPhase(GamePhaseType.Sequence);
-    await this.getGameManager().dialogueManager.showDialogue(dialogueId);
+    await this.getGameManager().getDialogueManager().showDialogue(dialogueId);
     await this.getGameManager().phaseManager.popPhase();
   }
 
   public async showDialogueInSamePhase(dialogueId: ItemId) {
-    await this.getGameManager().dialogueManager.showDialogue(dialogueId);
-  }
-
-  public getDialogueById(dialogueId: ItemId) {
-    return mandatory(this.getGameMap().getDialogueMap().get(dialogueId));
+    await this.getGameManager().getDialogueManager().showDialogue(dialogueId);
   }
 
   /////////////////////
@@ -290,7 +286,9 @@ class GameGlobalAPI {
   /////////////////////
 
   public async obtainCollectible(collectibleId: string) {
-    this.getGameManager().userStateManager.addToList(UserStateTypes.collectibles, collectibleId);
+    this.getGameManager()
+      .getUserStateManager()
+      .addToList(UserStateTypes.collectibles, collectibleId);
   }
 
   /////////////////////
@@ -410,15 +408,25 @@ class GameGlobalAPI {
     overrideExpression?: string,
     overridePosition?: GamePosition
   ) {
-    return this.getGameManager().characterManager.createCharacterSprite(
-      characterId,
-      overrideExpression,
-      overridePosition
-    );
+    return this.getGameManager()
+      .getCharacterManager()
+      .createCharacterSprite(characterId, overrideExpression, overridePosition);
+  }
+
+  /////////////////////
+  //  Item retrieval //
+  /////////////////////
+
+  public getDialogueById(dialogueId: ItemId) {
+    return mandatory(this.getGameMap().getDialogueMap().get(dialogueId));
   }
 
   public getCharacterById(characterId: ItemId) {
     return mandatory(this.getGameMap().getCharacterMap().get(characterId));
+  }
+
+  public getActionById(actionId: ItemId) {
+    return mandatory(this.getGameMap().getActionMap().get(actionId));
   }
 }
 

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -171,20 +171,22 @@ class GameManager extends Phaser.Scene {
 
     await this.phaseManager.swapPhase(GamePhaseType.Sequence);
 
-    // Execute start actions, notif, then cutscene
-    await this.getActionManager().fastForwardGameActions(
-      this.getStateManager().getTriggeredActions()
-    );
-
-    // Execute start actions, notif, then cutscene
     if (startAction) {
+      // Execute fast forward actions
+      await this.getActionManager().fastForwardGameActions(
+        this.getStateManager().getTriggeredActions()
+      );
+      // Execute start actions, notif, then cutscene
       await this.getActionManager().processGameActions(
         this.getStateManager().getGameMap().getCheckpointCompleteActions()
       );
     }
+
     if (!this.getStateManager().hasTriggeredInteraction(locationId)) {
       await GameGlobalAPI.getInstance().bringUpUpdateNotif(gameLocation.name);
+      this.getStateManager().removeLocationNotif(locationId);
     }
+
     await this.getActionManager().processGameActions(gameLocation.actionIds);
 
     await this.phaseManager.swapPhase(GamePhaseType.Menu);

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -48,12 +48,12 @@ class GameManager extends Phaser.Scene {
 
   public stateManager?: GameStateManager;
   public layerManager: GameLayerManager;
-  public objectManager: GameObjectManager;
-  public characterManager: GameCharacterManager;
-  public dialogueManager: GameDialogueManager;
-  public actionManager: GameActionManager;
-  public userStateManager: GameUserStateManager;
-  public boundingBoxManager: GameBBoxManager;
+  public objectManager?: GameObjectManager;
+  public characterManager?: GameCharacterManager;
+  public dialogueManager?: GameDialogueManager;
+  public actionManager?: GameActionManager;
+  public userStateManager?: GameUserStateManager;
+  public boundingBoxManager?: GameBBoxManager;
   public popUpManager: GamePopUpManager;
   public saveManager?: GameSaveManager;
   public escapeManager: GameEscapeManager;
@@ -67,12 +67,6 @@ class GameManager extends Phaser.Scene {
     this.currentLocationId = Constants.nullInteractionId;
 
     this.layerManager = new GameLayerManager();
-    this.characterManager = new GameCharacterManager();
-    this.objectManager = new GameObjectManager();
-    this.dialogueManager = new GameDialogueManager();
-    this.actionManager = new GameActionManager();
-    this.userStateManager = new GameUserStateManager();
-    this.boundingBoxManager = new GameBBoxManager();
     this.popUpManager = new GamePopUpManager();
     this.escapeManager = new GameEscapeManager();
     this.phaseManager = new GamePhaseManager();
@@ -82,6 +76,7 @@ class GameManager extends Phaser.Scene {
   }
 
   public init({ gameCheckpoint, continueGame, chapterNum, checkpointNum }: GameManagerProps) {
+    GameGlobalAPI.getInstance().setGameManager(this);
     SourceAcademyGame.getInstance().setCurrentSceneRef(this);
     SourceAcademyGame.getInstance()
       .getSaveManager()
@@ -109,19 +104,11 @@ class GameManager extends Phaser.Scene {
   //////////////////////
 
   public preload() {
-    GameGlobalAPI.getInstance().setGameManager(this);
     addLoadingScreen(this);
-
     this.currentLocationId = this.getSaveManager().getLoadedLocation() || this.currentLocationId;
-    this.userStateManager.initialise();
-    this.dialogueManager.initialise();
-    this.characterManager.initialise();
-    this.actionManager.initialise(this);
     this.inputManager.initialise(this);
-    this.boundingBoxManager.initialise();
-    this.objectManager.initialise();
     this.layerManager.initialise(this);
-    this.awardsManager.initialise(this, this.userStateManager, this.phaseManager);
+    this.awardsManager.initialise(this, this.getUserStateManager(), this.phaseManager);
     this.phaseManager.initialise(
       createGamePhases(this.escapeManager, this.awardsManager),
       this.inputManager
@@ -151,8 +138,8 @@ class GameManager extends Phaser.Scene {
   //////////////////////
 
   public async create() {
-    await this.userStateManager.loadAssessments();
-    await this.userStateManager.loadAchievements();
+    await this.getUserStateManager().loadAssessments();
+    await this.getUserStateManager().loadAchievements();
     await this.changeLocationTo(this.currentLocationId, true);
     await GameGlobalAPI.getInstance().saveGame();
   }
@@ -177,26 +164,28 @@ class GameManager extends Phaser.Scene {
 
     // Render all assets related to the location
     this.backgroundManager.renderBackgroundLayerContainer(locationId);
-    this.objectManager.renderObjectsLayerContainer(locationId);
-    this.boundingBoxManager.renderBBoxLayerContainer(locationId);
-    this.characterManager.renderCharacterLayerContainer(locationId);
+    this.getObjectManager().renderObjectsLayerContainer(locationId);
+    this.getBBoxManager().renderBBoxLayerContainer(locationId);
+    this.getCharacterManager().renderCharacterLayerContainer(locationId);
     this.layerManager.showLayer(Layer.Character);
 
     await this.phaseManager.swapPhase(GamePhaseType.Sequence);
 
     // Execute start actions, notif, then cutscene
-    await this.actionManager.fastForwardGameActions(this.getStateManager().getTriggeredActions());
+    await this.getActionManager().fastForwardGameActions(
+      this.getStateManager().getTriggeredActions()
+    );
 
     // Execute start actions, notif, then cutscene
     if (startAction) {
-      await this.actionManager.processGameActions(
+      await this.getActionManager().processGameActions(
         this.getStateManager().getGameMap().getCheckpointCompleteActions()
       );
     }
     if (!this.getStateManager().hasTriggeredInteraction(locationId)) {
       await GameGlobalAPI.getInstance().bringUpUpdateNotif(gameLocation.name);
     }
-    await this.actionManager.processGameActions(gameLocation.actionIds);
+    await this.getActionManager().processGameActions(gameLocation.actionIds);
 
     await this.phaseManager.swapPhase(GamePhaseType.Menu);
   }
@@ -278,7 +267,7 @@ class GameManager extends Phaser.Scene {
 
     // Transition to the next scene if possible
     if (transitionToNextCheckpoint) {
-      await this.actionManager.processGameActions(
+      await this.getActionManager().processGameActions(
         this.getStateManager().getGameMap().getCheckpointCompleteActions()
       );
       this.cleanUp();
@@ -289,6 +278,13 @@ class GameManager extends Phaser.Scene {
 
   public getSaveManager = () => SourceAcademyGame.getInstance().getSaveManager();
   public getStateManager = () => mandatory(this.stateManager);
+
+  public getUserStateManager = () => mandatory(this.userStateManager);
+  public getObjectManager = () => mandatory(this.objectManager);
+  public getDialogueManager = () => mandatory(this.dialogueManager);
+  public getCharacterManager = () => mandatory(this.characterManager);
+  public getBBoxManager = () => mandatory(this.boundingBoxManager);
+  public getActionManager = () => mandatory(this.actionManager);
 }
 
 export default GameManager;

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -1,5 +1,6 @@
 import { BBoxProperty } from '../boundingBoxes/GameBoundingBoxTypes';
 import { GameCheckpoint } from '../chapter/GameChapterTypes';
+import { Character } from '../character/GameCharacterTypes';
 import { ItemId } from '../commons/CommonTypes';
 import GameMap from '../location/GameMap';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
@@ -9,7 +10,8 @@ import { ObjectProperty } from '../objects/GameObjectTypes';
 import { convertMapToArray } from '../save/GameSaveHelper';
 import GameGlobalAPI from '../scenes/gameManager/GameGlobalAPI';
 import SourceAcademyGame from '../SourceAcademyGame';
-import { StateChangeType, StateObserver, StateSubject } from './GameStateTypes';
+import { mandatory } from '../utils/GameUtils';
+import { StateObserver } from './GameStateTypes';
 
 /**
  * Manages all states related to story, chapter, or checkpoint;
@@ -20,31 +22,31 @@ import { StateChangeType, StateObserver, StateSubject } from './GameStateTypes';
  *
  * Employs observer pattern, and notifies its subjects on state update.
  */
-class GameStateManager implements StateSubject {
+
+class GameStateManager {
   // Subscribers
-  public subscribers: Array<StateObserver>;
+  private subscribers: Map<GameItemType, StateObserver>;
 
   // Game State
   private gameMap: GameMap;
   private checkpointObjective: GameObjective;
 
   // Triggered Interactions
-  private locationHasUpdate: Map<string, Map<GameItemType, boolean>>;
+  private updatedLocations: Set<LocationId>;
   private triggeredInteractions: Map<ItemId, boolean>;
   private triggeredActions: ItemId[];
 
   constructor(gameCheckpoint: GameCheckpoint) {
-    this.subscribers = new Array<StateObserver>();
+    this.subscribers = new Map<GameItemType, StateObserver>();
 
     this.gameMap = gameCheckpoint.map;
     this.checkpointObjective = gameCheckpoint.objectives;
 
-    this.locationHasUpdate = new Map<string, Map<GameItemType, boolean>>();
+    this.updatedLocations = new Set<LocationId>();
     this.triggeredInteractions = new Map<ItemId, boolean>();
     this.triggeredActions = [];
 
     this.loadStatesFromSaveManager();
-    this.registerAllItems();
   }
 
   /**
@@ -64,110 +66,27 @@ class GameStateManager implements StateSubject {
       .forEach(objective => this.checkpointObjective.setObjective(objective, true));
   }
 
-  /**
-   * Register every attribute of each location under the chapter
-   */
-  private registerAllItems() {
-    this.gameMap.getLocations().forEach((_location, locationId) => {
-      this.locationHasUpdate.set(locationId, new Map<GameItemType, boolean>());
-      Object.values(GameItemType).forEach(value =>
-        this.locationHasUpdate.get(locationId)!.set(value, false)
-      );
-    });
-  }
-
   ///////////////////////////////
   //        Subscribers        //
   ///////////////////////////////
 
   /**
-   * Update all subscribers that there is an update at the location ID.
+   * This function is called to set state observers
    *
-   * @param changeType type of change
-   * @param locationId ID of location that has an update.
-   * @param id id of item related to the update
+   * @param gameItemType Type of game item the observer wants to watch
+   * @param stateObserver reference to state observer
    */
-  public update(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    this.subscribers.forEach(observer => observer.notify(changeType, locationId, id));
+  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
+    this.subscribers.set(gameItemType, stateObserver);
   }
 
   /**
-   * Allow a StateObserver implementer to subscribe to change of states.
+   * Obtains the subscriber that watches the game item
    *
-   * @param observer the instance of the implementer
+   * @param gameItemType the type of item being watched
    */
-  public subscribe(observer: StateObserver) {
-    this.subscribers.push(observer);
-  }
-
-  /**
-   * Allow a StateObserver implementer to unsubscribe to change of states.
-   *
-   * @param observer the instance of the implementer
-   */
-  public unsubscribe(observer: StateObserver) {
-    this.subscribers = this.subscribers.filter(obs => obs.observerId !== observer.observerId);
-  }
-
-  ///////////////////////////////
-  //          Helpers          //
-  ///////////////////////////////
-
-  /**
-   * Update a location ID's state based on its GameMode.
-   * Also notifies subjects.
-   *
-   * @param targetLocId the id of to be upDated location
-   * @param mode mode that has been updated
-   */
-  private updateLocationStateMode(
-    changeType: StateChangeType,
-    targetLocId: LocationId,
-    mode: GameMode
-  ): void {
-    switch (mode) {
-      case GameMode.Explore:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.boundingBoxes);
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.objects);
-        return;
-      case GameMode.Move:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.navigation);
-        return;
-      case GameMode.Talk:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.talkTopics);
-        return;
-      default:
-        return;
-    }
-  }
-
-  /**
-   * Update a location ID's state based on its attribute.
-   * Also notifies subjects.
-   *
-   * @param changeType type of change
-   * @param targetLocId the id of to be upDated location
-   * @param attr attribute that has been updated
-   * @param attrId id of the attribute element being added
-   */
-  private updateLocationStateAttr(
-    changeType: StateChangeType,
-    targetLocId: LocationId,
-    attr: GameItemType,
-    attrId?: string
-  ): void {
-    const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
-
-    this.locationHasUpdate.get(targetLocId)!.set(attr, true);
-
-    // Only update if player is not already at the location
-    if (currLocId !== targetLocId) {
-      // Location has an update to its state, reset its interaction back to not triggered
-      this.triggeredInteractions.set(targetLocId, false);
-    }
-
-    // Notify subscribers
-    this.update(changeType, targetLocId, attrId);
+  public getSubscriberForItemType(gameItemType: GameItemType) {
+    return mandatory(this.subscribers.get(gameItemType));
   }
 
   ///////////////////////////////
@@ -203,79 +122,38 @@ class GameStateManager implements StateSubject {
   }
 
   ///////////////////////////////
-  //       State Check         //
+  //          Notifs          //
   ///////////////////////////////
 
   /**
-   * Checks whether a location has any update based on the modes.
-   * A location has an update if any of its mode has been updated since
-   * last user interaction.
+   * Adds a location notification for a locationId
    *
-   * If the mode parameter is specified, only that specific mode is checked.
-   * If the mode parameter is not specified, update to any mode will return true.
-   *
-   * @param locationId location ID
-   * @param mode mode to check
-   * @returns {boolean}
+   * @param locationId locationId of location you want to add notif to
    */
-  public hasLocationUpdateMode(locationId: LocationId, mode?: GameMode): boolean | undefined {
-    if (mode) {
-      switch (mode) {
-        case GameMode.Explore:
-          this.hasLocationUpdateAttr(locationId, GameItemType.boundingBoxes);
-          this.hasLocationUpdateAttr(locationId, GameItemType.objects);
-          return;
-        case GameMode.Move:
-          this.hasLocationUpdateAttr(locationId, GameItemType.navigation);
-          return;
-        case GameMode.Talk:
-          this.hasLocationUpdateAttr(locationId, GameItemType.talkTopics);
-          return;
-        default:
-          return;
-      }
-    }
-    return this.hasLocationUpdateAttr(locationId);
+  public addLocationNotif(locationId: LocationId) {
+    this.updatedLocations.add(locationId);
   }
 
   /**
-   * Checks whether a location has any update based on the attributes.
-   * A location has an update if any of its attributes has been updated since
-   * last user interaction.
+   * Removes a location notification for a locationId
    *
-   * If the mode parameter is specified, only that specific mode is checked.
-   * If the mode parameter is not specified, update to any mode will return true.
-   *
-   * @param locationId location ID
-   * @param mode mode to check
-   * @returns {boolean}
+   * @param locationId locationId of location you want to remove notif of
    */
-  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
-    this.gameMap.checkLocationExists(locationId);
-    if (attr) {
-      return this.locationHasUpdate.get(locationId)!.get(attr);
-    }
-
-    // If no attr is specified, update to any attr will return true
-    let result = false;
-    const locationModeState = this.locationHasUpdate.get(locationId);
-    locationModeState!.forEach((hasUpdate, attr, map) => (result = result || hasUpdate));
-    return result;
+  public removeLocationNotif(locationId: LocationId) {
+    this.updatedLocations.delete(locationId);
   }
 
   /**
-   * Inform state manager that an attribute's update has been noted of.
+   * Function to check if current location is the given locationId
    *
-   * @param locationId location ID
-   * @param attr attribute which update has been consumed
+   * @param locationId locationId that you want to check whether is current one
    */
-  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
-    this.gameMap.checkLocationExists(locationId);
-    this.locationHasUpdate.get(locationId)!.set(attr, false);
+  public isCurrentLocation(locationId: LocationId) {
+    return locationId === GameGlobalAPI.getInstance().getCurrLocId();
   }
 
   ///////////////////////////////
-  //    Location Mode State    //
+  //       Location Mode       //
   ///////////////////////////////
 
   /**
@@ -284,7 +162,7 @@ class GameStateManager implements StateSubject {
    * @param locationId location ID
    * @returns {GameMode[]} game modes
    */
-  public getLocationMode(locationId: LocationId): GameMode[] {
+  public getLocationModes(locationId: LocationId): GameMode[] {
     return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
   }
 
@@ -295,70 +173,100 @@ class GameStateManager implements StateSubject {
    * @param mode game mode to add
    */
   public addLocationMode(locationId: LocationId, mode: GameMode) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    location.modes!.add(mode);
-    this.gameMap.getLocations().get(locationId)!.modes!.add(mode);
-    this.updateLocationStateMode(StateChangeType.Add, locationId, GameMode.Menu);
+    this.gameMap.getLocationAtId(locationId).modes.add(mode);
   }
 
   /**
    * Remove a mode from a location.
-   * If the mode is not present at the location, nothing
-   * will be executed.
    *
    * @param locationId location ID
    * @param mode game mode to remove
    */
   public removeLocationMode(locationId: LocationId, mode: GameMode) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    if (!location.modes) return;
-    location.modes.delete(mode);
-    this.updateLocationStateMode(StateChangeType.Delete, locationId, GameMode.Menu);
+    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
   }
 
   ///////////////////////////////
-  //    Location Attr State    //
+  //        State Check        //
   ///////////////////////////////
 
   /**
    * Get an IDs of an attribute of a location.
    *
-   * @param attr location attribute
+   * @param gameItemType location attribute
    * @param locationId id of location
-   * @param {ItemId[]}
+   * @returns {ItemId[]}
    */
-  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
-    const location = this.gameMap.getLocationAtId(locationId);
-    return Array.from(location[attr]) || [];
+  public getLocationAttr(gameItemType: GameItemType, locationId: LocationId): ItemId[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId)[gameItemType]) || [];
   }
 
   /**
    * Add an item ID to an attribute of the location.
    *
-   * @param attr attribute to add to
-   * @param locationId id of location
-   * @param attrElem item ID to be added
+   * @param gameItemType attribute to add to
+   * @param locationId id of location to add items to
+   * @param itemId item ID to be added
    */
-  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    if (!location[attr]) location[attr] = new Set([]);
-    location[attr].add(attrElem);
-    this.updateLocationStateAttr(StateChangeType.Add, locationId, attr, attrElem);
+  public addItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId) {
+    this.gameMap.getLocationAtId(locationId)[gameItemType].add(itemId);
+
+    this.isCurrentLocation(locationId)
+      ? this.getSubscriberForItemType(gameItemType).handleAdd(itemId)
+      : this.addLocationNotif(locationId);
   }
 
   /**
    * Remove an item ID from an attribute of the location.
    * If ID is not found within the attribute, nothing will be executed.
    *
-   * @param attr attribute to remove from
-   * @param locationId id of location
-   * @param attrElem item ID to be removed
+   * @param gameItemType attribute to remove from
+   * @param locationId id of location to remove items from
+   * @param itemId item ID to be removed
    */
-  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
+  public removeItem(gameItemType: GameItemType, locationId: LocationId, itemId: string) {
     const location = this.gameMap.getLocationAtId(locationId);
-    if (!location[attr]) return;
-    location[attr] = location[attr].filter((oldAttr: string) => oldAttr !== attrElem);
-    this.updateLocationStateAttr(StateChangeType.Delete, locationId, attr, attrElem);
+    location[gameItemType] = location[gameItemType].filter((oldItem: string) => oldItem !== itemId);
+
+    this.isCurrentLocation(locationId)
+      ? this.getSubscriberForItemType(gameItemType).handleDelete(itemId)
+      : this.addLocationNotif(locationId);
+  }
+
+  /**
+   * Replace an object property of the given ID with the new object
+   * property. Commonly used to update a specific object property.
+   *
+   * @param id id of object to change
+   * @param newObjProp new object property to replace the old one
+   */
+  public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
+    this.gameMap.setItemInMap(GameItemType.objects, id, newObjProp);
+    this.getSubscriberForItemType(GameItemType.objects).handleMutate(id);
+  }
+
+  /**
+   * Replace a bbox property of the given ID with the new bbox
+   * property. Commonly used to update a specific bbox property.
+   *
+   * @param id id of object to change
+   * @param newBBoxProp new object property to replace the old one
+   */
+  public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
+    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newBBoxProp);
+    this.getSubscriberForItemType(GameItemType.boundingBoxes).handleMutate(id);
+  }
+
+  /**
+   * Replace a character of the given ID with the new character
+   * property. Commonly used to update a specific character property.
+   *
+   * @param id id of object to change
+   * @param newCharacter new object property to replace the old one
+   */
+  public setCharacterProperty(id: ItemId, newCharacter: Character) {
+    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newCharacter);
+    this.getSubscriberForItemType(GameItemType.characters).handleMutate(id);
   }
 
   ///////////////////////////////
@@ -409,73 +317,6 @@ class GameStateManager implements StateSubject {
    */
   public completeObjective(key: string): void {
     this.checkpointObjective.setObjective(key, true);
-  }
-
-  ///////////////////////////////
-  //       Obj Property        //
-  ///////////////////////////////
-
-  /**
-   * Get object property map.
-   *
-   * @returns {Map<ItemId, ObjectProperty>}
-   */
-  public getObjPropertyMap() {
-    return this.gameMap.getObjectPropMap();
-  }
-
-  /**
-   * Replace an object property of the given ID with the new object
-   * property. Commonly used to update a specific object property.
-   *
-   * @param id id of object to change
-   * @param newObjProp new object property to replace the old one
-   */
-  public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
-    this.gameMap.setItemInMap(GameItemType.objects, id, newObjProp);
-
-    // Update every location that uses it
-    this.gameMap.getLocations().forEach((location, locationId) => {
-      if (location.objects && location.objects.has(id)) {
-        this.updateLocationStateAttr(StateChangeType.Mutate, locationId, GameItemType.objects, id);
-      }
-    });
-  }
-
-  ///////////////////////////////
-  //       BBox Property       //
-  ///////////////////////////////
-
-  /**
-   * Get bbox property map.
-   *
-   * @returns {Map<ItemId, BBoxProperty>}
-   */
-  public getBBoxPropertyMap() {
-    return this.gameMap.getBBoxPropMap();
-  }
-
-  /**
-   * Replace a bbox property of the given ID with the new bbox
-   * property. Commonly used to update a specific bbox property.
-   *
-   * @param id id of object to change
-   * @param newBBoxProp new object property to replace the old one
-   */
-  public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
-    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newBBoxProp);
-
-    // Update every location that uses it
-    this.gameMap.getLocations().forEach((location, locationId) => {
-      if (location.boundingBoxes && location.boundingBoxes.delete(id)) {
-        this.updateLocationStateAttr(
-          StateChangeType.Mutate,
-          locationId,
-          GameItemType.boundingBoxes,
-          id
-        );
-      }
-    });
   }
 
   ///////////////////////////////

--- a/src/features/game/state/GameStateTypes.ts
+++ b/src/features/game/state/GameStateTypes.ts
@@ -1,4 +1,4 @@
-import { LocationId } from '../location/GameMapTypes';
+import { ItemId } from '../commons/CommonTypes';
 
 export enum GameStateStorage {
   UserState = 'UserState',
@@ -22,28 +22,11 @@ export type UserState = {
 };
 
 /**
- * Represent the changes done to the state.
+ * State observer is a renderer that can reflect the changes
+ * to the current scene
  */
-export enum StateChangeType {
-  Add,
-  Mutate,
-  Delete
+export interface StateObserver {
+  handleAdd: (itemId: ItemId) => boolean;
+  handleDelete: (itemId: ItemId) => boolean;
+  handleMutate: (itemId: ItemId) => boolean;
 }
-
-/**
- * Observer pattern, the observer side.
- */
-export type StateObserver = {
-  observerId: string;
-  notify: (changeType: StateChangeType, locationId: LocationId, id?: string) => void;
-};
-
-/**
- * Observer pattern, the subject side.
- */
-export type StateSubject = {
-  subscribers: Array<StateObserver>;
-  update: (changeType: StateChangeType, locationId: LocationId, id?: string) => void;
-  subscribe: (observer: StateObserver) => void;
-  unsubscribe: (observer: StateObserver) => void;
-};


### PR DESCRIPTION
### Description

Many of the managers do not actually need initialise anymore to store their Property Maps since many of these can be found in GameStateManager, so we can construct them without initialising.

In Game Manager:
This removes all the initialise() in gameManager.preload(), and removes all the useless new Manager() calls in gameManager.constructor() [but adds the getManager() call below the code]

In Manager:
This removes many class properties stored in Managers and thus simplifies their construction process.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist

Please delete options that are not relevant.

- [ ] I have tested this code
- [ ] I have updated the documentation
