### PR TITLE
Stepper step limit control bar input

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -210,6 +210,7 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): Wo
   sharedbAceInitValue: '',
   sharedbAceIsInviting: false,
   sideContentActiveTab: SideContentType.questionOverview,
+  stepLimit: 1000,
   websocketStatus: 0,
   globals: [],
   isEditorAutorun: false,

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -1,0 +1,29 @@
+import { NumericInput, Tooltip } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import * as React from 'react';
+
+type ControlBarStepLimitProps = DispatchProps & StateProps;
+
+type DispatchProps = {
+  handleChangeStepLimit?: (stepLimit: number) => void;
+};
+
+type StateProps = {
+  stepLimit?: number;
+  key: string;
+};
+
+export function ControlBarStepLimit(props: ControlBarStepLimitProps) {
+  return (
+    <Tooltip content="Step Limit">
+      <NumericInput
+        leftIcon={IconNames.VERTICAL_BAR_CHART_ASC}
+        style={{ width: 80 }}
+        min={500}
+        max={5000}
+        value={props.stepLimit}
+        onValueChange={props.handleChangeStepLimit}
+      />
+    </Tooltip>
+  );
+}

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -580,6 +580,9 @@ export function* evalCode(
   const substIsActive: boolean = yield select(
     (state: OverallState) => (state.playground as PlaygroundState).usingSubst
   );
+  const stepLimit: number = yield select(
+    (state: OverallState) => state.workspaces[workspaceLocation].stepLimit
+  );
   const substActiveAndCorrectChapter =
     context.chapter <= 2 && workspaceLocation === 'playground' && substIsActive;
   if (substActiveAndCorrectChapter) {
@@ -598,12 +601,14 @@ export function* evalCode(
         : call(runInContext, code, context, {
             executionMethod: 'interpreter',
             originalMaxExecTime: execTime,
+            stepLimit: stepLimit,
             useSubst: substActiveAndCorrectChapter
           });
     } else if (variant === 'lazy') {
       return call(runInContext, code, context, {
         scheduler: 'preemptive',
         originalMaxExecTime: execTime,
+        stepLimit: stepLimit,
         useSubst: substActiveAndCorrectChapter
       });
     } else if (variant === 'wasm') {
@@ -633,6 +638,7 @@ export function* evalCode(
         : call(runInContext, code, context, {
             scheduler: 'preemptive',
             originalMaxExecTime: execTime,
+            stepLimit: stepLimit,
             useSubst: substActiveAndCorrectChapter
           }),
 

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -130,6 +130,7 @@ describe('EVAL_EDITOR', () => {
             {
               scheduler: 'preemptive',
               originalMaxExecTime: execTime,
+              stepLimit: 1000,
               useSubst: false
             }
           ]
@@ -144,7 +145,7 @@ describe('EVAL_EDITOR', () => {
           args: [
             editorValue,
             context,
-            { scheduler: 'preemptive', originalMaxExecTime: execTime, useSubst: false }
+            { scheduler: 'preemptive', originalMaxExecTime: execTime, stepLimit: 1000, useSubst: false }
           ]
         })
         // running the student's program should return -1, which is written to REPL
@@ -217,6 +218,7 @@ describe('EVAL_REPL', () => {
         .call(runInContext, replValue, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: 1000,
+          stepLimit: 1000,
           useSubst: false
         })
         .dispatch({
@@ -688,7 +690,12 @@ describe('evalCode', () => {
     actionType = EVAL_EDITOR;
     context = createContext(); // mockRuntimeContext();
     value = 'test value';
-    options = { scheduler: 'preemptive', originalMaxExecTime: 1000, useSubst: false };
+    options = {
+      scheduler: 'preemptive',
+      originalMaxExecTime: 1000,
+      stepLimit: 1000,
+      useSubst: false
+    };
     lastDebuggerResult = { status: 'error' };
     state = generateDefaultState(workspaceLocation);
   });
@@ -701,6 +708,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterSuccess(value, workspaceLocation))
@@ -720,6 +728,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterSuccess(value, workspaceLocation))
@@ -742,6 +751,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterSuccess(value, workspaceLocation))
@@ -782,6 +792,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterSuccess(value, workspaceLocation))
@@ -809,6 +820,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterSuccess(value, workspaceLocation))
@@ -839,6 +851,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(endDebuggerPause(workspaceLocation))
@@ -852,6 +865,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put.like({ action: { type: EVAL_INTERPRETER_ERROR } })
@@ -874,6 +888,7 @@ describe('evalCode', () => {
         .call(runInContext, code, context, {
           scheduler: 'preemptive',
           originalMaxExecTime: execTime,
+          stepLimit: 1000,
           useSubst: false
         })
         .put(evalInterpreterError(context.errors, workspaceLocation))

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -145,7 +145,12 @@ describe('EVAL_EDITOR', () => {
           args: [
             editorValue,
             context,
-            { scheduler: 'preemptive', originalMaxExecTime: execTime, stepLimit: 1000, useSubst: false }
+            {
+              scheduler: 'preemptive',
+              originalMaxExecTime: execTime,
+              stepLimit: 1000,
+              useSubst: false
+            }
           ]
         })
         // running the student's program should return -1, which is written to REPL

--- a/src/commons/sideContent/SideContentSubstVisualizer.tsx
+++ b/src/commons/sideContent/SideContentSubstVisualizer.tsx
@@ -24,7 +24,8 @@ const SubstDefaultText = () => {
         <br />
         <br />
         On even-numbered steps, the part of the program that will be evaluated next is highlighted
-        in yellow. On odd-numbered steps, the result of the evaluation is highlighted in green.
+        in yellow. On odd-numbered steps, the result of the evaluation is highlighted in green. You
+        can change the maximum steps limit (500-5000, default 1000) in the control bar.
         <br />
         <br />
         <Divider />

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -18,6 +18,7 @@ import {
   CHANGE_EXEC_TIME,
   CHANGE_EXTERNAL_LIBRARY,
   CHANGE_SIDE_CONTENT_HEIGHT,
+  CHANGE_STEP_LIMIT,
   CHAPTER_SELECT,
   CLEAR_REPL_INPUT,
   CLEAR_REPL_OUTPUT,
@@ -69,6 +70,9 @@ export const changeExecTime = (execTime: string, workspaceLocation: WorkspaceLoc
 
 export const changeSideContentHeight = (height: number, workspaceLocation: WorkspaceLocation) =>
   action(CHANGE_SIDE_CONTENT_HEIGHT, { height, workspaceLocation });
+
+export const changeStepLimit = (stepLimit: number, workspaceLocation: WorkspaceLocation) =>
+  action(CHANGE_STEP_LIMIT, { stepLimit, workspaceLocation });
 
 export const chapterSelect = (
   chapter: number,

--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -43,6 +43,7 @@ import {
   CHANGE_EXEC_TIME,
   CHANGE_EXTERNAL_LIBRARY,
   CHANGE_SIDE_CONTENT_HEIGHT,
+  CHANGE_STEP_LIMIT,
   CLEAR_REPL_INPUT,
   CLEAR_REPL_OUTPUT,
   CLEAR_REPL_OUTPUT_LAST,
@@ -225,6 +226,14 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
         [workspaceLocation]: {
           ...state[workspaceLocation],
           sideContentHeight: action.payload.height
+        }
+      };
+    case CHANGE_STEP_LIMIT:
+      return {
+        ...state,
+        [workspaceLocation]: {
+          ...state[workspaceLocation],
+          stepLimit: action.payload.stepLimit
         }
       };
     case CLEAR_REPL_INPUT:

--- a/src/commons/workspace/WorkspaceTypes.ts
+++ b/src/commons/workspace/WorkspaceTypes.ts
@@ -16,6 +16,7 @@ export const CHANGE_EDITOR_WIDTH = 'CHANGE_EDITOR_WIDTH';
 export const CHANGE_EXEC_TIME = 'CHANGE_EXEC_TIME';
 export const CHANGE_EXTERNAL_LIBRARY = 'CHANGE_EXTERNAL_LIBRARY';
 export const CHANGE_SIDE_CONTENT_HEIGHT = 'CHANGE_SIDE_CONTENT_HEIGHT';
+export const CHANGE_STEP_LIMIT = 'CHANGE_STEP_LIMIT';
 export const CHAPTER_SELECT = 'CHAPTER_SELECT';
 export const CLEAR_REPL_INPUT = 'CLEAR_REPL_INPUT';
 export const CLEAR_REPL_OUTPUT = 'CLEAR_REPL_OUTPUT';
@@ -102,6 +103,7 @@ export type WorkspaceState = {
   readonly sharedbAceIsInviting: boolean;
   readonly sideContentActiveTab: SideContentType;
   readonly sideContentHeight?: number;
+  readonly stepLimit: number;
   readonly websocketStatus: number;
   readonly globals: Array<[string, any]>;
   readonly debuggerContext: DebuggerContext;

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -18,6 +18,7 @@ import { ControlBarExternalLibrarySelect } from '../../commons/controlBar/Contro
 import { ControlBarPersistenceButtons } from '../../commons/controlBar/ControlBarPersistenceButtons';
 import { ControlBarSessionButtons } from '../../commons/controlBar/ControlBarSessionButton';
 import { ControlBarShareButton } from '../../commons/controlBar/ControlBarShareButton';
+import { ControlBarStepLimit } from '../../commons/controlBar/ControlBarStepLimit';
 import { HighlightedLines, Position } from '../../commons/editor/EditorTypes';
 import Markdown from '../../commons/Markdown';
 import SideContentEnvVisualizer from '../../commons/sideContent/SideContentEnvVisualizer';
@@ -38,6 +39,7 @@ export type DispatchProps = {
   handleBrowseHistoryDown: () => void;
   handleBrowseHistoryUp: () => void;
   handleChangeExecTime: (execTime: number) => void;
+  handleChangeStepLimit: (stepLimit: number) => void;
   handleChapterSelect: (chapter: number, variant: Variant) => void;
   handleDeclarationNavigate: (cursorPosition: Position) => void;
   handleEditorEval: () => void;
@@ -96,6 +98,7 @@ export type StateProps = {
   sharedbAceIsInviting: boolean;
   sourceChapter: number;
   sourceVariant: Variant;
+  stepLimit: number;
   websocketStatus: number;
   externalLibraryName: ExternalLibraryName;
   usingSubst: boolean;
@@ -294,6 +297,18 @@ const Playground: React.FC<PlaygroundProps> = props => {
     [execTime, handleChangeExecTime]
   );
 
+  const { handleChangeStepLimit, stepLimit } = props;
+  const stepperStepLimit = React.useMemo(
+    () => (
+      <ControlBarStepLimit
+        stepLimit={stepLimit}
+        handleChangeStepLimit={(stepLimit: number) => handleChangeStepLimit(stepLimit)}
+        key="step_limit"
+      />
+    ),
+    [stepLimit, handleChangeStepLimit]
+  );
+
   const { handleExternalSelect, externalLibraryName } = props;
   const externalLibrarySelect = React.useMemo(
     () => (
@@ -423,7 +438,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         props.sourceVariant !== 'concurrent' ? externalLibrarySelect : null,
         sessionButtons,
         persistenceButtons,
-        executionTime
+        props.usingSubst ? stepperStepLimit : executionTime
       ],
       replButtons: [
         props.sourceVariant !== 'concurrent' && props.sourceVariant !== 'wasm' ? evalButton : null,

--- a/src/pages/playground/PlaygroundContainer.ts
+++ b/src/pages/playground/PlaygroundContainer.ts
@@ -28,6 +28,7 @@ import {
   changeEditorWidth,
   changeExecTime,
   changeSideContentHeight,
+  changeStepLimit,
   chapterSelect,
   clearReplOutput,
   evalEditor,
@@ -63,6 +64,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => 
   editorWidth: state.workspaces.playground.editorWidth,
   editorValue: state.workspaces.playground.editorValue!,
   execTime: state.workspaces.playground.execTime,
+  stepLimit: state.workspaces.playground.stepLimit,
   isEditorAutorun: state.workspaces.playground.isEditorAutorun,
   breakpoints: state.workspaces.playground.breakpoints,
   highlightedLines: state.workspaces.playground.highlightedLines,
@@ -97,6 +99,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChangeExecTime: (execTime: number) =>
         changeExecTime(execTime.toString(), workspaceLocation),
+      handleChangeStepLimit: (stepLimit: number) => changeStepLimit(stepLimit, workspaceLocation),
       handleChapterSelect: (chapter: number, variant: Variant) =>
         chapterSelect(chapter, variant, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: Position) =>

--- a/src/pages/playground/__tests__/Playground.tsx
+++ b/src/pages/playground/__tests__/Playground.tsx
@@ -11,6 +11,7 @@ import Playground, { PlaygroundProps } from '../Playground';
 const baseProps = {
   editorValue: '',
   execTime: 1000,
+  stepLimit: 1000,
   breakpoints: [],
   highlightedLines: [],
   isRunning: false,
@@ -35,6 +36,7 @@ const baseProps = {
   handleBrowseHistoryDown: () => {},
   handleBrowseHistoryUp: () => {},
   handleChangeExecTime: (execTime: number) => {},
+  handleChangeStepLimit: (stepLimit: number) => {},
   handleChapterSelect: (chapter: number) => {},
   handleDeclarationNavigate: (cursorPosition: Position) => {},
   handleEditorEval: () => {},

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -398,7 +398,7 @@ $code-color-error: #ff4444;
         margin-top: 70px;
 
         .sa-substituter {
-          margin: 11px;
+          margin: 15px;
           height: unset;
 
           .beforeMarker {


### PR DESCRIPTION
### Description

Allows the user to control the maximum steps limit (500-5000, default 1000) in the control bar while on the stepper tab.

<img width="504" alt="Screenshot 2020-08-05 at 11 12 55 AM" src="https://user-images.githubusercontent.com/54243224/89368746-d9b12280-d70e-11ea-92da-4b05d573f548.png">

[Corresponding js-slang PR](https://github.com/source-academy/js-slang/pull/718)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

The execution time input on the control bar should change to the step limit input when the stepper tab is open. The maximum steps limit should change according to the input. Note that odd-numbered inputs will still produce an even number of steps (rounded up) due to the nature of the stepper always having even-numbered steps.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
