### PR TITLE
5. Simplify state manager

### DIFF
--- a/src/features/game/action/GameActionExecuter.ts
+++ b/src/features/game/action/GameActionExecuter.ts
@@ -22,10 +22,10 @@ export default class GameActionExecuter {
 
     switch (actionType) {
       case GameActionType.AddItem:
-        globalAPI.addLocationAttr(actionParams.attr, actionParams.locationId, actionParams.id);
+        globalAPI.addItem(actionParams.attr, actionParams.locationId, actionParams.id);
         return;
       case GameActionType.RemoveItem:
-        globalAPI.removeLocationAttr(actionParams.attr, actionParams.locationId, actionParams.id);
+        globalAPI.removeItem(actionParams.attr, actionParams.locationId, actionParams.id);
         return;
       case GameActionType.AddLocationMode:
         globalAPI.addLocationMode(actionParams.locationId, actionParams.mode);

--- a/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
+++ b/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
@@ -1,60 +1,22 @@
 import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import GameGlobalAPI from 'src/features/game/scenes/gameManager/GameGlobalAPI';
-import GameManager from 'src/features/game/scenes/gameManager/GameManager';
 
 import { Constants } from '../commons/CommonConstants';
 import { ItemId } from '../commons/CommonTypes';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
 import { ActivatableSprite, ActivateSpriteCallbacks } from '../objects/GameObjectTypes';
-import { StateChangeType, StateObserver } from '../state/GameStateTypes';
-import { mandatory } from '../utils/GameUtils';
+import { StateObserver } from '../state/GameStateTypes';
 import { BBoxProperty } from './GameBoundingBoxTypes';
 
 /**
  * Manager for rendering interactive bounding boxes in the location.
  */
 class GameBoundingBoxManager implements StateObserver {
-  public observerId: string;
   private bboxes: Map<ItemId, ActivatableSprite>;
 
   constructor() {
-    this.observerId = 'GameBoundingBoxManager';
     this.bboxes = new Map<ItemId, ActivatableSprite>();
-  }
-
-  public initialise() {
-    GameGlobalAPI.getInstance().subscribeState(this);
-  }
-
-  /**
-   * Part of observer pattern. Receives notification from GameStateManager.
-   *
-   * On notify, will rerender all the bounding boxes on the location to reflect
-   * the update to the state if applicable.
-   *
-   * @param changeType type of change
-   * @param locationId id of the location being updated
-   * @param id id of item being updated
-   */
-  public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
-      locationId,
-      GameItemType.boundingBoxes
-    );
-    const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
-    if (hasUpdate && locationId === currLocationId) {
-      // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.boundingBoxes);
-
-      // If the update is on the current location, we rerender to reflect the update
-      if (id) {
-        // If Id is provided, we only need to address the specific bbox
-        this.handleBBoxChange(changeType, id);
-      } else {
-        // Else, rerender the whole layer
-        this.renderBBoxLayerContainer(locationId);
-      }
-    }
+    GameGlobalAPI.getInstance().watchGameItemType(GameItemType.boundingBoxes, this);
   }
 
   /**
@@ -108,10 +70,10 @@ class GameBoundingBoxManager implements StateObserver {
    *               onOut?: (id?: ItemId) => void
    *             }
    *
-   * @param gameManager game manager
    * @param objectProperty object property to be used
    */
-  private createBBox(gameManager: GameManager, bboxProperty: BBoxProperty): ActivatableSprite {
+  private createBBox(bboxProperty: BBoxProperty): ActivatableSprite {
+    const gameManager = GameGlobalAPI.getInstance().getGameManager();
     const { x, y, width, height, actionIds, interactionId } = bboxProperty;
     const bboxSprite = new Phaser.GameObjects.Rectangle(gameManager, x, y, width, height, 0, 0);
     if (bboxProperty.isInteractive) {
@@ -145,23 +107,6 @@ class GameBoundingBoxManager implements StateObserver {
   }
 
   /**
-   * Handle change of a specific bbox ID.
-   *
-   * @param changeType type of change
-   * @param id id of affected bbox
-   */
-  private handleBBoxChange(changeType: StateChangeType, id: ItemId) {
-    switch (changeType) {
-      case StateChangeType.Add:
-        return this.handleAdd(id);
-      case StateChangeType.Mutate:
-        return this.handleMutate(id);
-      case StateChangeType.Delete:
-        return this.handleDelete(id);
-    }
-  }
-
-  /**
    * Add the bbox, specified by the ID, into the scene
    * and keep track of it within the mapping.
    *
@@ -170,18 +115,14 @@ class GameBoundingBoxManager implements StateObserver {
    *
    * @param id id of bbox
    */
-  private handleAdd(id: ItemId) {
-    const gameManager = GameGlobalAPI.getInstance().getGameManager();
-    const bboxPropMap = GameGlobalAPI.getInstance().getBBoxPropertyMap();
-
-    const bboxProp = mandatory(bboxPropMap.get(id));
-    const bbox = this.createBBox(gameManager, bboxProp);
+  public handleAdd(id: ItemId) {
+    const bboxProp = GameGlobalAPI.getInstance().getBBoxById(id);
+    const bbox = this.createBBox(bboxProp);
     GameGlobalAPI.getInstance().addContainerToLayer(
       Layer.BBox,
       bbox.sprite as Phaser.GameObjects.Rectangle
     );
     this.bboxes.set(id, bbox);
-
     return bbox;
   }
 
@@ -193,9 +134,10 @@ class GameBoundingBoxManager implements StateObserver {
    *
    * @param id id of bbox
    */
-  private handleMutate(id: ItemId) {
-    this.handleDelete(id);
-    this.handleAdd(id);
+  public handleMutate(id: ItemId) {
+    if (this.handleDelete(id)) {
+      this.handleAdd(id);
+    }
   }
 
   /**
@@ -204,9 +146,14 @@ class GameBoundingBoxManager implements StateObserver {
    *
    * @param id id of the bbox
    */
-  private handleDelete(id: ItemId) {
+  public handleDelete(id: ItemId): boolean {
     const bbox = this.bboxes.get(id);
-    if (bbox) (bbox.sprite as Phaser.GameObjects.Rectangle).destroy();
+    if (bbox) {
+      this.bboxes.delete(id);
+      (bbox.sprite as Phaser.GameObjects.Rectangle).destroy();
+      return true;
+    }
+    return false;
   }
 }
 

--- a/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
+++ b/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
@@ -36,7 +36,7 @@ class GameBoundingBoxManager implements StateObserver {
     this.bboxes.clear();
 
     // Add all the bbox
-    bboxIdsToRender.map(id => this.handleAdd(id));
+    bboxIdsToRender.forEach(id => this.handleAdd(id));
   }
 
   /**
@@ -114,8 +114,9 @@ class GameBoundingBoxManager implements StateObserver {
    * in the mapping.
    *
    * @param id id of bbox
+   * @return {boolean} true if successful, false otherwise
    */
-  public handleAdd(id: ItemId) {
+  public handleAdd(id: ItemId): boolean {
     const bboxProp = GameGlobalAPI.getInstance().getBBoxById(id);
     const bbox = this.createBBox(bboxProp);
     GameGlobalAPI.getInstance().addContainerToLayer(
@@ -123,7 +124,7 @@ class GameBoundingBoxManager implements StateObserver {
       bbox.sprite as Phaser.GameObjects.Rectangle
     );
     this.bboxes.set(id, bbox);
-    return bbox;
+    return true;
   }
 
   /**
@@ -133,11 +134,10 @@ class GameBoundingBoxManager implements StateObserver {
    * the updated property.
    *
    * @param id id of bbox
+   * @return {boolean} true if successful, false otherwise
    */
-  public handleMutate(id: ItemId) {
-    if (this.handleDelete(id)) {
-      this.handleAdd(id);
-    }
+  public handleMutate(id: ItemId): boolean {
+    return this.handleDelete(id) && this.handleAdd(id);
   }
 
   /**
@@ -145,6 +145,7 @@ class GameBoundingBoxManager implements StateObserver {
    * applicable.
    *
    * @param id id of the bbox
+   * @return {boolean} true if successful, false otherwise
    */
   public handleDelete(id: ItemId): boolean {
     const bbox = this.bboxes.get(id);

--- a/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
+++ b/src/features/game/boundingBoxes/GameBoundingBoxManager.ts
@@ -36,7 +36,7 @@ class GameBoundingBoxManager implements StateObserver {
     this.bboxes.clear();
 
     // Add all the bbox
-    bboxIdsToRender.forEach(id => this.handleAdd(id));
+    bboxIdsToRender.map(id => this.handleAdd(id));
   }
 
   /**

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -35,7 +35,7 @@ export default class CharacterManager implements StateObserver {
     this.characterSpriteMap.clear();
 
     // Add all the characters
-    idsToRender.forEach(id => this.handleAdd(id));
+    idsToRender.map(id => this.handleAdd(id));
   }
 
   /**

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -35,7 +35,7 @@ export default class CharacterManager implements StateObserver {
     this.characterSpriteMap.clear();
 
     // Add all the characters
-    idsToRender.map(id => this.handleAdd(id));
+    idsToRender.forEach(id => this.handleAdd(id));
   }
 
   /**
@@ -72,12 +72,14 @@ export default class CharacterManager implements StateObserver {
    * and keep track of it within the mapping.
    *
    * @param id id of character
+   * @return {boolean} true if successful, false otherwise
+
    */
-  public handleAdd(id: ItemId) {
+  public handleAdd(id: ItemId): boolean {
     const characterSprite = this.createCharacterSprite(id);
     GameGlobalAPI.getInstance().addContainerToLayer(Layer.Character, characterSprite);
     this.characterSpriteMap.set(id, characterSprite);
-    return characterSprite;
+    return true;
   }
 
   /**
@@ -86,18 +88,20 @@ export default class CharacterManager implements StateObserver {
    * Internally, will delete and re-add the character with
    * the updated property.
    *
-   * @param id id of characer
+   * @param id id of character
+   * @return {boolean} true if successful, false otherwise
+
    */
-  public handleMutate(id: ItemId) {
-    this.handleDelete(id);
-    this.handleAdd(id);
+  public handleMutate(id: ItemId): boolean {
+    return this.handleDelete(id) && this.handleAdd(id);
   }
 
   /**
    * Delete the character of the given id, if
    * applicable.
    *
-   * @param id id of the bbox
+   * @param id id of the character
+   *  @return {boolean} true if successful, false otherwise
    */
   public handleDelete(id: ItemId) {
     const char = this.characterSpriteMap.get(id);

--- a/src/features/game/character/GameCharacterManager.ts
+++ b/src/features/game/character/GameCharacterManager.ts
@@ -4,7 +4,7 @@ import { screenSize } from '../commons/CommonConstants';
 import { GamePosition, ItemId } from '../commons/CommonTypes';
 import { Layer } from '../layer/GameLayerTypes';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
-import { StateChangeType, StateObserver } from '../state/GameStateTypes';
+import { StateObserver } from '../state/GameStateTypes';
 import { resize } from '../utils/SpriteUtils';
 import CharConstants from './GameCharacterConstants';
 
@@ -12,44 +12,11 @@ import CharConstants from './GameCharacterConstants';
  * Manager for rendering characters in the location.
  */
 export default class CharacterManager implements StateObserver {
-  public observerId: string;
   private characterSpriteMap: Map<ItemId, Phaser.GameObjects.Image>;
 
   constructor() {
-    this.observerId = 'GameCharacterManager';
     this.characterSpriteMap = new Map<ItemId, Phaser.GameObjects.Image>();
-    GameGlobalAPI.getInstance().subscribeState(this);
-  }
-
-  /**
-   * Part of observer pattern. Receives notification from GameStateManager.
-   *
-   * On notify, will rerender all the characters on the location to reflect
-   * the update to the state if applicable.
-   *
-   * @param changeType type of change
-   * @param locationId id of the location being updated
-   * @param id id of item being updated
-   */
-  public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
-      locationId,
-      GameItemType.characters
-    );
-    const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
-    if (hasUpdate && locationId === currLocationId) {
-      // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.characters);
-
-      // If the update is on the current location, we rerender to reflect the update
-      if (id) {
-        // If Id is provided, we only need to address the specific character
-        this.handleCharacterChange(changeType, id);
-      } else {
-        // Else, rerender the whole layer
-        this.renderCharacterLayerContainer(locationId);
-      }
-    }
+    GameGlobalAPI.getInstance().watchGameItemType(GameItemType.characters, this);
   }
 
   /**
@@ -101,32 +68,12 @@ export default class CharacterManager implements StateObserver {
   }
 
   /**
-   * Handle change of a specific character ID.
-   *
-   * @param changeType type of change
-   * @param id id of affected character
-   */
-  private handleCharacterChange(changeType: StateChangeType, id: ItemId) {
-    switch (changeType) {
-      case StateChangeType.Add:
-        return this.handleAdd(id);
-      case StateChangeType.Mutate:
-        return this.handleMutate(id);
-      case StateChangeType.Delete:
-        return this.handleDelete(id);
-    }
-  }
-
-  /**
    * Add the character, specified by the ID, into the scene
    * and keep track of it within the mapping.
    *
-   * Throws error if the  character is not available
-   * in the mapping.
-   *
    * @param id id of character
    */
-  private handleAdd(id: ItemId) {
+  public handleAdd(id: ItemId) {
     const characterSprite = this.createCharacterSprite(id);
     GameGlobalAPI.getInstance().addContainerToLayer(Layer.Character, characterSprite);
     this.characterSpriteMap.set(id, characterSprite);
@@ -141,7 +88,7 @@ export default class CharacterManager implements StateObserver {
    *
    * @param id id of characer
    */
-  private handleMutate(id: ItemId) {
+  public handleMutate(id: ItemId) {
     this.handleDelete(id);
     this.handleAdd(id);
   }
@@ -152,8 +99,13 @@ export default class CharacterManager implements StateObserver {
    *
    * @param id id of the bbox
    */
-  private handleDelete(id: ItemId) {
+  public handleDelete(id: ItemId) {
     const char = this.characterSpriteMap.get(id);
-    if (char) char.destroy();
+    if (char) {
+      this.characterSpriteMap.delete(id);
+      char.destroy();
+      return true;
+    }
+    return false;
   }
 }

--- a/src/features/game/mode/menu/GameModeMenu.ts
+++ b/src/features/game/mode/menu/GameModeMenu.ts
@@ -27,7 +27,7 @@ class GameModeMenu implements IGameUI {
    */
   private getLatestLocationModes() {
     const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
-    let latestModesInLoc = GameGlobalAPI.getInstance().getModesByLocId(currLocId);
+    let latestModesInLoc = GameGlobalAPI.getInstance().getLocationModes(currLocId);
     const talkTopics = GameGlobalAPI.getInstance().getLocationAttr(
       GameItemType.talkTopics,
       currLocId

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -43,7 +43,7 @@ class GameObjectManager implements StateObserver {
     this.objects.clear();
 
     // Add all the objects
-    objIdsToRender.map(id => this.handleAdd(id));
+    objIdsToRender.forEach(id => this.handleAdd(id));
   }
 
   /**
@@ -149,8 +149,9 @@ class GameObjectManager implements StateObserver {
    * and keep track of it within the mapping.
    *
    * @param id id of object
+   * @return {boolean} true if successful, false otherwise
    */
-  public handleAdd(id: ItemId) {
+  public handleAdd(id: ItemId): boolean {
     const objectProp = GameGlobalAPI.getInstance().getObjectById(id);
     const object = this.createObject(objectProp);
     GameGlobalAPI.getInstance().addContainerToLayer(
@@ -158,7 +159,7 @@ class GameObjectManager implements StateObserver {
       (object.sprite as GlowingImage).getContainer()
     );
     this.objects.set(id, object);
-    return object;
+    return true;
   }
 
   /**
@@ -168,11 +169,10 @@ class GameObjectManager implements StateObserver {
    * the updated property.
    *
    * @param id id of object
+   * @return {boolean} true if successful, false otherwise
    */
-  public handleMutate(id: ItemId) {
-    if (this.handleDelete(id)) {
-      this.handleAdd(id);
-    }
+  public handleMutate(id: ItemId): boolean {
+    return this.handleDelete(id) && this.handleAdd(id);
   }
 
   /**
@@ -180,6 +180,7 @@ class GameObjectManager implements StateObserver {
    * applicable.
    *
    * @param id id of the object
+   * @return {boolean} true if successful, false otherwise
    */
   public handleDelete(id: ItemId): boolean {
     const object = this.objects.get(id);

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -43,7 +43,7 @@ class GameObjectManager implements StateObserver {
     this.objects.clear();
 
     // Add all the objects
-    objIdsToRender.forEach(id => this.handleAdd(id));
+    objIdsToRender.map(id => this.handleAdd(id));
   }
 
   /**

--- a/src/features/game/objects/GameObjectManager.ts
+++ b/src/features/game/objects/GameObjectManager.ts
@@ -1,13 +1,11 @@
 import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import GameGlobalAPI from 'src/features/game/scenes/gameManager/GameGlobalAPI';
-import GameManager from 'src/features/game/scenes/gameManager/GameManager';
 
 import { Constants } from '../commons/CommonConstants';
 import { ItemId } from '../commons/CommonTypes';
 import GlowingImage from '../effects/GlowingObject';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
-import { StateChangeType, StateObserver } from '../state/GameStateTypes';
-import { mandatory } from '../utils/GameUtils';
+import { StateObserver } from '../state/GameStateTypes';
 import { ActivatableSprite, ActivateSpriteCallbacks, ObjectProperty } from './GameObjectTypes';
 
 /**
@@ -21,44 +19,11 @@ import { ActivatableSprite, ActivateSpriteCallbacks, ObjectProperty } from './Ga
  * It is a subject/listener of GameStateManager.
  */
 class GameObjectManager implements StateObserver {
-  public observerId: string;
   private objects: Map<ItemId, ActivatableSprite>;
 
   constructor() {
-    this.observerId = 'GameObjectManager';
     this.objects = new Map<ItemId, ActivatableSprite>();
-    GameGlobalAPI.getInstance().subscribeState(this);
-  }
-
-  /**
-   * Part of observer pattern. Receives notification from GameStateManager.
-   *
-   * On notify, will rerender objects on the location to reflect
-   * the update to the state if applicable.
-   *
-   * @param changeType type of change
-   * @param locationId id of the location being updated
-   * @param id id of item being updated
-   */
-  public notify(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    const hasUpdate = GameGlobalAPI.getInstance().hasLocationUpdateAttr(
-      locationId,
-      GameItemType.objects
-    );
-    const currLocationId = GameGlobalAPI.getInstance().getCurrLocId();
-    if (hasUpdate && locationId === currLocationId) {
-      // Inform state manager that update has been consumed
-      GameGlobalAPI.getInstance().consumedLocationUpdate(locationId, GameItemType.objects);
-
-      // If the update is on the current location, we rerender to reflect the update
-      if (id) {
-        // If Id is provided, we only need to address the specific object
-        this.handleObjectChange(changeType, id);
-      } else {
-        // Else, rerender the whole layer
-        this.renderObjectsLayerContainer(locationId);
-      }
-    }
+    GameGlobalAPI.getInstance().watchGameItemType(GameItemType.objects, this);
   }
 
   /**
@@ -146,13 +111,10 @@ class GameObjectManager implements StateObserver {
    *               onOut?: (id?: ItemId) => void
    *             }
    *
-   * @param gameManager game manager
    * @param objectProperty object property to be used
    */
-  private createObject(
-    gameManager: GameManager,
-    objectProperty: ObjectProperty
-  ): ActivatableSprite {
+  private createObject(objectProperty: ObjectProperty): ActivatableSprite {
+    const gameManager = GameGlobalAPI.getInstance().getGameManager();
     const { assetKey, x, y, width, height, actionIds, interactionId } = objectProperty;
     const object = new GlowingImage(gameManager, x, y, assetKey, width, height);
 
@@ -183,43 +145,19 @@ class GameObjectManager implements StateObserver {
   }
 
   /**
-   * Handle change of a specific object ID.
-   *
-   * @param changeType type of change
-   * @param id id of affected object
-   */
-  private handleObjectChange(changeType: StateChangeType, id: ItemId) {
-    switch (changeType) {
-      case StateChangeType.Add:
-        return this.handleAdd(id);
-      case StateChangeType.Mutate:
-        return this.handleMutate(id);
-      case StateChangeType.Delete:
-        return this.handleDelete(id);
-    }
-  }
-
-  /**
    * Add the object, specified by the ID, into the scene
    * and keep track of it within the mapping.
    *
-   * Throws error if the object property is not available
-   * in the mapping.
-   *
    * @param id id of object
    */
-  private handleAdd(id: ItemId) {
-    const gameManager = GameGlobalAPI.getInstance().getGameManager();
-    const objectPropMap = GameGlobalAPI.getInstance().getObjPropertyMap();
-
-    const objectProp = mandatory(objectPropMap.get(id));
-    const object = this.createObject(gameManager, objectProp);
+  public handleAdd(id: ItemId) {
+    const objectProp = GameGlobalAPI.getInstance().getObjectById(id);
+    const object = this.createObject(objectProp);
     GameGlobalAPI.getInstance().addContainerToLayer(
       Layer.Objects,
       (object.sprite as GlowingImage).getContainer()
     );
     this.objects.set(id, object);
-
     return object;
   }
 
@@ -231,9 +169,10 @@ class GameObjectManager implements StateObserver {
    *
    * @param id id of object
    */
-  private handleMutate(id: ItemId) {
-    this.handleDelete(id);
-    this.handleAdd(id);
+  public handleMutate(id: ItemId) {
+    if (this.handleDelete(id)) {
+      this.handleAdd(id);
+    }
   }
 
   /**
@@ -242,9 +181,14 @@ class GameObjectManager implements StateObserver {
    *
    * @param id id of the object
    */
-  private handleDelete(id: ItemId) {
+  public handleDelete(id: ItemId): boolean {
     const object = this.objects.get(id);
-    if (object) (object.sprite as GlowingImage).getContainer().destroy();
+    if (object) {
+      this.objects.delete(id);
+      (object.sprite as GlowingImage).getContainer().destroy();
+      return true;
+    }
+    return false;
   }
 }
 

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -1,10 +1,13 @@
 import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import { GameMode } from 'src/features/game/mode/GameModeTypes';
 
+import { GameAction } from '../../action/GameActionTypes';
 import { SoundAsset } from '../../assets/AssetsTypes';
 import { BBoxProperty } from '../../boundingBoxes/GameBoundingBoxTypes';
+import { Character } from '../../character/GameCharacterTypes';
 import { GamePosition, ItemId } from '../../commons/CommonTypes';
 import { AssetKey } from '../../commons/CommonTypes';
+import { Dialogue } from '../../dialogue/GameDialogueTypes';
 import { displayNotification } from '../../effects/Notification';
 import { GameItemType, GameLocation, LocationId } from '../../location/GameMapTypes';
 import { ActivateSpriteCallbacks, ObjectProperty } from '../../objects/GameObjectTypes';
@@ -57,12 +60,16 @@ class GameGlobalAPI {
     return this.getGameManager().getStateManager().getGameMap().getLocationAtId(locationId);
   }
 
+  public async changeLocationTo(locationName: string) {
+    await this.getGameManager().changeLocationTo(locationName);
+  }
+
   /////////////////////
   //    Game Mode    //
   /////////////////////
 
-  public getModesByLocId(locationId: LocationId): GameMode[] {
-    return this.getGameManager().getStateManager().getLocationMode(locationId);
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return this.getGameManager().getStateManager().getLocationModes(locationId);
   }
 
   public addLocationMode(locationId: LocationId, mode: GameMode): void {
@@ -71,22 +78,6 @@ class GameGlobalAPI {
 
   public removeLocationMode(locationId: LocationId, mode: GameMode): void {
     this.getGameManager().getStateManager().removeLocationMode(locationId, mode);
-  }
-
-  /////////////////////
-  //  Game Locations //
-  /////////////////////
-
-  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
-    return this.getGameManager().getStateManager().hasLocationUpdateAttr(locationId, attr);
-  }
-
-  public hasLocationUpdateMode(locationId: LocationId, mode?: GameMode): boolean | undefined {
-    return this.getGameManager().getStateManager().hasLocationUpdateMode(locationId, mode);
-  }
-
-  public async changeLocationTo(locationName: string) {
-    await this.getGameManager().changeLocationTo(locationName);
   }
 
   /////////////////////
@@ -109,12 +100,12 @@ class GameGlobalAPI {
   //    Game Attr    //
   /////////////////////
 
-  public getGameMap() {
-    return this.getGameManager().getStateManager().getGameMap();
+  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
+    this.getGameManager().getStateManager().watchGameItemType(gameItemType, stateObserver);
   }
 
-  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
-    return this.getGameManager().getStateManager().consumedLocationUpdate(locationId, attr);
+  public getGameMap() {
+    return this.getGameManager().getStateManager().getGameMap();
   }
 
   public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
@@ -129,14 +120,6 @@ class GameGlobalAPI {
     return this.getGameManager().getStateManager().removeLocationAttr(attr, locationId, attrElem);
   }
 
-  public subscribeState(observer: StateObserver) {
-    this.getGameManager().getStateManager().subscribe(observer);
-  }
-
-  public unsubscribeState(observer: StateObserver) {
-    this.getGameManager().getStateManager().unsubscribe(observer);
-  }
-
   /////////////////////
   //  Game Objects   //
   /////////////////////
@@ -147,10 +130,6 @@ class GameGlobalAPI {
 
   public makeObjectBlink(objectId: ItemId, turnOn: boolean) {
     this.getGameManager().getObjectManager().makeObjectBlink(objectId, turnOn);
-  }
-
-  public getObjPropertyMap() {
-    return this.getGameManager().getStateManager().getObjPropertyMap();
   }
 
   public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
@@ -168,10 +147,6 @@ class GameGlobalAPI {
   /////////////////////
   //    Game BBox    //
   /////////////////////
-
-  public getBBoxPropertyMap() {
-    return this.getGameManager().getStateManager().getBBoxPropertyMap();
-  }
 
   public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
     this.getGameManager().getStateManager().setBBoxProperty(id, newBBoxProp);
@@ -417,16 +392,24 @@ class GameGlobalAPI {
   //  Item retrieval //
   /////////////////////
 
-  public getDialogueById(dialogueId: ItemId) {
+  public getDialogueById(dialogueId: ItemId): Dialogue {
     return mandatory(this.getGameMap().getDialogueMap().get(dialogueId));
   }
 
-  public getCharacterById(characterId: ItemId) {
+  public getCharacterById(characterId: ItemId): Character {
     return mandatory(this.getGameMap().getCharacterMap().get(characterId));
   }
 
-  public getActionById(actionId: ItemId) {
+  public getActionById(actionId: ItemId): GameAction {
     return mandatory(this.getGameMap().getActionMap().get(actionId));
+  }
+
+  public getObjectById(objectId: ItemId): ObjectProperty {
+    return mandatory(this.getGameMap().getObjectPropMap().get(objectId));
+  }
+
+  public getBBoxById(bboxId: ItemId): BBoxProperty {
+    return mandatory(this.getGameMap().getBBoxPropMap().get(bboxId));
   }
 }
 

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -97,7 +97,7 @@ class GameGlobalAPI {
   }
 
   /////////////////////
-  //    Game Attr    //
+  //    Game Items   //
   /////////////////////
 
   public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
@@ -108,16 +108,16 @@ class GameGlobalAPI {
     return this.getGameManager().getStateManager().getGameMap();
   }
 
-  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
-    return this.getGameManager().getStateManager().getLocationAttr(attr, locationId);
+  public getLocationAttr(gameItemType: GameItemType, locationId: LocationId): ItemId[] {
+    return this.getGameManager().getStateManager().getLocationAttr(gameItemType, locationId);
   }
 
-  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
-    this.getGameManager().getStateManager().addLocationAttr(attr, locationId, attrElem);
+  public addItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId): void {
+    this.getGameManager().getStateManager().addItem(gameItemType, locationId, itemId);
   }
 
-  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string): void {
-    return this.getGameManager().getStateManager().removeLocationAttr(attr, locationId, attrElem);
+  public removeItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId): void {
+    return this.getGameManager().getStateManager().removeItem(gameItemType, locationId, itemId);
   }
 
   /////////////////////

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -171,20 +171,22 @@ class GameManager extends Phaser.Scene {
 
     await this.phaseManager.swapPhase(GamePhaseType.Sequence);
 
-    // Execute start actions, notif, then cutscene
-    await this.getActionManager().fastForwardGameActions(
-      this.getStateManager().getTriggeredActions()
-    );
-
-    // Execute start actions, notif, then cutscene
     if (startAction) {
+      // Execute fast forward actions
+      await this.getActionManager().fastForwardGameActions(
+        this.getStateManager().getTriggeredActions()
+      );
+      // Execute start actions, notif, then cutscene
       await this.getActionManager().processGameActions(
         this.getStateManager().getGameMap().getCheckpointCompleteActions()
       );
     }
+
     if (!this.getStateManager().hasTriggeredInteraction(locationId)) {
       await GameGlobalAPI.getInstance().bringUpUpdateNotif(gameLocation.name);
+      this.getStateManager().removeLocationNotif(locationId);
     }
+
     await this.getActionManager().processGameActions(gameLocation.actionIds);
 
     await this.phaseManager.swapPhase(GamePhaseType.Menu);

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -153,6 +153,40 @@ class GameStateManager {
   }
 
   ///////////////////////////////
+  //       Location Mode       //
+  ///////////////////////////////
+
+  /**
+   * Add a mode to a location.
+   *
+   * @param locationId location ID
+   * @param mode game mode to add
+   */
+  public addLocationMode(locationId: LocationId, mode: GameMode) {
+    this.gameMap.getLocationAtId(locationId).modes.add(mode);
+  }
+
+  /**
+   * Remove a mode from a location.
+   *
+   * @param locationId location ID
+   * @param mode game mode to remove
+   */
+  public removeLocationMode(locationId: LocationId, mode: GameMode) {
+    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
+  }
+
+  /**
+   * Get modes available to a location based on the location ID.
+   *
+   * @param locationId location ID
+   * @returns {GameMode[]} game modes
+   */
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
+  }
+
+  ///////////////////////////////
   //        State Check        //
   ///////////////////////////////
 
@@ -233,40 +267,6 @@ class GameStateManager {
   public setCharacterProperty(id: ItemId, newCharacter: Character) {
     this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newCharacter);
     this.getSubscriberForItemType(GameItemType.characters).handleMutate(id);
-  }
-
-  ///////////////////////////////
-  //       Location Mode       //
-  ///////////////////////////////
-
-  /**
-   * Add a mode to a location.
-   *
-   * @param locationId location ID
-   * @param mode game mode to add
-   */
-  public addLocationMode(locationId: LocationId, mode: GameMode) {
-    this.gameMap.getLocationAtId(locationId).modes.add(mode);
-  }
-
-  /**
-   * Remove a mode from a location.
-   *
-   * @param locationId location ID
-   * @param mode game mode to remove
-   */
-  public removeLocationMode(locationId: LocationId, mode: GameMode) {
-    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
-  }
-
-  /**
-   * Get modes available to a location based on the location ID.
-   *
-   * @param locationId location ID
-   * @returns {GameMode[]} game modes
-   */
-  public getLocationModes(locationId: LocationId): GameMode[] {
-    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
   }
 
   ///////////////////////////////

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -1,5 +1,6 @@
 import { BBoxProperty } from '../boundingBoxes/GameBoundingBoxTypes';
 import { GameCheckpoint } from '../chapter/GameChapterTypes';
+import { Character } from '../character/GameCharacterTypes';
 import { ItemId } from '../commons/CommonTypes';
 import GameMap from '../location/GameMap';
 import { GameItemType, LocationId } from '../location/GameMapTypes';
@@ -9,42 +10,39 @@ import { ObjectProperty } from '../objects/GameObjectTypes';
 import { convertMapToArray } from '../save/GameSaveHelper';
 import GameGlobalAPI from '../scenes/gameManager/GameGlobalAPI';
 import SourceAcademyGame from '../SourceAcademyGame';
-import { StateChangeType, StateObserver, StateSubject } from './GameStateTypes';
+import { mandatory } from '../utils/GameUtils';
+import { StateObserver } from './GameStateTypes';
 
 /**
  * Manages all states related to story, chapter, or checkpoint;
- * e.g. checkpoint objectives, objects' property, bboxes' property.
  *
  * Other than this manager, all other manager should not need to
  * manage their own state.
- *
- * Employs observer pattern, and notifies its subjects on state update.
  */
-class GameStateManager implements StateSubject {
+class GameStateManager {
   // Subscribers
-  public subscribers: Array<StateObserver>;
+  private subscribers: Map<GameItemType, StateObserver>;
 
   // Game State
   private gameMap: GameMap;
   private checkpointObjective: GameObjective;
 
   // Triggered Interactions
-  private locationHasUpdate: Map<string, Map<GameItemType, boolean>>;
+  private updatedLocations: Set<LocationId>;
   private triggeredInteractions: Map<ItemId, boolean>;
   private triggeredActions: ItemId[];
 
   constructor(gameCheckpoint: GameCheckpoint) {
-    this.subscribers = new Array<StateObserver>();
+    this.subscribers = new Map<GameItemType, StateObserver>();
 
     this.gameMap = gameCheckpoint.map;
     this.checkpointObjective = gameCheckpoint.objectives;
 
-    this.locationHasUpdate = new Map<string, Map<GameItemType, boolean>>();
+    this.updatedLocations = new Set<LocationId>();
     this.triggeredInteractions = new Map<ItemId, boolean>();
     this.triggeredActions = [];
 
     this.loadStatesFromSaveManager();
-    this.registerAllItems();
   }
 
   /**
@@ -62,112 +60,6 @@ class GameStateManager implements StateSubject {
       .getSaveManager()
       .getCompletedObjectives()
       .forEach(objective => this.checkpointObjective.setObjective(objective, true));
-  }
-
-  /**
-   * Register every attribute of each location under the chapter
-   */
-  private registerAllItems() {
-    this.gameMap.getLocations().forEach((_location, locationId) => {
-      this.locationHasUpdate.set(locationId, new Map<GameItemType, boolean>());
-      Object.values(GameItemType).forEach(value =>
-        this.locationHasUpdate.get(locationId)!.set(value, false)
-      );
-    });
-  }
-
-  ///////////////////////////////
-  //        Subscribers        //
-  ///////////////////////////////
-
-  /**
-   * Update all subscribers that there is an update at the location ID.
-   *
-   * @param changeType type of change
-   * @param locationId ID of location that has an update.
-   * @param id id of item related to the update
-   */
-  public update(changeType: StateChangeType, locationId: LocationId, id?: string) {
-    this.subscribers.forEach(observer => observer.notify(changeType, locationId, id));
-  }
-
-  /**
-   * Allow a StateObserver implementer to subscribe to change of states.
-   *
-   * @param observer the instance of the implementer
-   */
-  public subscribe(observer: StateObserver) {
-    this.subscribers.push(observer);
-  }
-
-  /**
-   * Allow a StateObserver implementer to unsubscribe to change of states.
-   *
-   * @param observer the instance of the implementer
-   */
-  public unsubscribe(observer: StateObserver) {
-    this.subscribers = this.subscribers.filter(obs => obs.observerId !== observer.observerId);
-  }
-
-  ///////////////////////////////
-  //          Helpers          //
-  ///////////////////////////////
-
-  /**
-   * Update a location ID's state based on its GameMode.
-   * Also notifies subjects.
-   *
-   * @param targetLocId the id of to be upDated location
-   * @param mode mode that has been updated
-   */
-  private updateLocationStateMode(
-    changeType: StateChangeType,
-    targetLocId: LocationId,
-    mode: GameMode
-  ): void {
-    switch (mode) {
-      case GameMode.Explore:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.boundingBoxes);
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.objects);
-        return;
-      case GameMode.Move:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.navigation);
-        return;
-      case GameMode.Talk:
-        this.updateLocationStateAttr(changeType, targetLocId, GameItemType.talkTopics);
-        return;
-      default:
-        return;
-    }
-  }
-
-  /**
-   * Update a location ID's state based on its attribute.
-   * Also notifies subjects.
-   *
-   * @param changeType type of change
-   * @param targetLocId the id of to be upDated location
-   * @param attr attribute that has been updated
-   * @param attrId id of the attribute element being added
-   */
-  private updateLocationStateAttr(
-    changeType: StateChangeType,
-    targetLocId: LocationId,
-    attr: GameItemType,
-    attrId?: string
-  ): void {
-    const currLocId = GameGlobalAPI.getInstance().getCurrLocId();
-
-    this.locationHasUpdate.get(targetLocId)!.set(attr, true);
-
-    // Only update if player is not already at the location
-    if (currLocId !== targetLocId) {
-      // Location has an update to its state, reset its interaction back to not triggered
-      this.triggeredInteractions.set(targetLocId, false);
-    }
-
-    // Notify subscribers
-    this.update(changeType, targetLocId, attrId);
   }
 
   ///////////////////////////////
@@ -203,90 +95,8 @@ class GameStateManager implements StateSubject {
   }
 
   ///////////////////////////////
-  //       State Check         //
+  //       Location Mode       //
   ///////////////////////////////
-
-  /**
-   * Checks whether a location has any update based on the modes.
-   * A location has an update if any of its mode has been updated since
-   * last user interaction.
-   *
-   * If the mode parameter is specified, only that specific mode is checked.
-   * If the mode parameter is not specified, update to any mode will return true.
-   *
-   * @param locationId location ID
-   * @param mode mode to check
-   * @returns {boolean}
-   */
-  public hasLocationUpdateMode(locationId: LocationId, mode?: GameMode): boolean | undefined {
-    if (mode) {
-      switch (mode) {
-        case GameMode.Explore:
-          this.hasLocationUpdateAttr(locationId, GameItemType.boundingBoxes);
-          this.hasLocationUpdateAttr(locationId, GameItemType.objects);
-          return;
-        case GameMode.Move:
-          this.hasLocationUpdateAttr(locationId, GameItemType.navigation);
-          return;
-        case GameMode.Talk:
-          this.hasLocationUpdateAttr(locationId, GameItemType.talkTopics);
-          return;
-        default:
-          return;
-      }
-    }
-    return this.hasLocationUpdateAttr(locationId);
-  }
-
-  /**
-   * Checks whether a location has any update based on the attributes.
-   * A location has an update if any of its attributes has been updated since
-   * last user interaction.
-   *
-   * If the mode parameter is specified, only that specific mode is checked.
-   * If the mode parameter is not specified, update to any mode will return true.
-   *
-   * @param locationId location ID
-   * @param mode mode to check
-   * @returns {boolean}
-   */
-  public hasLocationUpdateAttr(locationId: LocationId, attr?: GameItemType): boolean | undefined {
-    this.gameMap.checkLocationExists(locationId);
-    if (attr) {
-      return this.locationHasUpdate.get(locationId)!.get(attr);
-    }
-
-    // If no attr is specified, update to any attr will return true
-    let result = false;
-    const locationModeState = this.locationHasUpdate.get(locationId);
-    locationModeState!.forEach((hasUpdate, attr, map) => (result = result || hasUpdate));
-    return result;
-  }
-
-  /**
-   * Inform state manager that an attribute's update has been noted of.
-   *
-   * @param locationId location ID
-   * @param attr attribute which update has been consumed
-   */
-  public consumedLocationUpdate(locationId: LocationId, attr: GameItemType) {
-    this.gameMap.checkLocationExists(locationId);
-    this.locationHasUpdate.get(locationId)!.set(attr, false);
-  }
-
-  ///////////////////////////////
-  //    Location Mode State    //
-  ///////////////////////////////
-
-  /**
-   * Get modes available to a location based on the location ID.
-   *
-   * @param locationId location ID
-   * @returns {GameMode[]} game modes
-   */
-  public getLocationMode(locationId: LocationId): GameMode[] {
-    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
-  }
 
   /**
    * Add a mode to a location.
@@ -295,41 +105,95 @@ class GameStateManager implements StateSubject {
    * @param mode game mode to add
    */
   public addLocationMode(locationId: LocationId, mode: GameMode) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    location.modes!.add(mode);
-    this.gameMap.getLocations().get(locationId)!.modes!.add(mode);
-    this.updateLocationStateMode(StateChangeType.Add, locationId, GameMode.Menu);
+    this.gameMap.getLocationAtId(locationId).modes.add(mode);
   }
 
   /**
    * Remove a mode from a location.
-   * If the mode is not present at the location, nothing
-   * will be executed.
    *
    * @param locationId location ID
    * @param mode game mode to remove
    */
   public removeLocationMode(locationId: LocationId, mode: GameMode) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    if (!location.modes) return;
-    location.modes.delete(mode);
-    this.updateLocationStateMode(StateChangeType.Delete, locationId, GameMode.Menu);
+    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
+  }
+
+  /**
+   * Get modes available to a location based on the location ID.
+   *
+   * @param locationId location ID
+   * @returns {GameMode[]} game modes
+   */
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
   }
 
   ///////////////////////////////
-  //    Location Attr State    //
+  //        Subscribing        //
+  ///////////////////////////////
+
+  /**
+   * This function is called to set state observers
+   *
+   * @param gameItemType Type of game item the observer wants to watch
+   * @param stateObserver reference to state observer
+   */
+  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
+    this.subscribers.set(gameItemType, stateObserver);
+  }
+
+  /**
+   * Obtains the subscriber that watches the game item
+   *
+   * @param gameItemType the type of item being watched
+   */
+  public getSubscriberForItemType(gameItemType: GameItemType) {
+    return mandatory(this.subscribers.get(gameItemType));
+  }
+
+  ///////////////////////////////
+  //      Location Helpers     //
+  ///////////////////////////////
+
+  /**
+   * Adds a location notification for a locationId
+   *
+   * @param locationId locationId of location you want to add notif to
+   */
+  public addLocationNotif(locationId: LocationId) {
+    this.updatedLocations.add(locationId);
+  }
+
+  /**
+   * Removes a location notification for a locationId
+   *
+   * @param locationId locationId of location you want to remove notif of
+   */
+  public removeLocationNotif(locationId: LocationId) {
+    this.updatedLocations.delete(locationId);
+  }
+
+  /**
+   * Function to check if current location is the given locationId
+   * @param locationId
+   */
+  public isCurrentLocation(locationId: LocationId) {
+    return locationId !== GameGlobalAPI.getInstance().getCurrLocId();
+  }
+
+  ///////////////////////////////
+  //        State Check        //
   ///////////////////////////////
 
   /**
    * Get an IDs of an attribute of a location.
    *
-   * @param attr location attribute
+   * @param gameItemType location attribute
    * @param locationId id of location
-   * @param {ItemId[]}
+   * @returns {ItemId[]}
    */
-  public getLocationAttr(attr: GameItemType, locationId: LocationId): ItemId[] {
-    const location = this.gameMap.getLocationAtId(locationId);
-    return Array.from(location[attr]) || [];
+  public getLocationAttr(gameItemType: GameItemType, locationId: LocationId): ItemId[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId)[gameItemType]) || [];
   }
 
   /**
@@ -339,11 +203,12 @@ class GameStateManager implements StateSubject {
    * @param locationId id of location
    * @param attrElem item ID to be added
    */
-  public addLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
-    const location = this.gameMap.getLocationAtId(locationId);
-    if (!location[attr]) location[attr] = new Set([]);
-    location[attr].add(attrElem);
-    this.updateLocationStateAttr(StateChangeType.Add, locationId, attr, attrElem);
+  public addLocationAttr(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId) {
+    this.gameMap.getLocationAtId(locationId)[gameItemType].add(itemId);
+
+    this.isCurrentLocation(locationId)
+      ? this.getSubscriberForItemType(gameItemType).handleAdd(itemId)
+      : this.addLocationNotif(locationId);
   }
 
   /**
@@ -354,11 +219,49 @@ class GameStateManager implements StateSubject {
    * @param locationId id of location
    * @param attrElem item ID to be removed
    */
-  public removeLocationAttr(attr: GameItemType, locationId: LocationId, attrElem: string) {
+  public removeLocationAttr(gameItemType: GameItemType, locationId: LocationId, itemId: string) {
     const location = this.gameMap.getLocationAtId(locationId);
-    if (!location[attr]) return;
-    location[attr] = location[attr].filter((oldAttr: string) => oldAttr !== attrElem);
-    this.updateLocationStateAttr(StateChangeType.Delete, locationId, attr, attrElem);
+    location[gameItemType] = location[gameItemType].filter((oldItem: string) => oldItem !== itemId);
+
+    this.isCurrentLocation(locationId)
+      ? this.getSubscriberForItemType(gameItemType).handleDelete(itemId)
+      : this.addLocationNotif(locationId);
+  }
+
+  /**
+   * Replace an object property of the given ID with the new object
+   * property. Commonly used to update a specific object property.
+   *
+   * @param id id of object to change
+   * @param newObjProp new object property to replace the old one
+   */
+  public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
+    this.gameMap.setItemInMap(GameItemType.objects, id, newObjProp);
+    this.getSubscriberForItemType(GameItemType.objects).handleMutate(id);
+  }
+
+  /**
+   * Replace a bbox property of the given ID with the new bbox
+   * property. Commonly used to update a specific bbox property.
+   *
+   * @param id id of object to change
+   * @param newBBoxProp new object property to replace the old one
+   */
+  public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
+    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newBBoxProp);
+    this.getSubscriberForItemType(GameItemType.boundingBoxes).handleMutate(id);
+  }
+
+  /**
+   * Replace a character of the given ID with the new character
+   * property. Commonly used to update a specific bbox property.
+   *
+   * @param id id of object to change
+   * @param newCharacter new object property to replace the old one
+   */
+  public setCharacterProperty(id: ItemId, newCharacter: Character) {
+    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newCharacter);
+    this.getSubscriberForItemType(GameItemType.characters).handleMutate(id);
   }
 
   ///////////////////////////////
@@ -412,73 +315,6 @@ class GameStateManager implements StateSubject {
   }
 
   ///////////////////////////////
-  //       Obj Property        //
-  ///////////////////////////////
-
-  /**
-   * Get object property map.
-   *
-   * @returns {Map<ItemId, ObjectProperty>}
-   */
-  public getObjPropertyMap() {
-    return this.gameMap.getObjectPropMap();
-  }
-
-  /**
-   * Replace an object property of the given ID with the new object
-   * property. Commonly used to update a specific object property.
-   *
-   * @param id id of object to change
-   * @param newObjProp new object property to replace the old one
-   */
-  public setObjProperty(id: ItemId, newObjProp: ObjectProperty) {
-    this.gameMap.setItemInMap(GameItemType.objects, id, newObjProp);
-
-    // Update every location that uses it
-    this.gameMap.getLocations().forEach((location, locationId) => {
-      if (location.objects && location.objects.has(id)) {
-        this.updateLocationStateAttr(StateChangeType.Mutate, locationId, GameItemType.objects, id);
-      }
-    });
-  }
-
-  ///////////////////////////////
-  //       BBox Property       //
-  ///////////////////////////////
-
-  /**
-   * Get bbox property map.
-   *
-   * @returns {Map<ItemId, BBoxProperty>}
-   */
-  public getBBoxPropertyMap() {
-    return this.gameMap.getBBoxPropMap();
-  }
-
-  /**
-   * Replace a bbox property of the given ID with the new bbox
-   * property. Commonly used to update a specific bbox property.
-   *
-   * @param id id of object to change
-   * @param newBBoxProp new object property to replace the old one
-   */
-  public setBBoxProperty(id: ItemId, newBBoxProp: BBoxProperty) {
-    this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newBBoxProp);
-
-    // Update every location that uses it
-    this.gameMap.getLocations().forEach((location, locationId) => {
-      if (location.boundingBoxes && location.boundingBoxes.delete(id)) {
-        this.updateLocationStateAttr(
-          StateChangeType.Mutate,
-          locationId,
-          GameItemType.boundingBoxes,
-          id
-        );
-      }
-    });
-  }
-
-  ///////////////////////////////
   //          Saving           //
   ///////////////////////////////
 
@@ -510,6 +346,8 @@ class GameStateManager implements StateSubject {
   }
 
   public getGameMap = () => this.gameMap;
+  public getObjPropertyMap = () => this.gameMap.getObjectPropMap();
+  public getBBoxPropertyMap = () => this.gameMap.getBBoxPropMap();
 }
 
 export default GameStateManager;

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -15,10 +15,14 @@ import { StateObserver } from './GameStateTypes';
 
 /**
  * Manages all states related to story, chapter, or checkpoint;
+ * e.g. checkpoint objectives, objects' property, bboxes' property.
  *
  * Other than this manager, all other manager should not need to
  * manage their own state.
+ *
+ * Employs observer pattern, and notifies its subjects on state update.
  */
+
 class GameStateManager {
   // Subscribers
   private subscribers: Map<GameItemType, StateObserver>;
@@ -63,6 +67,29 @@ class GameStateManager {
   }
 
   ///////////////////////////////
+  //        Subscribers        //
+  ///////////////////////////////
+
+  /**
+   * This function is called to set state observers
+   *
+   * @param gameItemType Type of game item the observer wants to watch
+   * @param stateObserver reference to state observer
+   */
+  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
+    this.subscribers.set(gameItemType, stateObserver);
+  }
+
+  /**
+   * Obtains the subscriber that watches the game item
+   *
+   * @param gameItemType the type of item being watched
+   */
+  public getSubscriberForItemType(gameItemType: GameItemType) {
+    return mandatory(this.subscribers.get(gameItemType));
+  }
+
+  ///////////////////////////////
   //        Interaction        //
   ///////////////////////////////
 
@@ -95,64 +122,7 @@ class GameStateManager {
   }
 
   ///////////////////////////////
-  //       Location Mode       //
-  ///////////////////////////////
-
-  /**
-   * Add a mode to a location.
-   *
-   * @param locationId location ID
-   * @param mode game mode to add
-   */
-  public addLocationMode(locationId: LocationId, mode: GameMode) {
-    this.gameMap.getLocationAtId(locationId).modes.add(mode);
-  }
-
-  /**
-   * Remove a mode from a location.
-   *
-   * @param locationId location ID
-   * @param mode game mode to remove
-   */
-  public removeLocationMode(locationId: LocationId, mode: GameMode) {
-    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
-  }
-
-  /**
-   * Get modes available to a location based on the location ID.
-   *
-   * @param locationId location ID
-   * @returns {GameMode[]} game modes
-   */
-  public getLocationModes(locationId: LocationId): GameMode[] {
-    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
-  }
-
-  ///////////////////////////////
-  //        Subscribing        //
-  ///////////////////////////////
-
-  /**
-   * This function is called to set state observers
-   *
-   * @param gameItemType Type of game item the observer wants to watch
-   * @param stateObserver reference to state observer
-   */
-  public watchGameItemType(gameItemType: GameItemType, stateObserver: StateObserver) {
-    this.subscribers.set(gameItemType, stateObserver);
-  }
-
-  /**
-   * Obtains the subscriber that watches the game item
-   *
-   * @param gameItemType the type of item being watched
-   */
-  public getSubscriberForItemType(gameItemType: GameItemType) {
-    return mandatory(this.subscribers.get(gameItemType));
-  }
-
-  ///////////////////////////////
-  //      Location Helpers     //
+  //          Notifs          //
   ///////////////////////////////
 
   /**
@@ -263,6 +233,40 @@ class GameStateManager {
   public setCharacterProperty(id: ItemId, newCharacter: Character) {
     this.gameMap.setItemInMap(GameItemType.boundingBoxes, id, newCharacter);
     this.getSubscriberForItemType(GameItemType.characters).handleMutate(id);
+  }
+
+  ///////////////////////////////
+  //       Location Mode       //
+  ///////////////////////////////
+
+  /**
+   * Add a mode to a location.
+   *
+   * @param locationId location ID
+   * @param mode game mode to add
+   */
+  public addLocationMode(locationId: LocationId, mode: GameMode) {
+    this.gameMap.getLocationAtId(locationId).modes.add(mode);
+  }
+
+  /**
+   * Remove a mode from a location.
+   *
+   * @param locationId location ID
+   * @param mode game mode to remove
+   */
+  public removeLocationMode(locationId: LocationId, mode: GameMode) {
+    this.gameMap.getLocationAtId(locationId).modes.delete(mode);
+  }
+
+  /**
+   * Get modes available to a location based on the location ID.
+   *
+   * @param locationId location ID
+   * @returns {GameMode[]} game modes
+   */
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
   }
 
   ///////////////////////////////

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -175,7 +175,8 @@ class GameStateManager {
 
   /**
    * Function to check if current location is the given locationId
-   * @param locationId
+   *
+   * @param locationId locationId that you want to check whether is current one
    */
   public isCurrentLocation(locationId: LocationId) {
     return locationId !== GameGlobalAPI.getInstance().getCurrLocId();
@@ -199,11 +200,11 @@ class GameStateManager {
   /**
    * Add an item ID to an attribute of the location.
    *
-   * @param attr attribute to add to
-   * @param locationId id of location
-   * @param attrElem item ID to be added
+   * @param gameItemType attribute to add to
+   * @param locationId id of location to add items to
+   * @param itemId item ID to be added
    */
-  public addLocationAttr(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId) {
+  public addItem(gameItemType: GameItemType, locationId: LocationId, itemId: ItemId) {
     this.gameMap.getLocationAtId(locationId)[gameItemType].add(itemId);
 
     this.isCurrentLocation(locationId)
@@ -215,11 +216,11 @@ class GameStateManager {
    * Remove an item ID from an attribute of the location.
    * If ID is not found within the attribute, nothing will be executed.
    *
-   * @param attr attribute to remove from
-   * @param locationId id of location
-   * @param attrElem item ID to be removed
+   * @param gameItemType attribute to remove from
+   * @param locationId id of location to remove items from
+   * @param itemId item ID to be removed
    */
-  public removeLocationAttr(gameItemType: GameItemType, locationId: LocationId, itemId: string) {
+  public removeItem(gameItemType: GameItemType, locationId: LocationId, itemId: string) {
     const location = this.gameMap.getLocationAtId(locationId);
     location[gameItemType] = location[gameItemType].filter((oldItem: string) => oldItem !== itemId);
 
@@ -346,8 +347,6 @@ class GameStateManager {
   }
 
   public getGameMap = () => this.gameMap;
-  public getObjPropertyMap = () => this.gameMap.getObjectPropMap();
-  public getBBoxPropertyMap = () => this.gameMap.getBBoxPropMap();
 }
 
 export default GameStateManager;

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -259,7 +259,7 @@ class GameStateManager {
 
   /**
    * Replace a character of the given ID with the new character
-   * property. Commonly used to update a specific bbox property.
+   * property. Commonly used to update a specific character property.
    *
    * @param id id of object to change
    * @param newCharacter new object property to replace the old one

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -157,6 +157,16 @@ class GameStateManager {
   ///////////////////////////////
 
   /**
+   * Get modes available to a location based on the location ID.
+   *
+   * @param locationId location ID
+   * @returns {GameMode[]} game modes
+   */
+  public getLocationModes(locationId: LocationId): GameMode[] {
+    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
+  }
+
+  /**
    * Add a mode to a location.
    *
    * @param locationId location ID
@@ -174,16 +184,6 @@ class GameStateManager {
    */
   public removeLocationMode(locationId: LocationId, mode: GameMode) {
     this.gameMap.getLocationAtId(locationId).modes.delete(mode);
-  }
-
-  /**
-   * Get modes available to a location based on the location ID.
-   *
-   * @param locationId location ID
-   * @returns {GameMode[]} game modes
-   */
-  public getLocationModes(locationId: LocationId): GameMode[] {
-    return Array.from(this.gameMap.getLocationAtId(locationId).modes) || [];
   }
 
   ///////////////////////////////

--- a/src/features/game/state/GameStateManager.ts
+++ b/src/features/game/state/GameStateManager.ts
@@ -179,7 +179,7 @@ class GameStateManager {
    * @param locationId locationId that you want to check whether is current one
    */
   public isCurrentLocation(locationId: LocationId) {
-    return locationId !== GameGlobalAPI.getInstance().getCurrLocId();
+    return locationId === GameGlobalAPI.getInstance().getCurrLocId();
   }
 
   ///////////////////////////////

--- a/src/features/game/state/GameStateTypes.ts
+++ b/src/features/game/state/GameStateTypes.ts
@@ -22,7 +22,7 @@ export type UserState = {
 };
 
 export interface StateObserver {
-  handleAdd: (itemId: ItemId) => any;
+  handleAdd: (itemId: ItemId) => boolean;
   handleDelete: (itemId: ItemId) => boolean;
-  handleMutate: (itemId: ItemId) => void;
+  handleMutate: (itemId: ItemId) => boolean;
 }

--- a/src/features/game/state/GameStateTypes.ts
+++ b/src/features/game/state/GameStateTypes.ts
@@ -1,4 +1,4 @@
-import { LocationId } from '../location/GameMapTypes';
+import { ItemId } from '../commons/CommonTypes';
 
 export enum GameStateStorage {
   UserState = 'UserState',
@@ -21,29 +21,8 @@ export type UserState = {
   [K in UserStateTypes]?: string[];
 };
 
-/**
- * Represent the changes done to the state.
- */
-export enum StateChangeType {
-  Add,
-  Mutate,
-  Delete
+export interface StateObserver {
+  handleAdd: (itemId: ItemId) => any;
+  handleDelete: (itemId: ItemId) => boolean;
+  handleMutate: (itemId: ItemId) => void;
 }
-
-/**
- * Observer pattern, the observer side.
- */
-export type StateObserver = {
-  observerId: string;
-  notify: (changeType: StateChangeType, locationId: LocationId, id?: string) => void;
-};
-
-/**
- * Observer pattern, the subject side.
- */
-export type StateSubject = {
-  subscribers: Array<StateObserver>;
-  update: (changeType: StateChangeType, locationId: LocationId, id?: string) => void;
-  subscribe: (observer: StateObserver) => void;
-  unsubscribe: (observer: StateObserver) => void;
-};

--- a/src/features/game/state/GameStateTypes.ts
+++ b/src/features/game/state/GameStateTypes.ts
@@ -21,6 +21,10 @@ export type UserState = {
   [K in UserStateTypes]?: string[];
 };
 
+/**
+ * State observer is a renderer that can reflect the changes
+ * to the current scene
+ */
 export interface StateObserver {
   handleAdd: (itemId: ItemId) => boolean;
   handleDelete: (itemId: ItemId) => boolean;


### PR DESCRIPTION
### Description

Simplify code for state manager
- Assumes one GameItemType has one StateObserver (can be changed)
- Only record whether location has update or no update (for notif), either way managers have to rerender locations on location change
- Handle add, mutate and delete based on state observer 
- Remove concept of modes knowing updates, since we want to re-render regardless of mode

If no accept, the following changes were also made:
- Change handleDelete and handleMutate to ensure correct location
- renaming of getModesByLoc to getLocationModes
- renaming of locAttr to gameItem
- execute fast-forward actions only on startAction


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist

Please delete options that are not relevant.

- [ ] I have tested this code
- [ ] I have updated the documentation
