### PR TITLE
Disable the REPL for the WebAssembly variant

### DIFF
--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -47,7 +47,9 @@ class Repl extends React.PureComponent<ReplProps, {}> {
             className={classNames('repl-input-parent', 'row', Classes.CARD, Classes.ELEVATION_0)}
             handlers={handlers}
           >
-            {this.props.sourceVariant !== 'concurrent' ? <ReplInput {...inputProps} /> : null}
+            {this.props.sourceVariant !== 'concurrent' && this.props.sourceVariant !== 'wasm' ? (
+              <ReplInput {...inputProps} />
+            ) : null}
           </HotKeys>
         </div>
       </div>

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -419,7 +419,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
         persistenceButtons,
         executionTime
       ],
-      replButtons: [props.sourceVariant !== 'concurrent' ? evalButton : null, clearButton]
+      replButtons: [
+        props.sourceVariant !== 'concurrent' && props.sourceVariant !== 'wasm' ? evalButton : null,
+        clearButton
+      ]
     },
     editorProps: {
       sourceChapter: props.sourceChapter,


### PR DESCRIPTION
### Description

This PR disables the REPL for the `wasm` variant in a similar way as the `concurrent` variant.  Running `yarn install` modified yarn.lock, so I also added the new lock file to this PR.

Fixes #1392.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Rebuild cadet-frontend, set the language variant to Source 1 WebAssembly, and observe that the REPL input box is now hidden.

### Checklist

- [x] I have tested this code
