### PR TITLE
Bump Sourceror to 0.7.0 (adds module support and some optimisations)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "redux-saga": "^1.1.3",
     "sharedb-ace": "^1.0.9",
     "showdown": "^1.9.1",
-    "sourceror": "^0.6.3",
+    "sourceror": "file:../sourceror/sourceror-driver",
     "typesafe-actions": "^5.1.0",
     "xml2js": "^0.4.23",
     "yareco": "^0.1.5"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "redux-saga": "^1.1.3",
     "sharedb-ace": "^1.0.9",
     "showdown": "^1.9.1",
-    "sourceror": "file:../sourceror/sourceror-driver",
+    "sourceror": "^0.7.0",
     "typesafe-actions": "^5.1.0",
     "xml2js": "^0.4.23",
     "yareco": "^0.1.5"

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -636,7 +636,9 @@ export function* evalCode(
   }
   async function wasm_compile_and_run(wasmCode: string, wasmContext: Context): Promise<Result> {
     return Sourceror.compile(wasmCode, wasmContext)
-      .then((wasmModule: WebAssembly.Module) => Sourceror.run(wasmModule, wasmContext))
+      .then((wasmModule: WebAssembly.Module) =>
+        Sourceror.run(wasmModule, Sourceror.makePlatformImports(), wasmContext)
+      )
       .then(
         (returnedValue: any) => ({ status: 'finished', context, value: returnedValue }),
         _ => ({ status: 'error' })

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -50,6 +50,7 @@ import {
   visualiseEnv
 } from '../utils/JsSlangHelper';
 import { showSuccessMessage, showWarningMessage } from '../utils/NotificationsHelper';
+import { makeExternalBuiltins as makeSourcerorExternalBuiltins } from '../utils/SourcerorHelper';
 import { notifyProgramEvaluated } from '../workspace/WorkspaceActions';
 import {
   BEGIN_CLEAR_CONTEXT,
@@ -636,12 +637,21 @@ export function* evalCode(
   }
   async function wasm_compile_and_run(wasmCode: string, wasmContext: Context): Promise<Result> {
     return Sourceror.compile(wasmCode, wasmContext)
-      .then((wasmModule: WebAssembly.Module) =>
-        Sourceror.run(wasmModule, Sourceror.makePlatformImports(), wasmContext)
-      )
+      .then((wasmModule: WebAssembly.Module) => {
+        const transcoder = new Sourceror.Transcoder();
+        return Sourceror.run(
+          wasmModule,
+          Sourceror.makePlatformImports(makeSourcerorExternalBuiltins(wasmContext), transcoder),
+          transcoder,
+          wasmContext
+        );
+      })
       .then(
-        (returnedValue: any) => ({ status: 'finished', context, value: returnedValue }),
-        _ => ({ status: 'error' })
+        (returnedValue: any): Result => ({ status: 'finished', context, value: returnedValue }),
+        (e: any): Result => {
+          console.log(e);
+          return { status: 'error' };
+        }
       );
   }
 

--- a/src/commons/utils/SourcerorHelper.ts
+++ b/src/commons/utils/SourcerorHelper.ts
@@ -1,0 +1,13 @@
+import { Context } from 'js-slang/dist/types';
+
+import { handleConsoleLog } from '../application/actions/InterpreterActions';
+
+export function makeExternalBuiltins(context: Context): any {
+  return {
+    display: (v: string) => {
+      if (typeof (window as any).__REDUX_STORE__ !== 'undefined') {
+        (window as any).__REDUX_STORE__.dispatch(handleConsoleLog(v, context.externalContext));
+      }
+    }
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13675,15 +13675,13 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourceror@^0.6.3:
+"sourceror@file:../sourceror/sourceror-driver":
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/sourceror/-/sourceror-0.6.3.tgz#633dba344c75c64a67fda90d75f5def3c9e6d452"
-  integrity sha512-mZ9hJxcrKKNfOs8Gyi7MMDHzkzj8jBzl1yfnZANSxmS++kccHMwDWPAudFSv2tIohdpzM3uL3VE6q+A3IDLkzA==
   dependencies:
     "@btzy/libsourceror" "^0.0.1"
     "@types/estree" "^0.0.45"
     "@types/node" "^14.0.14"
-    js-slang "^0.4.52"
+    js-slang "^0.4.53"
     node-getopt "^0.3.2"
 
 spawn-error-forwarder@~1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -13681,6 +13681,7 @@ source-map@^0.7.3:
     "@btzy/libsourceror" "^0.0.1"
     "@types/estree" "^0.0.45"
     "@types/node" "^14.0.14"
+    acorn "^7.3.1"
     js-slang "^0.4.53"
     node-getopt "^0.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,11 +1195,6 @@
     classnames "^2.2"
     tslib "~1.10.0"
 
-"@btzy/libsourceror@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@btzy/libsourceror/-/libsourceror-0.0.1.tgz#a7283ce300ba6ac4dac3bcc8402c53e29f20db91"
-  integrity sha512-5zGfpcAzo/DSmpF39fTpv0veC5onFqOd5n7YavlqVSjiUrw+imr5befbvwTV3ak8VepTB9qGK/FNghB2otdH5g==
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1931,7 +1926,7 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/estree@*", "@types/estree@0.0.45", "@types/estree@^0.0.45":
+"@types/estree@*", "@types/estree@0.0.45":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
   integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
@@ -2049,7 +2044,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.0.14", "@types/node@^14.0.27":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.0.27":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
@@ -8451,7 +8446,7 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
-js-slang@^0.4.52, js-slang@^0.4.60:
+js-slang@^0.4.60:
   version "0.4.60"
   resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.60.tgz#89b353a6db4f07d0cf414cf13e0df5e41839d261"
   integrity sha512-q0xt5S6Vppe0AbfoFHi7Q0FH525cBNV+/Zvm5VHkM3CDN1H7dEcH+Iy80OUAI4THOECPE0AuAuikxIWxBzlKjg==
@@ -13675,14 +13670,13 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-"sourceror@file:../sourceror/sourceror-driver":
-  version "0.6.3"
+sourceror@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/sourceror/-/sourceror-0.7.0.tgz#2703f45ba25dad1b3c81fa9681b380d7796149f2"
+  integrity sha512-YGLI1Dq+p7Wb+G8+mJhzC9Z/LXi4VKWl2yI5ERZ2362g8c0EXn7NzO/X7p7ryLd9msPYZoYFzssvD7PcIfzJEg==
   dependencies:
-    "@btzy/libsourceror" "^0.0.1"
-    "@types/estree" "^0.0.45"
-    "@types/node" "^14.0.14"
     acorn "^7.3.1"
-    js-slang "^0.4.53"
+    js-slang "^0.4.60"
     node-getopt "^0.3.2"
 
 spawn-error-forwarder@~1.0.0:


### PR DESCRIPTION
### Description

Sourceror 0.7 adds the following:
- Modules and multi-file compilation
- Run-time function overloading (currently only accessible from modules, and is used to implement some parts of the standard library)
- FFI support (Sourceror can call into whitelisted host functions)
- Some variable allocation and type propagation optimisations
- Standard library support (for now you must explicitly import the names, but it will be auto-imported once the prelude is implemented)
  - Source §1's standard library is essentially complete.  There are just two places where it does not agree with the Source §1 spec:
    - Functions do not print their bodies when stringified
    - True varargs are not supported (however, for any given N, we can implement function overloads that take up to N arguments)

Generally, this version runs about as fast as the previous version.  Sometimes it runs slightly faster.  However, it seems that js-slang has gotten slower - Sourceror is around 14 times faster than js-slang now.

Note that the modules feature allows importing of modules from arbitrary URLs by design.  However, this is safe, because all modules are compiled by Sourceror, and only host functions that have been explicitly chosen can be linked into the compiled WebAssembly module.

Documentation for the new features are not ready yet, but should come to the js-slang repo in a separate PR.  For now, you can refer to the standard library implementation.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Build cadet frontend with the new version of Sourceror, and set the language variant to Source §1 WebAssembly.

Example code:

```
import { math_sqrt } from "std/math";
import { parse_float } from "std/misc.ffi";
import { get_time, display, is_string, undefined, prompt, stringify } from "std/misc";

display(1);
display(1, "Number:");
display(1.5, "Non-integer number:");
display("test");
display("test", "String:");
const val = prompt("Enter a number:");
if (is_string(val)) {
    display(parse_float(val) + 1, "One more than the number you entered:");
}
else {}
display("The square root of two is " + stringify(math_sqrt(2))) + ".";

function square(x) {
    return x * x;
}
function abs(x) {
    return x >= 0 ? x : -x;
}
function good_enough(guess, x) {
    return abs(square(guess) - x) < 0.001;
}
function average(x,y) {
    return (x + y) / 2;
}
function improve(guess, x) {
    return average(guess, x / guess);
}
function sqrt_iter(guess, x) {
    return good_enough(guess, x)
            ? guess
            : sqrt_iter(improve(guess, x), x);
}
function sqrt(x) {
    return sqrt_iter(1, x);
}
function f(x, op) {
    return x === 0 ? sqrt(100) : op(f(x - 1, op), f(x - 1, op));
}

const start_time = get_time();
f(18, (a,b) => a+b);
display(get_time() - start_time, "Benchmarking function took this long:");
```

The output should be something like this:

```
1
Number: 1
Non-integer number: 1.5
"test"
String: "test"
One more than the number you entered: 124.456
"The square root of two is 1.4142135623730951"
Benchmarking function took this long: 465
465
```

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
