### PR TITLE
Catch all uncaught errors thrown from Sagas

### DIFF
--- a/src/commons/sagas/AchievementSaga.ts
+++ b/src/commons/sagas/AchievementSaga.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import {
   EDIT_ACHIEVEMENT,
@@ -10,6 +10,7 @@ import {
 import { OverallState } from '../application/ApplicationTypes';
 import { actions } from '../utils/ActionsHelper';
 import { editAchievement, getAchievements, removeAchievement, removeGoal } from './RequestsSaga';
+import { safeTakeEvery as takeEvery } from './SafeEffects';
 
 export default function* AchievementSaga(): SagaIterator {
   yield takeEvery(GET_ACHIEVEMENTS, function* () {

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -1,7 +1,7 @@
 /*eslint no-eval: "error"*/
 /*eslint-env browser*/
 import { SagaIterator } from 'redux-saga';
-import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import { OverallState, Role } from '../../commons/application/ApplicationTypes';
 import {
@@ -73,6 +73,7 @@ import {
   publishAssessment,
   uploadAssessment
 } from './RequestsSaga';
+import { safeTakeEvery as takeEvery } from './SafeEffects';
 
 function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_AUTH, function* (action: ReturnType<typeof actions.fetchAuth>) {

--- a/src/commons/sagas/LoginSaga.ts
+++ b/src/commons/sagas/LoginSaga.ts
@@ -1,10 +1,11 @@
 import { SagaIterator } from 'redux-saga';
-import { call, takeEvery } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 
 import { LOGIN } from '../application/types/SessionTypes';
 import { actions } from '../utils/ActionsHelper';
 import { computeEndpointUrl } from '../utils/AuthHelper';
 import { showWarningMessage } from '../utils/NotificationsHelper';
+import { safeTakeEvery as takeEvery } from './SafeEffects';
 
 export default function* LoginSaga(): SagaIterator {
   yield takeEvery(LOGIN, updateLoginHref);

--- a/src/commons/sagas/PersistenceSaga.tsx
+++ b/src/commons/sagas/PersistenceSaga.tsx
@@ -1,8 +1,7 @@
 import { Intent } from '@blueprintjs/core';
 import * as React from 'react';
 import { SagaIterator } from 'redux-saga';
-import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
-import { playgroundUpdatePersistenceFile } from 'src/features/playground/PlaygroundActions';
+import { call, put, select } from 'redux-saga/effects';
 
 import {
   PERSISTENCE_INITIALISE,
@@ -25,6 +24,7 @@ import {
   showWarningMessage
 } from '../utils/NotificationsHelper';
 import { AsyncReturnType } from '../utils/TypeHelper';
+import { safeTakeEvery as takeEvery, safeTakeLatest as takeLatest } from './SafeEffects';
 
 const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
 const SCOPES = 'profile https://www.googleapis.com/auth/drive.file';
@@ -38,7 +38,7 @@ const MIME_SOURCE = 'text/plain';
 
 export function* persistenceSaga(): SagaIterator {
   yield takeLatest(LOGOUT_GOOGLE, function* () {
-    yield put(playgroundUpdatePersistenceFile(undefined));
+    yield put(actions.playgroundUpdatePersistenceFile(undefined));
     yield call(ensureInitialised);
     yield call([gapi.auth2.getAuthInstance(), 'signOut']);
   });

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -2,7 +2,7 @@ import { Variant } from 'js-slang/dist/types';
 import { compressToEncodedURIComponent } from 'lz-string';
 import * as qs from 'query-string';
 import { SagaIterator } from 'redux-saga';
-import { call, delay, put, race, select, takeEvery } from 'redux-saga/effects';
+import { call, delay, put, race, select } from 'redux-saga/effects';
 
 import { ExternalLibraryName } from '../../commons/application/types/ExternalTypes';
 import {
@@ -14,6 +14,7 @@ import { GENERATE_LZ_STRING, SHORTEN_URL } from '../../features/playground/Playg
 import { defaultEditorValue, OverallState } from '../application/ApplicationTypes';
 import Constants from '../utils/Constants';
 import { showSuccessMessage, showWarningMessage } from '../utils/NotificationsHelper';
+import { safeTakeEvery as takeEvery } from './SafeEffects';
 
 export default function* PlaygroundSaga(): SagaIterator {
   yield takeEvery(GENERATE_LZ_STRING, updateQueryString);

--- a/src/commons/sagas/SafeEffects.ts
+++ b/src/commons/sagas/SafeEffects.ts
@@ -1,0 +1,64 @@
+import { ActionMatchingPattern } from '@redux-saga/types';
+import * as Sentry from '@sentry/browser';
+import {
+  ActionPattern,
+  ForkEffect,
+  HelperWorkerParameters,
+  takeEvery,
+  takeLatest
+} from 'redux-saga/effects';
+
+// it's not possible to abstract the two functions into HOF over takeEvery and takeLatest
+// without stepping out of TypeScript's type system because the type system does not support
+// higher-kinded types (type parameters that take )
+
+function handleUncaughtError(error: any) {
+  if (process.env.NODE_ENV === 'development') {
+    // react-error-overlay is a "special" package that's automatically included
+    // in development mode by CRA
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    import('react-error-overlay').then(reo => reo.reportRuntimeError(error));
+  }
+  Sentry.captureException(error);
+  console.error(error);
+}
+
+export function safeTakeEvery<P extends ActionPattern, A extends ActionMatchingPattern<P>>(
+  pattern: P,
+  worker: (action: A) => any
+): ForkEffect<never>;
+export function safeTakeEvery<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect<never> {
+  function* wrappedWorker(...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>) {
+    try {
+      yield* worker(...args);
+    } catch (error) {
+      handleUncaughtError(error);
+    }
+  }
+  return takeEvery<P, typeof wrappedWorker>(pattern, wrappedWorker, ...args);
+}
+
+export function safeTakeLatest<P extends ActionPattern, A extends ActionMatchingPattern<P>>(
+  pattern: P,
+  worker: (action: A) => any
+): ForkEffect<never>;
+export function safeTakeLatest<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect<never> {
+  function* wrappedWorker(...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>) {
+    try {
+      yield* worker(...args);
+    } catch (error) {
+      handleUncaughtError(error);
+    }
+  }
+  return takeLatest<P, typeof wrappedWorker>(pattern, wrappedWorker, ...args);
+}

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -18,7 +18,7 @@ import { validateAndAnnotate } from 'js-slang/dist/validator/validator';
 import { random } from 'lodash';
 import Phaser from 'phaser';
 import { SagaIterator } from 'redux-saga';
-import { call, delay, put, race, select, take, takeEvery } from 'redux-saga/effects';
+import { call, delay, put, race, select, take } from 'redux-saga/effects';
 import * as Sourceror from 'sourceror';
 
 import { PlaygroundState } from '../../features/playground/PlaygroundTypes';
@@ -66,6 +66,7 @@ import {
   UPDATE_EDITOR_BREAKPOINTS,
   WorkspaceLocation
 } from '../workspace/WorkspaceTypes';
+import { safeTakeEvery as takeEvery } from './SafeEffects';
 
 let breakpoints: string[] = [];
 export default function* WorkspaceSaga(): SagaIterator {


### PR DESCRIPTION
### Description

Catch all uncaught errors thrown from Sagas.

This prevents the Sagas from terminating.

In development mode, also show the React runtime error screen.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Throw an error in a Saga.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
