### PR TITLE
Disable Stepper tab for lazy Source variants

### DIFF
--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -395,8 +395,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
       tabs.push(envVisualizerTab);
     }
 
-    if (props.sourceChapter <= 2 && props.sourceVariant !== 'wasm') {
-      // Enable Subst Visualizer for Source 1 & 2
+    if (props.sourceChapter <= 2 && props.sourceVariant === 'default') {
+      // Enable Subst Visualizer only for default Source 1 & 2
       tabs.push({
         label: 'Stepper',
         iconName: IconNames.FLOW_REVIEW,


### PR DESCRIPTION
## Disable Stepper tab for lazy Source variants
Summary: Fixes #1429.

### Changelog
- Display the Stepper tab only for default Source 1 and 2
  - Stepper is thus disabled for all non-default variants of Source 1 and 2, and all variants (including default) of Source 3 or 4

### Verification instructions
1. Proceed to the Playground in the development environment, and verify the Stepper tab is hidden with any lazy Source variant

### Screenshots

#### Side-content tabs displayed for Source 2 Lazy
![image](https://user-images.githubusercontent.com/44989315/89290083-e2f8ab80-d68a-11ea-8d0a-8fa7bc42a32b.png)

Last updated 4 Aug 2020, 7:45 PM