### PR TITLE
Fix game not terminating properly after leaving page

### DIFF
--- a/src/pages/academy/game/Game.tsx
+++ b/src/pages/academy/game/Game.tsx
@@ -16,10 +16,11 @@ function Game() {
   const [isUsingMock, setIsUsingMock] = React.useState(false);
 
   React.useEffect(() => {
-    createSourceAcademyGame();
+    const game = createSourceAcademyGame();
     return () => {
-      SourceAcademyGame.getInstance().isMounted = false;
-      SourceAcademyGame.getInstance().stopAllSounds();
+      game.isMounted = false;
+      game.stopAllSounds();
+      game.destroy(true);
     };
   }, []);
 


### PR DESCRIPTION
### Description

Fix the game not terminating properly when navigating away from the game page.

If a user clicks on the "Source Academy" button, React Router actually navigates
to /academy, and then immediately back to /academy/game. This often leads to
multiple instances of the game running (just repeatedly click on the Source
Academy logo button and you can easily reproduce it).

The reason is that the navigation back to /academy/game causes the Game page to
be reloaded, and `createSourceAcademyGame` called, before the destructor (the
lambda returned from `useEffect`) of the initial Game page runs.

Thus when the destructor eventually runs, `SourceAcademyGame.getInstance()` now
refers to the **new** game instance. The old game instance is left in the
background.

```
React.useEffect(() => {
  createSourceAcademyGame();
  return () => {
    SourceAcademyGame.getInstance().isMounted = false;
    SourceAcademyGame.getInstance().stopAllSounds();
  };
}, []);
```

Calling `destroy` also explicitly terminates all the event loops etc. set up by
Phaser immediately which should help with the memory and CPU issues persisting
after leaving the Game page.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Open the game and repeatedly click the "Source Academy" logo button. See (or actually, hear) that there is only ever one game instance.

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
- [ ] I have updated the documentation
