### PR TITLE
Remove all initialise functions

### DIFF
--- a/src/features/game/awards/GameAwardsManager.ts
+++ b/src/features/game/awards/GameAwardsManager.ts
@@ -8,7 +8,7 @@ import { Layer } from '../layer/GameLayerTypes';
 import { GamePhaseType } from '../phase/GamePhaseTypes';
 import SourceAcademyGame from '../SourceAcademyGame';
 import { createButton } from '../utils/ButtonUtils';
-import { limitNumber, mandatory, sleep } from '../utils/GameUtils';
+import { limitNumber, sleep } from '../utils/GameUtils';
 import { resizeUnderflow } from '../utils/SpriteUtils';
 import { calcListFormatPos } from '../utils/StyleUtils';
 import { createBitmapText } from '../utils/TextUtils';
@@ -29,7 +29,7 @@ import { AwardPage, AwardProperty } from './GameAwardsTypes';
  * available for browsing.
  */
 class GameAwardsManager implements IGameUI {
-  private scene?: IBaseScene;
+  private scene: IBaseScene;
 
   private uiContainer: Phaser.GameObjects.Container | undefined;
   private previewContainer: Phaser.GameObjects.Container | undefined;
@@ -38,14 +38,11 @@ class GameAwardsManager implements IGameUI {
   private currActivePage: AwardPage;
   private activePageNumber: Map<AwardPage, number>;
 
-  constructor() {
+  constructor(scene: IBaseScene) {
+    this.scene = scene;
     this.activePageNumber = new Map<AwardPage, number>();
     this.currActivePage = AwardPage.Collectibles;
-  }
-
-  public initialise(scene: IBaseScene) {
-    this.scene = scene;
-    this.scene.phaseManager.addPhaseToMap(GamePhaseType.AwardMenu, this);
+    this.scene.getPhaseManager().addPhaseToMap(GamePhaseType.AwardMenu, this);
 
     // Set all initial pages number to zero
     Object.keys(AwardPage).forEach((page, index) => {
@@ -77,14 +74,12 @@ class GameAwardsManager implements IGameUI {
       const bannerPos = this.getPageOptPositions();
       const chosenIdx = Object.keys(AwardPage).findIndex(pg => pg === (page as string));
       const bannerChosen = new Phaser.GameObjects.Sprite(
-        this.getScene(),
+        this.scene,
         bannerPos[chosenIdx][0],
         bannerPos[chosenIdx][1] + awardsConstants.pageYStartPos,
         ImageAssets.awardsPageChosen.key
       );
-      this.pageChosenContainer = new Phaser.GameObjects.Container(this.getScene(), 0, 0, [
-        bannerChosen
-      ]);
+      this.pageChosenContainer = new Phaser.GameObjects.Container(this.scene, 0, 0, [bannerChosen]);
       this.uiContainer.add(this.pageChosenContainer);
 
       // Set default preview
@@ -96,10 +91,10 @@ class GameAwardsManager implements IGameUI {
    * Create the container that encapsulate the 'Award Menu' UI.
    */
   private createUIContainer() {
-    const awardContainer = new Phaser.GameObjects.Container(this.getScene(), 0, 0);
+    const awardContainer = new Phaser.GameObjects.Container(this.scene, 0, 0);
 
     const blackUnderlay = new Phaser.GameObjects.Rectangle(
-      this.getScene(),
+      this.scene,
       0,
       0,
       screenSize.x,
@@ -109,7 +104,7 @@ class GameAwardsManager implements IGameUI {
       .setAlpha(0.7)
       .setInteractive();
 
-    const awardBg = new Phaser.GameObjects.Image(this.getScene(), 0, 0, ImageAssets.awardsMenu.key);
+    const awardBg = new Phaser.GameObjects.Image(this.scene, 0, 0, ImageAssets.awardsMenu.key);
     awardContainer.add([blackUnderlay, awardBg]);
 
     // Add options
@@ -133,14 +128,14 @@ class GameAwardsManager implements IGameUI {
 
     // Add back button
     const backButton = this.createPageOpt('Back', 0, awardsConstants.backButtonYPos, async () => {
-      if (this.getPhaseManager().isCurrentPhase(GamePhaseType.AwardMenu)) {
-        await this.getPhaseManager().popPhase();
+      if (this.scene.getPhaseManager().isCurrentPhase(GamePhaseType.AwardMenu)) {
+        await this.scene.getPhaseManager().popPhase();
       }
     });
     awardContainer.add(backButton);
 
     // Add page arrows
-    const arrowLeft = createButton(this.getScene(), {
+    const arrowLeft = createButton(this.scene, {
       assetKey: ImageAssets.arrow.key,
       onUp: () => this.nextPage(false)
     })
@@ -151,7 +146,7 @@ class GameAwardsManager implements IGameUI {
         awardsConstants.arrowDownYPos
       );
 
-    const arrowRight = createButton(this.getScene(), {
+    const arrowRight = createButton(this.scene, {
       assetKey: ImageAssets.arrow.key,
       onUp: () => this.nextPage(true)
     })
@@ -165,7 +160,7 @@ class GameAwardsManager implements IGameUI {
 
     // Add preview frame
     const frame = new Phaser.GameObjects.Sprite(
-      this.getScene(),
+      this.scene,
       awardsConstants.previewXPos,
       awardsConstants.previewYPos,
       ImageAssets.popUpFrame.key
@@ -197,11 +192,11 @@ class GameAwardsManager implements IGameUI {
   private setPreview(award?: AwardProperty) {
     if (this.uiContainer) {
       if (this.previewContainer) this.previewContainer.destroy();
-      this.previewContainer = new Phaser.GameObjects.Container(this.getScene(), 0, 0);
+      this.previewContainer = new Phaser.GameObjects.Container(this.scene, 0, 0);
 
       if (award) {
         // Preview image
-        const previewSprite = new Phaser.GameObjects.Sprite(this.getScene(), 0, 0, award.assetKey);
+        const previewSprite = new Phaser.GameObjects.Sprite(this.scene, 0, 0, award.assetKey);
         resizeUnderflow(previewSprite, awardsConstants.previewDim, awardsConstants.previewDim);
         previewSprite
           .setPosition(awardsConstants.previewXPos, awardsConstants.previewYPos)
@@ -209,7 +204,7 @@ class GameAwardsManager implements IGameUI {
 
         // Preview title
         const previewTitle = createBitmapText(
-          this.getScene(),
+          this.scene,
           award.title,
           awardsConstants.previewTitleTextConfig,
           awardTitleStyle
@@ -217,7 +212,7 @@ class GameAwardsManager implements IGameUI {
 
         // Preview asset key
         const previewKey = createBitmapText(
-          this.getScene(),
+          this.scene,
           award.assetKey,
           awardsConstants.previewKeyTextConfig,
           awardKeyStyle
@@ -225,7 +220,7 @@ class GameAwardsManager implements IGameUI {
 
         // Preview description
         const previewDesc = new Phaser.GameObjects.Text(
-          this.getScene(),
+          this.scene,
           awardsConstants.previewXPos,
           awardsConstants.previewYPos + awardsConstants.previewDescTextYOffset,
           award.description,
@@ -278,7 +273,7 @@ class GameAwardsManager implements IGameUI {
    * @param callback callback to be executed on click
    */
   private createPageOpt(text: string, xPos: number, yPos: number, callback: any) {
-    return createButton(this.getScene(), {
+    return createButton(this.scene, {
       assetKey: ImageAssets.awardsPage.key,
       message: text,
       textConfig: { x: awardsConstants.pageTextXPos, y: 0, oriX: 0.1, oriY: 0.5 },
@@ -292,7 +287,7 @@ class GameAwardsManager implements IGameUI {
    * to be selected on the screen.
    */
   private createItemsContainer() {
-    const itemsContainer = new Phaser.GameObjects.Container(this.getScene(), 0, 0);
+    const itemsContainer = new Phaser.GameObjects.Container(this.scene, 0, 0);
 
     // Use the previously active page number of the page
     const items = this.getItems(this.activePageNumber.get(this.currActivePage)!);
@@ -327,7 +322,7 @@ class GameAwardsManager implements IGameUI {
    * @param callback callback to be executed on click
    */
   private createItemButton(obj: string, xPos: number, yPos: number, callback: any) {
-    return createButton(this.getScene(), {
+    return createButton(this.scene, {
       assetKey: ImageAssets.awardsBanner.key,
       message: obj,
       textConfig: { x: awardsConstants.listTextXPos, y: 0, oriX: 0.0, oriY: 0.55 },
@@ -372,7 +367,7 @@ class GameAwardsManager implements IGameUI {
    */
   public async activateUI(): Promise<void> {
     this.uiContainer = this.createUIContainer();
-    this.getLayerManager().addToLayer(Layer.UI, this.uiContainer);
+    this.scene.getLayerManager().addToLayer(Layer.UI, this.uiContainer);
     this.getSoundManager().playSound(SoundAssets.menuEnter.key);
 
     // Set initial page
@@ -380,7 +375,7 @@ class GameAwardsManager implements IGameUI {
 
     this.uiContainer.setPosition(screenCenter.x, -screenSize.y);
 
-    this.getScene().tweens.add({
+    this.scene.tweens.add({
       targets: this.uiContainer,
       ...entryTweenProps,
       y: screenCenter.y
@@ -398,19 +393,16 @@ class GameAwardsManager implements IGameUI {
       this.uiContainer.setPosition(this.uiContainer.x, this.uiContainer.y);
       this.getSoundManager().playSound(SoundAssets.menuExit.key);
 
-      this.getScene().tweens.add({
+      this.scene.tweens.add({
         targets: this.uiContainer,
         ...exitTweenProps
       });
 
       await sleep(exitTweenProps.duration);
-      fadeAndDestroy(this.getScene(), this.uiContainer, { fadeDuration: 50 });
+      fadeAndDestroy(this.scene, this.uiContainer, { fadeDuration: 50 });
     }
   }
 
-  private getScene = () => mandatory(this.scene);
-  private getLayerManager = () => mandatory(this.getScene().layerManager);
-  private getPhaseManager = () => mandatory(this.getScene().phaseManager);
   private getSoundManager = () => SourceAcademyGame.getInstance().getSoundManager();
   private getUserStateManager = () => SourceAcademyGame.getInstance().getUserStateManager();
 }

--- a/src/features/game/background/GameBackgroundManager.ts
+++ b/src/features/game/background/GameBackgroundManager.ts
@@ -10,12 +10,6 @@ import { resizeOverflow } from '../utils/SpriteUtils';
  * Loads the background for a location on navigate and change_location action.
  */
 export default class GameBackgroundManager {
-  public observerId: string;
-
-  constructor() {
-    this.observerId = 'GameBackgroundManager';
-  }
-
   /**
    * Render the background with the asset attached to the location ID.
    *

--- a/src/features/game/commons/CommonTypes.ts
+++ b/src/features/game/commons/CommonTypes.ts
@@ -92,8 +92,8 @@ export type TextConfig = { x: number; y: number; oriX: number; oriY: number };
  * @interface
  */
 export interface IBaseScene extends Phaser.Scene {
-  layerManager: GameLayerManager;
-  inputManager: GameInputManager;
-  phaseManager: GamePhaseManager;
+  getLayerManager: () => GameLayerManager;
+  getInputManager: () => GameInputManager;
+  getPhaseManager: () => GamePhaseManager;
   cleanUp: () => void;
 }

--- a/src/features/game/effects/FadeEffect.ts
+++ b/src/features/game/effects/FadeEffect.ts
@@ -112,7 +112,7 @@ export const blackFade = async (
   callback: any
 ) => {
   const fadeBlack = blackScreen(scene);
-  scene.layerManager.addToLayer(Layer.Effects, fadeBlack);
+  scene.getLayerManager().addToLayer(Layer.Effects, fadeBlack);
 
   fadeBlack.setAlpha(0);
   scene.tweens.add(fadeIn([fadeBlack], fadeDuration));

--- a/src/features/game/escape/GameEscapeManager.ts
+++ b/src/features/game/escape/GameEscapeManager.ts
@@ -8,7 +8,6 @@ import { GamePhaseType } from '../phase/GamePhaseTypes';
 import settingsConstants from '../scenes/settings/SettingsConstants';
 import SourceAcademyGame, { GameType } from '../SourceAcademyGame';
 import { createButton } from '../utils/ButtonUtils';
-import { mandatory } from '../utils/GameUtils';
 import { calcTableFormatPos, Direction } from '../utils/StyleUtils';
 import { createBitmapText } from '../utils/TextUtils';
 import escapeConstants, {
@@ -23,16 +22,16 @@ import escapeConstants, {
 class GameEscapeManager implements IGameUI {
   private bgmVolumeRadioButtons: CommonRadioButton | undefined;
   private sfxVolumeRadioButtons: CommonRadioButton | undefined;
-  private scene?: IBaseScene;
+  private scene: IBaseScene;
 
   /**
    * Initialises the escape manager UI
    *
    * @param scene - the scene to add escape manager
    */
-  public initialise(scene: IBaseScene) {
+  public constructor(scene: IBaseScene) {
     this.scene = scene;
-    this.scene.phaseManager.addPhaseToMap(GamePhaseType.EscapeMenu, this);
+    this.scene.getPhaseManager().addPhaseToMap(GamePhaseType.EscapeMenu, this);
   }
 
   /**
@@ -40,10 +39,10 @@ class GameEscapeManager implements IGameUI {
    * i.e. the background, the buttons, and the options.
    */
   private createUIContainer() {
-    const escapeMenuContainer = new Phaser.GameObjects.Container(this.getScene(), 0, 0);
+    const escapeMenuContainer = new Phaser.GameObjects.Container(this.scene, 0, 0);
 
     const escapeMenuBg = new Phaser.GameObjects.Image(
-      this.getScene(),
+      this.scene,
       screenCenter.x,
       screenCenter.y,
       ImageAssets.escapeMenuBackground.key
@@ -62,7 +61,7 @@ class GameEscapeManager implements IGameUI {
     escapeMenuContainer.add(
       settings.map((setting, index) =>
         createBitmapText(
-          this.getScene(),
+          this.scene,
           setting,
           {
             ...escapeConstants.settingsTextConfig,
@@ -126,7 +125,7 @@ class GameEscapeManager implements IGameUI {
    */
   private createSettingsRadioOptions(defaultChoiceIdx: number, yPos: number) {
     return new CommonRadioButton(
-      this.getScene(),
+      this.scene,
       {
         choices: settingsConstants.volContainerOpts,
         defaultChoiceIdx: defaultChoiceIdx,
@@ -156,17 +155,17 @@ class GameEscapeManager implements IGameUI {
         callback: () => {
           this.cleanUp();
           if (SourceAcademyGame.getInstance().isGameType(GameType.Simulator)) {
-            this.getScene().scene.start('StorySimulatorMenu');
+            this.scene.scene.start('StorySimulatorMenu');
           } else {
-            this.getScene().scene.start('MainMenu');
+            this.scene.scene.start('MainMenu');
           }
         }
       },
       {
         text: 'Continue',
         callback: async () => {
-          if (this.getPhaseManager().isCurrentPhase(GamePhaseType.EscapeMenu)) {
-            await this.getPhaseManager().popPhase();
+          if (this.scene.getPhaseManager().isCurrentPhase(GamePhaseType.EscapeMenu)) {
+            await this.scene.getPhaseManager().popPhase();
           }
         }
       },
@@ -187,7 +186,7 @@ class GameEscapeManager implements IGameUI {
    * @param callback callback to be executed on click
    */
   private createEscapeOptButton(text: string, xPos: number, yPos: number, callback: any) {
-    return createButton(this.getScene(), {
+    return createButton(this.scene, {
       assetKey: ImageAssets.mediumButton.key,
       message: text,
       textConfig: escapeConstants.escapeOptTextConfig,
@@ -220,8 +219,8 @@ class GameEscapeManager implements IGameUI {
    * Cleaning up of related managers.
    */
   private cleanUp() {
-    this.getInputManager().clearListeners();
-    this.getLayerManager().clearAllLayers();
+    this.scene.getInputManager().clearListeners();
+    this.scene.getLayerManager().clearAllLayers();
   }
 
   /**
@@ -233,7 +232,7 @@ class GameEscapeManager implements IGameUI {
   public activateUI() {
     const escapeMenuContainer = this.createUIContainer();
     this.getSoundManager().playSound(SoundAssets.menuEnter.key);
-    this.getLayerManager().addToLayer(Layer.Escape, escapeMenuContainer);
+    this.scene.getLayerManager().addToLayer(Layer.Escape, escapeMenuContainer);
   }
 
   /**
@@ -244,15 +243,11 @@ class GameEscapeManager implements IGameUI {
    */
   public deactivateUI() {
     this.getSoundManager().playSound(SoundAssets.menuExit.key);
-    this.getLayerManager().clearSeveralLayers([Layer.Escape]);
+    this.scene.getLayerManager().clearSeveralLayers([Layer.Escape]);
   }
 
-  private getScene = () => mandatory(this.scene);
-  private getLayerManager = () => mandatory(this.getScene().layerManager);
   private getSoundManager = () => SourceAcademyGame.getInstance().getSoundManager();
   private getSettingsSaveManager = () => SourceAcademyGame.getInstance().getSaveManager();
-  private getPhaseManager = () => mandatory(this.getScene().phaseManager);
-  private getInputManager = () => mandatory(this.getScene().inputManager);
 }
 
 export default GameEscapeManager;

--- a/src/features/game/input/GameInputManager.ts
+++ b/src/features/game/input/GameInputManager.ts
@@ -1,5 +1,3 @@
-import { mandatory } from '../utils/GameUtils';
-
 /**
  * Manager that keeps track of all the event listeners.
  * This manager allow clearing of all listeners at once,
@@ -9,20 +7,15 @@ import { mandatory } from '../utils/GameUtils';
  * if needed.
  */
 class GameInputManager {
-  private scene: Phaser.Scene | undefined;
+  private scene: Phaser.Scene;
   private keyboardListeners: Phaser.Input.Keyboard.Key[];
   private eventListeners: Phaser.Input.InputPlugin[];
 
-  constructor() {
+  constructor(scene: Phaser.Scene) {
     this.keyboardListeners = [];
     this.eventListeners = [];
-  }
-
-  public initialise(scene: Phaser.Scene) {
     this.scene = scene;
   }
-
-  public getScene = () => mandatory(this.scene);
 
   /**
    * Enable/disable mouse input based on the parameter.
@@ -30,7 +23,7 @@ class GameInputManager {
    * @param active if true, mouse input is enabled. Else, mouse input is disabled.
    */
   public enableMouseInput(active: boolean) {
-    this.getScene().input.mouse.enabled = active;
+    this.scene.input.mouse.enabled = active;
   }
 
   /**
@@ -39,7 +32,7 @@ class GameInputManager {
    * @param active if true, keyboard input is enabled. Else, keyboard input is disabled.
    */
   public enableKeyboardInput(active: boolean) {
-    this.getScene().input.keyboard.enabled = active;
+    this.scene.input.keyboard.enabled = active;
   }
 
   /**
@@ -55,7 +48,7 @@ class GameInputManager {
     event: string | symbol,
     callback: Function
   ) {
-    const keyObj = this.getScene().input.keyboard.addKey(key);
+    const keyObj = this.scene.input.keyboard.addKey(key);
     const keyboardListener = keyObj.addListener(event, callback);
     this.keyboardListeners.push(keyboardListener);
   }
@@ -68,7 +61,7 @@ class GameInputManager {
    * @param callback callback to execute on event
    */
   public registerEventListener(event: string | symbol, callback: Function) {
-    const eventListener = this.getScene().input.addListener(event, callback);
+    const eventListener = this.scene.input.addListener(event, callback);
     this.eventListeners.concat(eventListener);
   }
 

--- a/src/features/game/layer/GameLayerManager.ts
+++ b/src/features/game/layer/GameLayerManager.ts
@@ -10,22 +10,13 @@ import { defaultLayerSequence, Layer } from './GameLayerTypes';
  * as specified in Game Layer types
  */
 class GameLayerManager {
-  private mainLayer: Phaser.GameObjects.Container | undefined;
   private layers: Map<Layer, Phaser.GameObjects.Container>;
 
-  constructor() {
-    this.mainLayer = undefined;
-    this.layers = new Map<Layer, Phaser.GameObjects.Container>();
-  }
-
-  public initialise(scene: Phaser.Scene) {
-    this.mainLayer = new Phaser.GameObjects.Container(scene, 0, 0);
-    scene.add.existing(this.mainLayer);
-    for (const layerType of defaultLayerSequence) {
-      const layerContainer = new Phaser.GameObjects.Container(scene, 0, 0);
-      this.layers.set(layerType, layerContainer);
-      this.mainLayer.add(layerContainer);
-    }
+  constructor(scene: Phaser.Scene) {
+    this.layers = new Map(
+      defaultLayerSequence.map(layer => [layer, new Phaser.GameObjects.Container(scene, 0, 0)])
+    );
+    this.layers.forEach(layer => scene.add.existing(layer));
   }
 
   /**

--- a/src/features/game/parser/ActionParser.ts
+++ b/src/features/game/parser/ActionParser.ts
@@ -116,8 +116,8 @@ export default class ActionParser {
         actionParamObj.id = actionParams[0];
         Parser.validator.assertItemType(GameItemType.objects, actionParams[0], actionType);
         actionParamObj.position = ParserConverter.stringToPosition(actionParams[1]);
-        actionParamObj.duration = parseInt(actionParams[2]) * 1000;
-        actionParamObj.size = ParserConverter.stringToSize(actionParams[3]);
+        actionParams[2] && (actionParamObj.duration = parseInt(actionParams[2]) * 1000);
+        actionParams[3] && (actionParamObj.size = ParserConverter.stringToSize(actionParams[3]));
         break;
 
       case GameActionType.MakeObjectBlink:

--- a/src/features/game/phase/GamePhaseManager.ts
+++ b/src/features/game/phase/GamePhaseManager.ts
@@ -1,7 +1,6 @@
 import { Constants } from '../commons/CommonConstants';
 import { IGameUI } from '../commons/CommonTypes';
 import GameInputManager from '../input/GameInputManager';
-import { mandatory } from '../utils/GameUtils';
 import { GamePhaseType } from './GamePhaseTypes';
 
 /**
@@ -17,7 +16,7 @@ import { GamePhaseType } from './GamePhaseTypes';
 export default class GamePhaseManager {
   public phaseMap: Map<GamePhaseType, IGameUI>;
   private phaseStack: GamePhaseType[];
-  private inputManager: GameInputManager | undefined;
+  private inputManager: GameInputManager;
   private interruptTransitionCallback: (
     prevPhase: GamePhaseType,
     newPhase: GamePhaseType
@@ -29,6 +28,7 @@ export default class GamePhaseManager {
     this.phaseMap = phaseMap;
     this.interruptTransitionCallback = Constants.nullFunction;
     this.transitionCallback = Constants.nullFunction;
+    this.inputManager = inputManager;
   }
 
   public addPhaseToMap(gamePhaseType: GamePhaseType, gameUI: IGameUI) {
@@ -113,15 +113,15 @@ export default class GamePhaseManager {
    */
   private async executePhaseTransition(prevPhase: GamePhaseType, newPhase: GamePhaseType) {
     // Disable inputs to avoid user input mutating the stack
-    this.getInputManager().enableKeyboardInput(false);
-    this.getInputManager().enableMouseInput(false);
+    this.inputManager.enableKeyboardInput(false);
+    this.inputManager.enableMouseInput(false);
     await this.phaseMap.get(prevPhase)!.deactivateUI();
 
     // Execute phase transition callback.
     // If executed, we no longer do transition to the new phase.
     if (await this.interruptTransitionCallback(prevPhase, newPhase)) {
-      this.getInputManager().enableMouseInput(true);
-      this.getInputManager().enableKeyboardInput(true);
+      this.inputManager.enableMouseInput(true);
+      this.inputManager.enableKeyboardInput(true);
       return;
     }
 
@@ -129,8 +129,8 @@ export default class GamePhaseManager {
 
     // Transition to new phase
     await this.phaseMap.get(newPhase)!.activateUI();
-    this.getInputManager().enableMouseInput(true);
-    this.getInputManager().enableKeyboardInput(true);
+    this.inputManager.enableMouseInput(true);
+    this.inputManager.enableKeyboardInput(true);
   }
 
   /**
@@ -155,6 +155,4 @@ export default class GamePhaseManager {
     }
     return this.phaseStack[this.phaseStack.length - 1];
   }
-
-  public getInputManager = () => mandatory(this.inputManager);
 }

--- a/src/features/game/phase/GamePhaseManager.ts
+++ b/src/features/game/phase/GamePhaseManager.ts
@@ -20,15 +20,11 @@ export default class GamePhaseManager {
   private inputManager: GameInputManager | undefined;
   private phaseTransitionCallback: (newPhase: GamePhaseType) => Promise<boolean> | void;
 
-  constructor() {
+  constructor(phaseMap: Map<GamePhaseType, IGameUI>, inputManager: GameInputManager) {
     this.phaseStack = [GamePhaseType.None];
-    this.phaseMap = new Map<GamePhaseType, IGameUI>();
-    this.phaseTransitionCallback = Constants.nullFunction;
-  }
-
-  public initialise(phaseMap: Map<GamePhaseType, IGameUI>, inputManager: GameInputManager) {
     this.phaseMap = phaseMap;
     this.inputManager = inputManager;
+    this.phaseTransitionCallback = Constants.nullFunction;
   }
 
   public addPhaseToMap(gamePhaseType: GamePhaseType, gameUI: IGameUI) {

--- a/src/features/game/save/GameSaveHelper.ts
+++ b/src/features/game/save/GameSaveHelper.ts
@@ -19,7 +19,7 @@ export function gameStateToJson(
 ): FullSaveState {
   const gameManager = GameGlobalAPI.getInstance().getGameManager();
   const gameStateManager = gameManager.getStateManager();
-  const phaseManager = gameManager.phaseManager;
+  const phaseManager = gameManager.getPhaseManager();
 
   return {
     gameSaveStates: {

--- a/src/features/game/scenes/awardsHall/AwardsHall.ts
+++ b/src/features/game/scenes/awardsHall/AwardsHall.ts
@@ -9,7 +9,7 @@ import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
 import SourceAcademyGame from '../../SourceAcademyGame';
 import { createButton } from '../../utils/ButtonUtils';
-import { limitNumber } from '../../utils/GameUtils';
+import { limitNumber, mandatory } from '../../utils/GameUtils';
 import { resizeUnderflow } from '../../utils/SpriteUtils';
 import { calcTableFormatPos, Direction } from '../../utils/StyleUtils';
 import { createBitmapText } from '../../utils/TextUtils';
@@ -20,8 +20,8 @@ import { createAwardsHoverContainer } from './AwardsHelper';
  * This scenes display all students awards (collectibles and achievements).
  */
 class AwardsHall extends Phaser.Scene {
-  public layerManager: GameLayerManager;
-  public inputManager: GameInputManager;
+  public layerManager?: GameLayerManager;
+  public inputManager?: GameInputManager;
 
   private backgroundTile: Phaser.GameObjects.TileSprite | undefined;
   private awardsContainer: Phaser.GameObjects.Container | undefined;
@@ -35,9 +35,6 @@ class AwardsHall extends Phaser.Scene {
     super('AwardsHall');
     SourceAcademyGame.getInstance().setCurrentSceneRef(this);
 
-    this.layerManager = new GameLayerManager();
-    this.inputManager = new GameInputManager();
-
     this.isScrollLeft = false;
     this.isScrollRight = false;
     this.scrollLim = 0;
@@ -45,14 +42,12 @@ class AwardsHall extends Phaser.Scene {
   }
 
   public init() {
-    this.layerManager = new GameLayerManager();
-    this.inputManager = new GameInputManager();
+    this.layerManager = new GameLayerManager(this);
+    this.inputManager = new GameInputManager(this);
   }
 
   public preload() {
     addLoadingScreen(this);
-    this.layerManager.initialise(this);
-    this.inputManager.initialise(this);
   }
 
   public async create() {
@@ -103,7 +98,7 @@ class AwardsHall extends Phaser.Scene {
       AwardsHallConstants.tileDim,
       ImageAssets.awardsBackground.key
     ).setOrigin(0, 0.25);
-    this.layerManager.addToLayer(Layer.Background, this.backgroundTile);
+    this.getLayerManager().addToLayer(Layer.Background, this.backgroundTile);
 
     // Add banners
     const banners = ['Achievements', 'Collectibles'];
@@ -113,7 +108,7 @@ class AwardsHall extends Phaser.Scene {
     });
     banners.forEach((banner, index) => {
       const bannerCont = this.createBanner(banner, bannerPos[index][1]);
-      this.layerManager.addToLayer(Layer.UI, bannerCont);
+      this.getLayerManager().addToLayer(Layer.UI, bannerCont);
     });
 
     const leftArrow = createButton(this, {
@@ -137,9 +132,9 @@ class AwardsHall extends Phaser.Scene {
       this.scene.start('MainMenu');
     });
 
-    this.layerManager.addToLayer(Layer.UI, leftArrow);
-    this.layerManager.addToLayer(Layer.UI, rightArrow);
-    this.layerManager.addToLayer(Layer.UI, backButton);
+    this.getLayerManager().addToLayer(Layer.UI, leftArrow);
+    this.getLayerManager().addToLayer(Layer.UI, rightArrow);
+    this.getLayerManager().addToLayer(Layer.UI, backButton);
   }
 
   /**
@@ -190,7 +185,7 @@ class AwardsHall extends Phaser.Scene {
       )
     );
 
-    this.layerManager.addToLayer(Layer.Objects, this.awardsContainer);
+    this.getLayerManager().addToLayer(Layer.Objects, this.awardsContainer);
   }
 
   /**
@@ -234,7 +229,7 @@ class AwardsHall extends Phaser.Scene {
       }
     );
 
-    this.layerManager.addToLayer(Layer.UI, hoverCont);
+    this.getLayerManager().addToLayer(Layer.UI, hoverCont);
     awardCont.add(image);
     return awardCont;
   }
@@ -243,8 +238,8 @@ class AwardsHall extends Phaser.Scene {
    * Clean up of related managers
    */
   private cleanUp() {
-    this.inputManager.clearListeners();
-    this.layerManager.clearAllLayers();
+    this.getInputManager().clearListeners();
+    this.getLayerManager().clearAllLayers();
   }
 
   /**
@@ -275,6 +270,8 @@ class AwardsHall extends Phaser.Scene {
   }
 
   public getUserStateManager = () => SourceAcademyGame.getInstance().getUserStateManager();
+  public getInputManager = () => mandatory(this.inputManager);
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default AwardsHall;

--- a/src/features/game/scenes/bindings/Bindings.ts
+++ b/src/features/game/scenes/bindings/Bindings.ts
@@ -4,6 +4,7 @@ import { screenCenter, screenSize } from '../../commons/CommonConstants';
 import GameInputManager from '../../input/GameInputManager';
 import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
+import { mandatory } from '../../utils/GameUtils';
 import { calcListFormatPos } from '../../utils/StyleUtils';
 import { createBitmapText } from '../../utils/TextUtils';
 import { bindingConstants, keyDescStyle, keyStyle } from './BindingsConstants';
@@ -13,18 +14,16 @@ import { bindingConstants, keyDescStyle, keyStyle } from './BindingsConstants';
  * Static scene.
  */
 class Bindings extends Phaser.Scene {
-  public layerManager: GameLayerManager;
-  public inputManager: GameInputManager;
+  public layerManager?: GameLayerManager;
+  public inputManager?: GameInputManager;
 
   constructor() {
     super('Bindings');
-    this.layerManager = new GameLayerManager();
-    this.inputManager = new GameInputManager();
   }
 
-  public preload() {
-    this.layerManager.initialise(this);
-    this.inputManager.initialise(this);
+  public init() {
+    this.layerManager = new GameLayerManager(this);
+    this.inputManager = new GameInputManager(this);
   }
 
   public create() {
@@ -50,8 +49,8 @@ class Bindings extends Phaser.Scene {
       screenSize.y,
       0
     ).setAlpha(0.3);
-    this.layerManager.addToLayer(Layer.Background, background);
-    this.layerManager.addToLayer(Layer.Background, blackOverlay);
+    this.getLayerManager().addToLayer(Layer.Background, background);
+    this.getLayerManager().addToLayer(Layer.Background, blackOverlay);
   }
 
   /**
@@ -78,12 +77,12 @@ class Bindings extends Phaser.Scene {
       )
     );
     const backButton = new CommonBackButton(this, () => {
-      this.layerManager.clearAllLayers();
+      this.getLayerManager().clearAllLayers();
       this.scene.start('MainMenu');
     });
 
-    this.layerManager.addToLayer(Layer.UI, bindingsContainer);
-    this.layerManager.addToLayer(Layer.UI, backButton);
+    this.getLayerManager().addToLayer(Layer.UI, bindingsContainer);
+    this.getLayerManager().addToLayer(Layer.UI, backButton);
   }
 
   /**
@@ -135,6 +134,8 @@ class Bindings extends Phaser.Scene {
     bindingContainer.add([keyIcon, keyText, keyDesc]);
     return bindingContainer;
   }
+  public getInputManager = () => mandatory(this.inputManager);
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default Bindings;

--- a/src/features/game/scenes/chapterSelect/ChapterSelect.ts
+++ b/src/features/game/scenes/chapterSelect/ChapterSelect.ts
@@ -1,9 +1,8 @@
 import { screenCenter, screenSize } from 'src/features/game/commons/CommonConstants';
-import { limitNumber, sleep, toS3Path } from 'src/features/game/utils/GameUtils';
+import { limitNumber, mandatory, sleep, toS3Path } from 'src/features/game/utils/GameUtils';
 
 import ImageAssets from '../../assets/ImageAssets';
 import CommonBackButton from '../../commons/CommonBackButton';
-import { addLoadingScreen } from '../../effects/LoadingScreen';
 import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
 import { FullSaveState } from '../../save/GameSaveTypes';
@@ -18,7 +17,7 @@ import { createChapter } from './ChapterSelectHelper';
  * Player is able to choose which chapter to play from here.
  */
 class ChapterSelect extends Phaser.Scene {
-  public layerManager: GameLayerManager;
+  public layerManager?: GameLayerManager;
 
   private chapterContainer: Phaser.GameObjects.Container | undefined;
   private backButtonContainer: Phaser.GameObjects.Container | undefined;
@@ -32,22 +31,14 @@ class ChapterSelect extends Phaser.Scene {
 
     this.chapterContainer = undefined;
     this.backButtonContainer = undefined;
-    this.layerManager = new GameLayerManager();
     this.autoScrolling = true;
     this.isScrollLeft = false;
     this.isScrollRight = false;
   }
 
-  public init() {
-    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
-  }
-
-  public preload() {
-    addLoadingScreen(this);
-    this.layerManager.initialise(this);
-  }
-
   public async create() {
+    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
+    this.layerManager = new GameLayerManager(this);
     await this.preloadChapterAssets();
     this.renderBackground();
     this.renderChapters();
@@ -75,7 +66,7 @@ class ChapterSelect extends Phaser.Scene {
    * Clean up of related managers.
    */
   public cleanUp() {
-    this.layerManager.clearAllLayers();
+    this.getLayerManager().clearAllLayers();
   }
 
   /**
@@ -108,8 +99,8 @@ class ChapterSelect extends Phaser.Scene {
       screenSize.y,
       0
     ).setAlpha(0.3);
-    this.layerManager.addToLayer(Layer.Background, background);
-    this.layerManager.addToLayer(Layer.Background, blackOverlay);
+    this.getLayerManager().addToLayer(Layer.Background, background);
+    this.getLayerManager().addToLayer(Layer.Background, blackOverlay);
   }
 
   /**
@@ -148,11 +139,11 @@ class ChapterSelect extends Phaser.Scene {
       .setPosition(screenCenter.x + chapConstants.arrowXOffset, screenCenter.y)
       .setScale(-1, 1);
 
-    this.layerManager.addToLayer(Layer.UI, this.chapterContainer);
-    this.layerManager.addToLayer(Layer.UI, this.backButtonContainer);
-    this.layerManager.addToLayer(Layer.UI, border);
-    this.layerManager.addToLayer(Layer.UI, leftArrow);
-    this.layerManager.addToLayer(Layer.UI, rightArrow);
+    this.getLayerManager().addToLayer(Layer.UI, this.chapterContainer);
+    this.getLayerManager().addToLayer(Layer.UI, this.backButtonContainer);
+    this.getLayerManager().addToLayer(Layer.UI, border);
+    this.getLayerManager().addToLayer(Layer.UI, leftArrow);
+    this.getLayerManager().addToLayer(Layer.UI, rightArrow);
   }
 
   private createMask() {
@@ -226,6 +217,7 @@ class ChapterSelect extends Phaser.Scene {
     });
     await sleep(scrollDuration);
   }
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default ChapterSelect;

--- a/src/features/game/scenes/gameManager/GameGlobalAPI.ts
+++ b/src/features/game/scenes/gameManager/GameGlobalAPI.ts
@@ -1,6 +1,3 @@
-import { Layer } from 'src/features/game/layer/GameLayerTypes';
-import { GameMode } from 'src/features/game/mode/GameModeTypes';
-
 import { GameAction } from '../../action/GameActionTypes';
 import { SoundAsset } from '../../assets/AssetsTypes';
 import { BBoxProperty } from '../../boundingBoxes/GameBoundingBoxTypes';
@@ -9,7 +6,9 @@ import { GamePosition, GameSize, ItemId } from '../../commons/CommonTypes';
 import { AssetKey } from '../../commons/CommonTypes';
 import { Dialogue } from '../../dialogue/GameDialogueTypes';
 import { displayNotification } from '../../effects/Notification';
+import { Layer } from '../../layer/GameLayerTypes';
 import { GameItemType, GameLocation, LocationId } from '../../location/GameMapTypes';
+import { GameMode } from '../../mode/GameModeTypes';
 import { ObjectProperty } from '../../objects/GameObjectTypes';
 import { GamePhaseType } from '../../phase/GamePhaseTypes';
 import { SettingsJson } from '../../save/GameSaveTypes';
@@ -196,27 +195,27 @@ class GameGlobalAPI {
   /////////////////////
 
   public clearSeveralLayers(layerTypes: Layer[]) {
-    this.getGameManager().layerManager.clearSeveralLayers(layerTypes);
+    this.getGameManager().getLayerManager().clearSeveralLayers(layerTypes);
   }
 
   public addContainerToLayer(layer: Layer, gameObj: Phaser.GameObjects.GameObject) {
-    this.getGameManager().layerManager.addToLayer(layer, gameObj);
+    this.getGameManager().getLayerManager().addToLayer(layer, gameObj);
   }
 
   public showLayer(layer: Layer) {
-    this.getGameManager().layerManager.showLayer(layer);
+    this.getGameManager().getLayerManager().showLayer(layer);
   }
 
   public hideLayer(layer: Layer) {
-    this.getGameManager().layerManager.hideLayer(layer);
+    this.getGameManager().getLayerManager().hideLayer(layer);
   }
 
   public async fadeInLayer(layer: Layer, fadeDuration?: number) {
-    await this.getGameManager().layerManager.fadeInLayer(layer, fadeDuration);
+    await this.getGameManager().getLayerManager().fadeInLayer(layer, fadeDuration);
   }
 
   public async fadeOutLayer(layer: Layer, fadeDuration?: number) {
-    await this.getGameManager().layerManager.fadeOutLayer(layer, fadeDuration);
+    await this.getGameManager().getLayerManager().fadeOutLayer(layer, fadeDuration);
   }
   /////////////////////
   //  Location Notif //
@@ -231,9 +230,9 @@ class GameGlobalAPI {
   /////////////////////
 
   public async processGameActions(actionIds: ItemId[] | undefined) {
-    await this.getGameManager().phaseManager.pushPhase(GamePhaseType.Sequence);
+    await this.getGameManager().getPhaseManager().pushPhase(GamePhaseType.Sequence);
     await this.getGameManager().getActionManager().processGameActions(actionIds);
-    await this.getGameManager().phaseManager.popPhase();
+    await this.getGameManager().getPhaseManager().popPhase();
   }
 
   public async processGameActionsInSamePhase(actionIds: ItemId[] | undefined) {
@@ -245,9 +244,9 @@ class GameGlobalAPI {
   /////////////////////
 
   public async showDialogue(dialogueId: ItemId) {
-    await this.getGameManager().phaseManager.pushPhase(GamePhaseType.Sequence);
+    await this.getGameManager().getPhaseManager().pushPhase(GamePhaseType.Sequence);
     await this.getGameManager().getDialogueManager().showDialogue(dialogueId);
-    await this.getGameManager().phaseManager.popPhase();
+    await this.getGameManager().getPhaseManager().popPhase();
   }
 
   public async showDialogueInSamePhase(dialogueId: ItemId) {
@@ -267,15 +266,15 @@ class GameGlobalAPI {
   /////////////////////
 
   public displayPopUp(itemId: ItemId, position: GamePosition, duration?: number, size?: GameSize) {
-    this.getGameManager().popUpManager.displayPopUp(itemId, position, duration, size);
+    this.getGameManager().getPopupManager().displayPopUp(itemId, position, duration, size);
   }
 
   public destroyAllPopUps() {
-    this.getGameManager().popUpManager.destroyAllPopUps();
+    this.getGameManager().getPopupManager().destroyAllPopUps();
   }
 
   public async destroyPopUp(position: GamePosition) {
-    this.getGameManager().popUpManager.destroyPopUp(position);
+    this.getGameManager().getPopupManager().destroyPopUp(position);
   }
 
   /////////////////////
@@ -335,11 +334,11 @@ class GameGlobalAPI {
   /////////////////////
 
   public enableKeyboardInput(active: boolean) {
-    this.getGameManager().inputManager.enableKeyboardInput(active);
+    this.getGameManager().getInputManager().enableKeyboardInput(active);
   }
 
   public enableMouseInput(active: boolean) {
-    this.getGameManager().inputManager.enableMouseInput(active);
+    this.getGameManager().getInputManager().enableMouseInput(active);
   }
 
   /////////////////////
@@ -347,19 +346,19 @@ class GameGlobalAPI {
   /////////////////////
 
   public async popPhase() {
-    await this.getGameManager().phaseManager.popPhase();
+    await this.getGameManager().getPhaseManager().popPhase();
   }
 
   public async pushPhase(gamePhaseType: GamePhaseType) {
-    await this.getGameManager().phaseManager.pushPhase(gamePhaseType);
+    await this.getGameManager().getPhaseManager().pushPhase(gamePhaseType);
   }
 
   public async swapPhase(gamePhaseType: GamePhaseType) {
-    await this.getGameManager().phaseManager.swapPhase(gamePhaseType);
+    await this.getGameManager().getPhaseManager().swapPhase(gamePhaseType);
   }
 
   public isCurrentPhase(gamePhaseType: GamePhaseType) {
-    return this.getGameManager().phaseManager.isCurrentPhase(gamePhaseType);
+    return this.getGameManager().getPhaseManager().isCurrentPhase(gamePhaseType);
   }
 
   /////////////////////
@@ -367,7 +366,7 @@ class GameGlobalAPI {
   /////////////////////
 
   public renderBackgroundLayerContainer(locationId: LocationId) {
-    this.getGameManager().backgroundManager.renderBackgroundLayerContainer(locationId);
+    this.getGameManager().getBackgroundManager().renderBackgroundLayerContainer(locationId);
   }
 
   /////////////////////

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -1,26 +1,24 @@
-import GameActionManager from 'src/features/game/action/GameActionManager';
-import GameBBoxManager from 'src/features/game/boundingBoxes/GameBoundingBoxManager';
-import { GameCheckpoint } from 'src/features/game/chapter/GameChapterTypes';
-import GameCharacterManager from 'src/features/game/character/GameCharacterManager';
-import GameDialogueManager from 'src/features/game/dialogue/GameDialogueManager';
-import { blackFade } from 'src/features/game/effects/FadeEffect';
-import { addLoadingScreen } from 'src/features/game/effects/LoadingScreen';
-import GameLayerManager from 'src/features/game/layer/GameLayerManager';
-import { LocationId } from 'src/features/game/location/GameMapTypes';
-import GameObjectManager from 'src/features/game/objects/GameObjectManager';
-import GamePopUpManager from 'src/features/game/popUp/GamePopUpManager';
-import SourceAcademyGame from 'src/features/game/SourceAcademyGame';
-import GameStateManager from 'src/features/game/state/GameStateManager';
-
+import GameActionManager from '../../action/GameActionManager';
 import GameAwardsManager from '../../awards/GameAwardsManager';
 import GameBackgroundManager from '../../background/GameBackgroundManager';
+import GameBBoxManager from '../../boundingBoxes/GameBoundingBoxManager';
+import { GameCheckpoint } from '../../chapter/GameChapterTypes';
+import GameCharacterManager from '../../character/GameCharacterManager';
 import { Constants } from '../../commons/CommonConstants';
+import GameDialogueManager from '../../dialogue/GameDialogueManager';
+import { blackFade } from '../../effects/FadeEffect';
+import { addLoadingScreen } from '../../effects/LoadingScreen';
 import GameEscapeManager from '../../escape/GameEscapeManager';
 import GameInputManager from '../../input/GameInputManager';
+import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
+import { LocationId } from '../../location/GameMapTypes';
+import GameObjectManager from '../../objects/GameObjectManager';
 import GamePhaseManager from '../../phase/GamePhaseManager';
 import { GamePhaseType } from '../../phase/GamePhaseTypes';
-import GameSaveManager from '../../save/GameSaveManager';
+import GamePopUpManager from '../../popUp/GamePopUpManager';
+import SourceAcademyGame from '../../SourceAcademyGame';
+import GameStateManager from '../../state/GameStateManager';
 import { mandatory, toS3Path } from '../../utils/GameUtils';
 import GameGlobalAPI from './GameGlobalAPI';
 import { createGamePhases } from './GameManagerHelper';
@@ -44,55 +42,43 @@ type GameManagerProps = {
  */
 class GameManager extends Phaser.Scene {
   public currentLocationId: LocationId;
-
-  public stateManager?: GameStateManager;
-  public layerManager: GameLayerManager;
-  public objectManager?: GameObjectManager;
-  public characterManager?: GameCharacterManager;
-  public dialogueManager?: GameDialogueManager;
-  public actionManager?: GameActionManager;
-  public boundingBoxManager?: GameBBoxManager;
-  public popUpManager: GamePopUpManager;
-  public saveManager?: GameSaveManager;
-  public escapeManager: GameEscapeManager;
-  public phaseManager: GamePhaseManager;
-  public backgroundManager: GameBackgroundManager;
-  public inputManager: GameInputManager;
-  public awardsManager: GameAwardsManager;
+  private stateManager?: GameStateManager;
+  private layerManager?: GameLayerManager;
+  private objectManager?: GameObjectManager;
+  private characterManager?: GameCharacterManager;
+  private dialogueManager?: GameDialogueManager;
+  private actionManager?: GameActionManager;
+  private boundingBoxManager?: GameBBoxManager;
+  private popUpManager?: GamePopUpManager;
+  private phaseManager?: GamePhaseManager;
+  private backgroundManager?: GameBackgroundManager;
+  private inputManager?: GameInputManager;
 
   constructor() {
     super('GameManager');
     this.currentLocationId = Constants.nullInteractionId;
-
-    this.layerManager = new GameLayerManager();
-    this.popUpManager = new GamePopUpManager();
-    this.escapeManager = new GameEscapeManager();
-    this.phaseManager = new GamePhaseManager();
-    this.backgroundManager = new GameBackgroundManager();
-    this.inputManager = new GameInputManager();
-    this.awardsManager = new GameAwardsManager();
   }
 
   public init({ gameCheckpoint, continueGame, chapterNum, checkpointNum }: GameManagerProps) {
     GameGlobalAPI.getInstance().setGameManager(this);
     SourceAcademyGame.getInstance().setCurrentSceneRef(this);
     this.getSaveManager().registerGameInfo(chapterNum, checkpointNum, continueGame);
-    this.currentLocationId = gameCheckpoint.startingLoc;
+    this.currentLocationId =
+      this.getSaveManager().getLoadedLocation() || gameCheckpoint.startingLoc;
 
+    this.layerManager = new GameLayerManager(this);
+    this.inputManager = new GameInputManager(this);
+    this.phaseManager = new GamePhaseManager(createGamePhases(), this.inputManager);
     this.stateManager = new GameStateManager(gameCheckpoint);
-    this.layerManager = new GameLayerManager();
     this.characterManager = new GameCharacterManager();
     this.objectManager = new GameObjectManager();
     this.dialogueManager = new GameDialogueManager();
     this.actionManager = new GameActionManager();
     this.boundingBoxManager = new GameBBoxManager();
-
-    this.popUpManager = new GamePopUpManager();
-    this.escapeManager = new GameEscapeManager();
-    this.phaseManager = new GamePhaseManager();
     this.backgroundManager = new GameBackgroundManager();
-    this.inputManager = new GameInputManager();
-    this.awardsManager = new GameAwardsManager();
+    this.popUpManager = new GamePopUpManager();
+    new GameEscapeManager(this);
+    new GameAwardsManager(this);
   }
 
   //////////////////////
@@ -101,17 +87,7 @@ class GameManager extends Phaser.Scene {
 
   public preload() {
     addLoadingScreen(this);
-    this.currentLocationId = this.getSaveManager().getLoadedLocation() || this.currentLocationId;
-
-    this.inputManager.initialise(this);
-    this.layerManager.initialise(this);
-    this.phaseManager.initialise(createGamePhases(), this.inputManager);
-    this.awardsManager.initialise(this);
-    this.escapeManager.initialise(this);
-
-    this.phaseManager.setCallback(
-      async (newPhase: GamePhaseType) => await this.checkpointTransition(newPhase)
-    );
+    this.getPhaseManager().setCallback(this.checkpointTransition);
     this.preloadLocationsAssets();
     this.bindKeyboardTriggers();
   }
@@ -160,17 +136,17 @@ class GameManager extends Phaser.Scene {
     await GameGlobalAPI.getInstance().playBgMusic(gameLocation.bgmKey);
 
     // Render all assets related to the location
-    this.backgroundManager.renderBackgroundLayerContainer(locationId);
+    this.getBackgroundManager().renderBackgroundLayerContainer(locationId);
     this.getObjectManager().renderObjectsLayerContainer(locationId);
     this.getBBoxManager().renderBBoxLayerContainer(locationId);
     this.getCharacterManager().renderCharacterLayerContainer(locationId);
 
-    await this.phaseManager.swapPhase(GamePhaseType.Sequence);
+    // Execute start actions, notif, then cutscene
+    await this.getPhaseManager().swapPhase(GamePhaseType.Sequence);
 
     if (startAction) {
-      // Execute start actions, notif, then cutscene
       await this.getActionManager().processGameActions(
-        this.getStateManager().getGameMap().getCheckpointCompleteActions()
+        this.getStateManager().getGameMap().getGameStartActions()
       );
     }
 
@@ -180,7 +156,7 @@ class GameManager extends Phaser.Scene {
     }
 
     await this.getActionManager().processGameActions(gameLocation.actionIds);
-    await this.phaseManager.swapPhase(GamePhaseType.Menu);
+    await this.getPhaseManager().swapPhase(GamePhaseType.Menu);
   }
 
   /**
@@ -196,7 +172,7 @@ class GameManager extends Phaser.Scene {
 
     // Transition to the new location
     await blackFade(this, 300, 500, async () => {
-      await this.layerManager.clearAllLayers();
+      await this.getLayerManager().clearAllLayers();
       await this.renderLocation(locationId, startAction);
     });
 
@@ -208,25 +184,25 @@ class GameManager extends Phaser.Scene {
    * Bind escape menu and awards menu to keyboard triggers.
    */
   private bindKeyboardTriggers() {
-    this.inputManager.registerKeyboardListener(
+    this.getInputManager().registerKeyboardListener(
       Phaser.Input.Keyboard.KeyCodes.ESC,
       'up',
       async () => {
-        if (this.phaseManager.isCurrentPhase(GamePhaseType.EscapeMenu)) {
-          await this.phaseManager.popPhase();
+        if (this.getPhaseManager().isCurrentPhase(GamePhaseType.EscapeMenu)) {
+          await this.getPhaseManager().popPhase();
         } else {
-          await this.phaseManager.pushPhase(GamePhaseType.EscapeMenu);
+          await this.getPhaseManager().pushPhase(GamePhaseType.EscapeMenu);
         }
       }
     );
-    this.inputManager.registerKeyboardListener(
+    this.getInputManager().registerKeyboardListener(
       Phaser.Input.Keyboard.KeyCodes.TAB,
       'up',
       async () => {
-        if (this.phaseManager.isCurrentPhase(GamePhaseType.AwardMenu)) {
-          await this.phaseManager.popPhase();
+        if (this.getPhaseManager().isCurrentPhase(GamePhaseType.AwardMenu)) {
+          await this.getPhaseManager().popPhase();
         } else {
-          await this.phaseManager.pushPhase(GamePhaseType.AwardMenu);
+          await this.getPhaseManager().pushPhase(GamePhaseType.AwardMenu);
         }
       }
     );
@@ -236,8 +212,8 @@ class GameManager extends Phaser.Scene {
    * Clean up on related managers
    */
   public cleanUp() {
-    this.inputManager.clearListeners();
-    this.layerManager.clearAllLayers();
+    this.getInputManager().clearListeners();
+    this.getLayerManager().clearAllLayers();
   }
 
   /**
@@ -276,6 +252,11 @@ class GameManager extends Phaser.Scene {
   public getCharacterManager = () => mandatory(this.characterManager);
   public getBBoxManager = () => mandatory(this.boundingBoxManager);
   public getActionManager = () => mandatory(this.actionManager);
+  public getInputManager = () => mandatory(this.inputManager);
+  public getLayerManager = () => mandatory(this.layerManager);
+  public getPhaseManager = () => mandatory(this.phaseManager);
+  public getBackgroundManager = () => mandatory(this.backgroundManager);
+  public getPopupManager = () => mandatory(this.popUpManager);
 }
 
 export default GameManager;

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -91,7 +91,7 @@ class GameManager extends Phaser.Scene {
       async (prevPhase: GamePhaseType, newPhase: GamePhaseType) =>
         await this.checkpointTransition(newPhase)
     );
-    this.phaseManager.setCallback(
+    this.getPhaseManager().setCallback(
       async (prevPhase: GamePhaseType, newPhase: GamePhaseType) =>
         await this.handleCharacterLayer(prevPhase, newPhase)
     );

--- a/src/features/game/scenes/gameManager/GameManager.ts
+++ b/src/features/game/scenes/gameManager/GameManager.ts
@@ -65,11 +65,14 @@ class GameManager extends Phaser.Scene {
     this.getSaveManager().registerGameInfo(chapterNum, checkpointNum, continueGame);
     this.currentLocationId =
       this.getSaveManager().getLoadedLocation() || gameCheckpoint.startingLoc;
+    this.stateManager = new GameStateManager(gameCheckpoint);
+    this.initialiseManagers();
+  }
 
+  private initialiseManagers() {
     this.layerManager = new GameLayerManager(this);
     this.inputManager = new GameInputManager(this);
     this.phaseManager = new GamePhaseManager(createGamePhases(), this.inputManager);
-    this.stateManager = new GameStateManager(gameCheckpoint);
     this.characterManager = new GameCharacterManager();
     this.objectManager = new GameObjectManager();
     this.dialogueManager = new GameDialogueManager();

--- a/src/features/game/scenes/mainMenu/MainMenu.ts
+++ b/src/features/game/scenes/mainMenu/MainMenu.ts
@@ -5,6 +5,7 @@ import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
 import SourceAcademyGame from '../../SourceAcademyGame';
 import { createButton } from '../../utils/ButtonUtils';
+import { mandatory } from '../../utils/GameUtils';
 import { calcTableFormatPos, Direction } from '../../utils/StyleUtils';
 import mainMenuConstants, { mainMenuStyle } from './MainMenuConstants';
 
@@ -14,20 +15,15 @@ import mainMenuConstants, { mainMenuStyle } from './MainMenuConstants';
  * User can navigate to other scenes from here.
  */
 class MainMenu extends Phaser.Scene {
-  private layerManager: GameLayerManager;
+  private layerManager?: GameLayerManager;
 
   constructor() {
     super('MainMenu');
-
-    this.layerManager = new GameLayerManager();
-  }
-
-  public preload() {
-    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
-    this.layerManager.initialise(this);
   }
 
   public async create() {
+    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
+    this.layerManager = new GameLayerManager(this);
     this.renderBackground();
     this.renderOptionButtons();
 
@@ -46,7 +42,7 @@ class MainMenu extends Phaser.Scene {
       ImageAssets.mainMenuBackground.key
     ).setDisplaySize(screenSize.x, screenSize.y);
 
-    this.layerManager.addToLayer(Layer.Background, backgroundImg);
+    this.getLayerManager().addToLayer(Layer.Background, backgroundImg);
   }
 
   /**
@@ -74,7 +70,7 @@ class MainMenu extends Phaser.Scene {
       )
     );
 
-    this.layerManager.addToLayer(Layer.UI, optionsContainer);
+    this.getLayerManager().addToLayer(Layer.UI, optionsContainer);
   }
 
   /**
@@ -125,40 +121,41 @@ class MainMenu extends Phaser.Scene {
       {
         text: mainMenuConstants.optionsText.chapterSelect,
         callback: () => {
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('ChapterSelect');
         }
       },
       {
         text: mainMenuConstants.optionsText.awards,
         callback: () => {
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('AwardsHall');
         }
       },
       {
         text: mainMenuConstants.optionsText.studentRoom,
         callback: () => {
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('RoomPreview');
         }
       },
       {
         text: mainMenuConstants.optionsText.settings,
         callback: () => {
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('Settings');
         }
       },
       {
         text: mainMenuConstants.optionsText.bindings,
         callback: () => {
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('Bindings');
         }
       }
     ];
   }
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default MainMenu;

--- a/src/features/game/scenes/settings/Settings.ts
+++ b/src/features/game/scenes/settings/Settings.ts
@@ -6,6 +6,7 @@ import GameLayerManager from '../../layer/GameLayerManager';
 import { Layer } from '../../layer/GameLayerTypes';
 import SourceAcademyGame from '../../SourceAcademyGame';
 import { createButton } from '../../utils/ButtonUtils';
+import { mandatory } from '../../utils/GameUtils';
 import { calcTableFormatPos, Direction } from '../../utils/StyleUtils';
 import { createBitmapText } from '../../utils/TextUtils';
 import settingsConstants, {
@@ -21,18 +22,15 @@ import settingsConstants, {
 class Settings extends Phaser.Scene {
   private bgmVolumeRadioButtons: CommonRadioButton | undefined;
   private sfxVolumeRadioButtons: CommonRadioButton | undefined;
-  private layerManager: GameLayerManager;
+  private layerManager?: GameLayerManager;
 
   constructor() {
     super('Settings');
-    this.layerManager = new GameLayerManager();
-  }
-  public preload() {
-    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
-    this.layerManager.initialise(this);
   }
 
   public async create() {
+    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
+    this.layerManager = new GameLayerManager(this);
     this.renderBackground();
     this.renderOptions();
   }
@@ -54,8 +52,8 @@ class Settings extends Phaser.Scene {
       screenCenter.y,
       ImageAssets.settingBanner.key
     );
-    this.layerManager.addToLayer(Layer.Background, background);
-    this.layerManager.addToLayer(Layer.Background, settingBgImg);
+    this.getLayerManager().addToLayer(Layer.Background, background);
+    this.getLayerManager().addToLayer(Layer.Background, settingBgImg);
   }
 
   /**
@@ -100,15 +98,15 @@ class Settings extends Phaser.Scene {
 
     // Create back button to main menu
     const backButton = new CommonBackButton(this, () => {
-      this.layerManager.clearAllLayers();
+      this.getLayerManager().clearAllLayers();
       this.scene.start('MainMenu');
     });
 
-    this.layerManager.addToLayer(Layer.UI, optCont);
-    this.layerManager.addToLayer(Layer.UI, this.sfxVolumeRadioButtons);
-    this.layerManager.addToLayer(Layer.UI, this.bgmVolumeRadioButtons);
-    this.layerManager.addToLayer(Layer.UI, applySettingsButton);
-    this.layerManager.addToLayer(Layer.UI, backButton);
+    this.getLayerManager().addToLayer(Layer.UI, optCont);
+    this.getLayerManager().addToLayer(Layer.UI, this.sfxVolumeRadioButtons);
+    this.getLayerManager().addToLayer(Layer.UI, this.bgmVolumeRadioButtons);
+    this.getLayerManager().addToLayer(Layer.UI, applySettingsButton);
+    this.getLayerManager().addToLayer(Layer.UI, backButton);
   }
 
   /**
@@ -188,6 +186,7 @@ class Settings extends Phaser.Scene {
   }
 
   public getSaveManager = () => SourceAcademyGame.getInstance().getSaveManager();
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default Settings;

--- a/src/features/storySimulator/background/SSBackgroundManager.ts
+++ b/src/features/storySimulator/background/SSBackgroundManager.ts
@@ -44,14 +44,14 @@ export default class SSBackgroundManager {
       return;
     }
 
-    this.getObjectPlacement().layerManager.clearLayerContents(Layer.Background);
+    this.getObjectPlacement().getLayerManager().clearLayerContents(Layer.Background);
     const backgroundSprite = new Phaser.GameObjects.Image(
       this.getObjectPlacement(),
       screenCenter.x,
       screenCenter.y,
       backgroundAssetKey
     ).setInteractive();
-    this.getObjectPlacement().layerManager.addToLayer(Layer.Background, backgroundSprite);
+    this.getObjectPlacement().getLayerManager().addToLayer(Layer.Background, backgroundSprite);
   }
 
   private getObjectPlacement = () => mandatory(this.objectPlacement);

--- a/src/features/storySimulator/boundingBoxes/SSBBoxManager.ts
+++ b/src/features/storySimulator/boundingBoxes/SSBBoxManager.ts
@@ -28,30 +28,34 @@ export default class SSBBoxManager implements ICheckpointLoggable {
   }
 
   private addBBoxListeners(objectPlacement: ObjectPlacement) {
-    this.getObjectPlacement().inputManager.registerEventListener('pointerdown', () => {
-      if (this.getObjectPlacement().isCursorMode(CursorMode.DrawBBox)) {
-        this.bboxBeingDrawn = this.createNewBBox();
-      }
-    });
-
-    this.getObjectPlacement().inputManager.registerEventListener('pointerup', () => {
-      if (this.getObjectPlacement().isCursorMode(CursorMode.DrawBBox) && this.bboxBeingDrawn) {
-        if (this.bboxBeingDrawn.displayWidth <= 2 || this.bboxBeingDrawn.displayHeight <= 2) {
-          this.bboxBeingDrawn.destroy();
-          return;
+    this.getObjectPlacement()
+      .getInputManager()
+      .registerEventListener('pointerdown', () => {
+        if (this.getObjectPlacement().isCursorMode(CursorMode.DrawBBox)) {
+          this.bboxBeingDrawn = this.createNewBBox();
         }
-        this.bboxBeingDrawn.x += this.bboxBeingDrawn.displayWidth / 2;
-        this.bboxBeingDrawn.y += this.bboxBeingDrawn.displayHeight / 2;
-        this.bboxBeingDrawn.setOrigin(0.5);
-        this.registerBBox(this.bboxBeingDrawn);
+      });
 
-        objectPlacement.input.setDraggable(this.bboxBeingDrawn);
-        this.getObjectPlacement().setActiveSelection(this.bboxBeingDrawn);
+    this.getObjectPlacement()
+      .getInputManager()
+      .registerEventListener('pointerup', () => {
+        if (this.getObjectPlacement().isCursorMode(CursorMode.DrawBBox) && this.bboxBeingDrawn) {
+          if (this.bboxBeingDrawn.displayWidth <= 2 || this.bboxBeingDrawn.displayHeight <= 2) {
+            this.bboxBeingDrawn.destroy();
+            return;
+          }
+          this.bboxBeingDrawn.x += this.bboxBeingDrawn.displayWidth / 2;
+          this.bboxBeingDrawn.y += this.bboxBeingDrawn.displayHeight / 2;
+          this.bboxBeingDrawn.setOrigin(0.5);
+          this.registerBBox(this.bboxBeingDrawn);
 
-        this.startingCoordinates = undefined;
-        this.bboxBeingDrawn = undefined;
-      }
-    });
+          objectPlacement.input.setDraggable(this.bboxBeingDrawn);
+          this.getObjectPlacement().setActiveSelection(this.bboxBeingDrawn);
+
+          this.startingCoordinates = undefined;
+          this.bboxBeingDrawn = undefined;
+        }
+      });
   }
 
   private createNewBBox() {
@@ -70,7 +74,7 @@ export default class SSBBoxManager implements ICheckpointLoggable {
       .setDataEnabled();
 
     this.startingCoordinates = [x, y];
-    this.getObjectPlacement().layerManager.addToLayer(Layer.BBox, bboxBeingDrawn);
+    this.getObjectPlacement().getLayerManager().addToLayer(Layer.BBox, bboxBeingDrawn);
     return bboxBeingDrawn;
   }
 

--- a/src/features/storySimulator/objects/SSObjectManager.ts
+++ b/src/features/storySimulator/objects/SSObjectManager.ts
@@ -52,7 +52,7 @@ export default class SSObjectManager implements ICheckpointLoggable {
       .setInteractive()
       .setDataEnabled();
     this.getObjectPlacement().input.setDraggable(objectSprite);
-    this.getObjectPlacement().layerManager.addToLayer(Layer.Objects, objectSprite);
+    this.getObjectPlacement().getLayerManager().addToLayer(Layer.Objects, objectSprite);
 
     this.registerObject(objectAssetKey, objectSprite);
   }

--- a/src/features/storySimulator/scenes/ObjectPlacement/ObjectPlacement.ts
+++ b/src/features/storySimulator/scenes/ObjectPlacement/ObjectPlacement.ts
@@ -23,8 +23,8 @@ import objPlacementConstants from './ObjectPlacementConstants';
  * the coordinates of the objects.
  */
 export default class ObjectPlacement extends Phaser.Scene {
-  public layerManager: GameLayerManager;
-  public inputManager: GameInputManager;
+  public layerManager?: GameLayerManager;
+  public inputManager?: GameInputManager;
   private transformManager: SSTransformManager;
   private cursorModes: SSCursorMode | undefined;
   private bboxManager: SSBBoxManager;
@@ -40,8 +40,6 @@ export default class ObjectPlacement extends Phaser.Scene {
 
   constructor() {
     super('ObjectPlacement');
-    this.layerManager = new GameLayerManager();
-    this.inputManager = new GameInputManager();
     this.objectManager = new SSObjectManager();
     this.bboxManager = new SSBBoxManager();
     this.backgroundManager = new SSBackgroundManager();
@@ -54,8 +52,8 @@ export default class ObjectPlacement extends Phaser.Scene {
   }
 
   public init() {
-    this.layerManager = new GameLayerManager();
-    this.inputManager = new GameInputManager();
+    this.layerManager = new GameLayerManager(this);
+    this.inputManager = new GameInputManager(this);
     this.objectManager = new SSObjectManager();
     this.bboxManager = new SSBBoxManager();
     this.backgroundManager = new SSBackgroundManager();
@@ -70,8 +68,6 @@ export default class ObjectPlacement extends Phaser.Scene {
   public create() {
     SourceAcademyGame.getInstance().setCurrentSceneRef(this);
 
-    this.layerManager.initialise(this);
-    this.inputManager.initialise(this);
     this.renderBackground();
     this.createUIButtons();
     this.backgroundManager.initialise(this);
@@ -113,7 +109,7 @@ export default class ObjectPlacement extends Phaser.Scene {
     uiContainer.add(this.cursorModes);
     uiContainer.add(backButton);
 
-    this.layerManager.addToLayer(Layer.UI, uiContainer);
+    this.getLayerManager().addToLayer(Layer.UI, uiContainer);
   }
 
   public renderBackground() {
@@ -125,7 +121,7 @@ export default class ObjectPlacement extends Phaser.Scene {
     );
     backgroundImg.setDisplaySize(screenSize.x, screenSize.y);
 
-    this.layerManager.addToLayer(Layer.Background, backgroundImg);
+    this.getLayerManager().addToLayer(Layer.Background, backgroundImg);
   }
 
   private populateCursorModes() {
@@ -186,7 +182,7 @@ export default class ObjectPlacement extends Phaser.Scene {
         const confirm = window.confirm('Are you sure you want to delete?');
 
         if (!confirm) return;
-        this.layerManager.clearSeveralLayers([Layer.Background, Layer.BBox, Layer.Objects]);
+        this.getLayerManager().clearSeveralLayers([Layer.Background, Layer.BBox, Layer.Objects]);
         this.objectManager.deleteAll();
         this.bboxManager.deleteAll();
         this.transformManager.deselect();
@@ -208,8 +204,8 @@ export default class ObjectPlacement extends Phaser.Scene {
   }
 
   private cleanUp() {
-    this.inputManager.clearListeners();
-    this.layerManager.clearAllLayers();
+    this.getInputManager().clearListeners();
+    this.getLayerManager().clearAllLayers();
   }
 
   public addAsset(assetKey: AssetKey, assetPath: AssetPath) {
@@ -251,4 +247,7 @@ export default class ObjectPlacement extends Phaser.Scene {
   public deleteBBox(bboxSprite: Phaser.GameObjects.Rectangle | Phaser.GameObjects.Image) {
     this.bboxManager.delete(bboxSprite);
   }
+
+  public getInputManager = () => mandatory(this.inputManager);
+  public getLayerManager = () => mandatory(this.layerManager);
 }

--- a/src/features/storySimulator/scenes/mainMenu/MainMenu.ts
+++ b/src/features/storySimulator/scenes/mainMenu/MainMenu.ts
@@ -8,7 +8,7 @@ import { Layer } from 'src/features/game/layer/GameLayerTypes';
 import Parser from 'src/features/game/parser/Parser';
 import SourceAcademyGame from 'src/features/game/SourceAcademyGame';
 import { createButton } from 'src/features/game/utils/ButtonUtils';
-import { toS3Path } from 'src/features/game/utils/GameUtils';
+import { mandatory, toS3Path } from 'src/features/game/utils/GameUtils';
 import { calcTableFormatPos } from 'src/features/game/utils/StyleUtils';
 
 import SSImageAssets from '../../assets/ImageAssets';
@@ -22,18 +22,16 @@ import mainMenuConstants, { mainMenuOptStyle } from './MainMenuConstants';
  * functionalities from here.
  */
 class MainMenu extends Phaser.Scene {
-  private layerManager: GameLayerManager;
+  private layerManager?: GameLayerManager;
 
   constructor() {
     super('StorySimulatorMenu');
-    this.layerManager = new GameLayerManager();
-  }
-  public init() {
-    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
-    this.layerManager.initialise(this);
   }
 
   public preload() {
+    SourceAcademyGame.getInstance().setCurrentSceneRef(this);
+    this.layerManager = new GameLayerManager(this);
+
     addLoadingScreen(this);
     Object.values(ImageAssets).forEach(asset => this.load.image(asset.key, toS3Path(asset.path)));
     Object.values(SSImageAssets).forEach(asset => this.load.image(asset.key, toS3Path(asset.path)));
@@ -74,7 +72,7 @@ class MainMenu extends Phaser.Scene {
         )
       )
     );
-    this.layerManager.addToLayer(Layer.UI, optionsContainer);
+    this.getLayerManager().addToLayer(Layer.UI, optionsContainer);
   }
 
   private getOptionButtons() {
@@ -83,7 +81,7 @@ class MainMenu extends Phaser.Scene {
         text: 'Object Placement',
         callback: () => {
           SourceAcademyGame.getInstance().setStorySimState(StorySimState.ObjectPlacement);
-          this.layerManager.clearAllLayers();
+          this.getLayerManager().clearAllLayers();
           this.scene.start('ObjectPlacement');
         }
       },
@@ -127,7 +125,7 @@ class MainMenu extends Phaser.Scene {
       return;
     }
 
-    this.layerManager.clearAllLayers();
+    this.getLayerManager().clearAllLayers();
 
     Parser.parse(defaultChapterText);
     if (checkpointTxt) {
@@ -156,9 +154,10 @@ class MainMenu extends Phaser.Scene {
       screenCenter.y,
       SSImageAssets.blueUnderlay.key
     ).setAlpha(0.5);
-    this.layerManager.addToLayer(Layer.Background, backgroundImg);
-    this.layerManager.addToLayer(Layer.Background, backgroundUnderlay);
+    this.getLayerManager().addToLayer(Layer.Background, backgroundImg);
+    this.getLayerManager().addToLayer(Layer.Background, backgroundUnderlay);
   }
+  public getLayerManager = () => mandatory(this.layerManager);
 }
 
 export default MainMenu;

--- a/src/features/storySimulator/transform/SSTransformManager.ts
+++ b/src/features/storySimulator/transform/SSTransformManager.ts
@@ -27,37 +27,39 @@ export default class SSTransformManager {
       1,
       0
     ).setAlpha(0.3);
-    this.getObjectPlacement().layerManager.addToLayer(Layer.Selector, this.activeSelectRect);
+    this.getObjectPlacement().getLayerManager().addToLayer(Layer.Selector, this.activeSelectRect);
   }
 
   private trackDraggables(objectPlacement: ObjectPlacement) {
-    objectPlacement.inputManager.registerEventListener(
-      'drag',
-      (
-        pointer: MouseEvent,
-        gameObject: Phaser.GameObjects.Image | Phaser.GameObjects.Rectangle,
-        dragX: number,
-        dragY: number
-      ) => {
-        if (!objectPlacement.isCursorMode(CursorMode.DrawBBox)) {
-          objectPlacement.getCursorManager().setCursorMode(CursorMode.DragResizeObj);
-          gameObject.x = dragX;
-          gameObject.y = dragY;
-        }
+    objectPlacement
+      .getInputManager()
+      .registerEventListener(
+        'drag',
+        (
+          pointer: MouseEvent,
+          gameObject: Phaser.GameObjects.Image | Phaser.GameObjects.Rectangle,
+          dragX: number,
+          dragY: number
+        ) => {
+          if (!objectPlacement.isCursorMode(CursorMode.DrawBBox)) {
+            objectPlacement.getCursorManager().setCursorMode(CursorMode.DragResizeObj);
+            gameObject.x = dragX;
+            gameObject.y = dragY;
+          }
 
-        if (gameObject.data.get('type') === 'object') {
-          objectPlacement.setObjAttribute(gameObject, 'x', dragX);
-          objectPlacement.setObjAttribute(gameObject, 'y', dragY);
-          this.setActiveSelection(gameObject);
-        }
+          if (gameObject.data.get('type') === 'object') {
+            objectPlacement.setObjAttribute(gameObject, 'x', dragX);
+            objectPlacement.setObjAttribute(gameObject, 'y', dragY);
+            this.setActiveSelection(gameObject);
+          }
 
-        if (gameObject.data.get('type') === 'bbox') {
-          objectPlacement.setBBoxAttribute(gameObject, 'x', dragX);
-          objectPlacement.setBBoxAttribute(gameObject, 'y', dragY);
-          this.setActiveSelection(gameObject);
+          if (gameObject.data.get('type') === 'bbox') {
+            objectPlacement.setBBoxAttribute(gameObject, 'x', dragX);
+            objectPlacement.setBBoxAttribute(gameObject, 'y', dragY);
+            this.setActiveSelection(gameObject);
+          }
         }
-      }
-    );
+      );
   }
 
   public resizeActive(enlarge: boolean) {
@@ -127,10 +129,12 @@ export default class SSTransformManager {
       Phaser.Input.Keyboard.KeyCodes.DELETE
     ];
     deleteKeys.forEach(key =>
-      this.getObjectPlacement().inputManager.registerKeyboardListener(key, 'up', () => {
-        this.deleteActiveSelection();
-        this.deselect();
-      })
+      this.getObjectPlacement()
+        .getInputManager()
+        .registerKeyboardListener(key, 'up', () => {
+          this.deleteActiveSelection();
+          this.deselect();
+        })
     );
   }
 

--- a/src/pages/academy/storySimulator/StorySimulator.tsx
+++ b/src/pages/academy/storySimulator/StorySimulator.tsx
@@ -12,7 +12,6 @@ import { createStorySimulatorGame } from './subcomponents/storySimulatorGame';
 
 function StorySimulator() {
   const session = useSelector((state: OverallState) => state.session);
-
   const [storySimState, setStorySimState] = React.useState<string>(StorySimState.Default);
 
   React.useEffect(() => {


### PR DESCRIPTION
### Description

- Removes concept of construct + initialise inside managers. Just construct directly
- Reduces declaration of manager in scenes from 4 times at the start (declare vars, fake construct, real construct, initialise) , to just 2 times (declare vars and construct) with 1 hidden getter at the bottom
- While scenes need mandatory getters, managers don't need to have mandatory getters anymore so they are kept simple

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist

Please delete options that are not relevant.

- [ ] I have tested this code
- [ ] I have updated the documentation
