### PR TITLE
Add minor UI fixes and Autograder help tooltip

### DIFF
--- a/src/commons/navigationBar/NavigationBar.tsx
+++ b/src/commons/navigationBar/NavigationBar.tsx
@@ -39,7 +39,7 @@ const NavigationBar: React.SFC<NavigationBarProps> = props => (
             to="/academy"
           >
             <Icon icon={IconNames.SYMBOL_DIAMOND} />
-            <NavbarHeading className="hidden-xs hidden-sm">Source Academy</NavbarHeading>
+            <NavbarHeading className="hidden-xs">Source Academy</NavbarHeading>
           </NavLink>{' '}
           <NavLink
             activeClassName={Classes.ACTIVE}
@@ -47,7 +47,7 @@ const NavigationBar: React.SFC<NavigationBarProps> = props => (
             to="/sourcecast"
           >
             <Icon icon={IconNames.MUSIC} />
-            <div className="navbar-button-text hidden-xs hidden-sm">Sourcecast</div>
+            <div className="navbar-button-text hidden-xs">Sourcecast</div>
           </NavLink>
         </>
       )}
@@ -57,7 +57,7 @@ const NavigationBar: React.SFC<NavigationBarProps> = props => (
         to="/playground"
       >
         <Icon icon={IconNames.CODE} />
-        <div className="navbar-button-text hidden-xs hidden-sm">
+        <div className="navbar-button-text hidden-xs">
           {Constants.playgroundOnly ? 'Source Academy Playground' : 'Playground'}
         </div>
       </NavLink>
@@ -68,7 +68,7 @@ const NavigationBar: React.SFC<NavigationBarProps> = props => (
           to="/achievement"
         >
           <Icon icon={IconNames.MOUNTAIN} />
-          <div className="navbar-button-text hidden-xs hidden-sm">Achievement</div>
+          <div className="navbar-button-text hidden-xs">Achievement</div>
         </NavLink>
       )}
     </NavbarGroup>
@@ -80,7 +80,7 @@ const NavigationBar: React.SFC<NavigationBarProps> = props => (
         to="/contributors"
       >
         <Icon icon={IconNames.HEART} />
-        <div className="navbar-button-text hidden-xs hidden-sm">Contributors</div>
+        <div className="navbar-button-text hidden-xs">Contributors</div>
       </NavLink>
 
       <div className="visible-xs">

--- a/src/commons/navigationBar/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/commons/navigationBar/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -5,20 +5,20 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
   <Blueprint3.NavbarGroup align=\\"left\\">
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/academy\\">
       <Blueprint3.Icon icon=\\"symbol-diamond\\" />
-      <Blueprint3.NavbarHeading className=\\"hidden-xs hidden-sm\\">
+      <Blueprint3.NavbarHeading className=\\"hidden-xs\\">
         Source Academy
       </Blueprint3.NavbarHeading>
     </NavLink>
      
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sourcecast\\">
       <Blueprint3.Icon icon=\\"music\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Sourcecast
       </div>
     </NavLink>
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/playground\\">
       <Blueprint3.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Playground
       </div>
     </NavLink>
@@ -26,7 +26,7 @@ exports[`NavigationBar renders "Not logged in" correctly 1`] = `
   <Blueprint3.NavbarGroup align=\\"right\\">
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/contributors\\">
       <Blueprint3.Icon icon=\\"heart\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Contributors
       </div>
     </NavLink>
@@ -46,20 +46,20 @@ exports[`NavigationBar renders correctly with username 1`] = `
   <Blueprint3.NavbarGroup align=\\"left\\">
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/academy\\">
       <Blueprint3.Icon icon=\\"symbol-diamond\\" />
-      <Blueprint3.NavbarHeading className=\\"hidden-xs hidden-sm\\">
+      <Blueprint3.NavbarHeading className=\\"hidden-xs\\">
         Source Academy
       </Blueprint3.NavbarHeading>
     </NavLink>
      
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sourcecast\\">
       <Blueprint3.Icon icon=\\"music\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Sourcecast
       </div>
     </NavLink>
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/playground\\">
       <Blueprint3.Icon icon=\\"code\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Playground
       </div>
     </NavLink>
@@ -67,7 +67,7 @@ exports[`NavigationBar renders correctly with username 1`] = `
   <Blueprint3.NavbarGroup align=\\"right\\">
     <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/contributors\\">
       <Blueprint3.Icon icon=\\"heart\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
+      <div className=\\"navbar-button-text hidden-xs\\">
         Contributors
       </div>
     </NavLink>

--- a/src/commons/sideContent/SideContentAutograder.tsx
+++ b/src/commons/sideContent/SideContentAutograder.tsx
@@ -1,4 +1,4 @@
-import { Collapse, Icon } from '@blueprintjs/core';
+import { Button, Collapse, Icon, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
@@ -34,43 +34,40 @@ class SideContentAutograder extends React.Component<SideContentAutograderProps, 
   }
 
   public render() {
+    const autograderTooltip = (
+      <div className="autograder-help-tooltip">
+        <p>Click on each testcase below to execute it with the program in the editor.</p>
+        <p>
+          To execute all testcases at once, evaluate the program in the editor with this tab active.
+        </p>
+        <p>A green or red background indicates a passed or failed testcase respectively.</p>
+        <p>Private testcases (only visible to staff when grading) have a grey background.</p>
+      </div>
+    );
+
+    const columnHeader = (colClass: string, colTitle: string) => (
+      <div className={colClass}>
+        {colTitle}
+        <Icon icon={IconNames.CARET_DOWN} />
+      </div>
+    );
+
     const testcasesHeader = (
       <div className="testcases-header">
-        <div className="header-fn">
-          <Icon icon={IconNames.CARET_DOWN} />
-          Testcase (click to run)
-        </div>
-        <div className="header-expected">
-          <Icon icon={IconNames.CARET_DOWN} />
-          Expected result
-        </div>
-        <div className="header-actual">
-          <Icon icon={IconNames.CARET_DOWN} />
-          Actual result
-        </div>
+        {columnHeader('header-fn', 'Testcase')}
+        {columnHeader('header-expected', 'Expected result')}
+        {columnHeader('header-actual', 'Actual result')}
       </div>
     );
 
     const resultsHeader = (
       <div className="results-header">
         <div className="header-data">
-          <div className="header-sn">
-            <Icon icon={IconNames.CARET_DOWN} />
-            S/N
-          </div>
-          <div className="header-status">
-            <Icon icon={IconNames.CARET_DOWN} />
-            Testcase status
-          </div>
+          {columnHeader('header-sn', 'S/N')}
+          {columnHeader('header-status', 'Testcase status')}
         </div>
-        <div className="header-expected">
-          <Icon icon={IconNames.CARET_DOWN} />
-          Expected result
-        </div>
-        <div className="header-actual">
-          <Icon icon={IconNames.CARET_DOWN} />
-          Actual result
-        </div>
+        {columnHeader('header-expected', 'Expected result')}
+        {columnHeader('header-actual', 'Actual result')}
       </div>
     );
 
@@ -106,13 +103,22 @@ class SideContentAutograder extends React.Component<SideContentAutograderProps, 
     const collapseButton = (label: string, isOpen: boolean, toggleFunc: () => void) =>
       controlButton(label, isOpen ? IconNames.CARET_DOWN : IconNames.CARET_RIGHT, toggleFunc, {
         className: 'collapse-button',
-        iconOnRight: true,
         minimal: true
       });
 
     return (
       <div className="Autograder">
-        {collapseButton('Testcases', this.state.showTestcases, this.toggleTestcases)}
+        <Button
+          className="collapse-button"
+          icon={this.state.showTestcases ? IconNames.CARET_DOWN : IconNames.CARET_RIGHT}
+          minimal={true}
+          onClick={this.toggleTestcases}
+        >
+          <span>Testcases</span>
+          <Tooltip content={autograderTooltip} position={PopoverPosition.LEFT} boundary={'window'}>
+            <Icon icon={IconNames.HELP} />
+          </Tooltip>
+        </Button>
         <Collapse isOpen={this.state.showTestcases} keepChildrenMounted={true}>
           {testcases}
         </Collapse>
@@ -124,17 +130,9 @@ class SideContentAutograder extends React.Component<SideContentAutograderProps, 
     );
   }
 
-  private toggleTestcases = () =>
-    this.setState({
-      ...this.state,
-      showTestcases: !this.state.showTestcases
-    });
+  private toggleTestcases = () => this.setState({ showTestcases: !this.state.showTestcases });
 
-  private toggleResults = () =>
-    this.setState({
-      ...this.state,
-      showResults: !this.state.showResults
-    });
+  private toggleResults = () => this.setState({ showResults: !this.state.showResults });
 }
 
 export default SideContentAutograder;

--- a/src/commons/sideContent/__tests__/__snapshots__/SideContentAutograder.tsx.snap
+++ b/src/commons/sideContent/__tests__/__snapshots__/SideContentAutograder.tsx.snap
@@ -3,24 +3,51 @@
 exports[`Autograder renders autograder results with different statuses correctly 1`] = `
 "<SideContentAutograder autogradingResults={{...}} testcases={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
   <div className=\\"Autograder\\">
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
-      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Testcases
-        </span>
-        <Blueprint3.Icon icon={{...}}>
-          <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
-            <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
-              <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                <desc>
-                  caret-down
-                </desc>
-                <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
-              </svg>
-            </span>
-          </Blueprint3.Icon>
+    <Blueprint3.Button className=\\"collapse-button\\" icon=\\"caret-down\\" minimal={true} onClick={[Function (anonymous)]}>
+      <button type=\\"button\\" className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} disabled={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon=\\"caret-down\\">
+          <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
+            <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+              <desc>
+                caret-down
+              </desc>
+              <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
+            </svg>
+          </span>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          <span>
+            Testcases
+          </span>
+          <Blueprint3.Tooltip content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+            <Blueprint3.Popover interactionKind=\\"hover-target\\" content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+              <Manager>
+                <span className=\\"bp3-popover-wrapper\\">
+                  <Reference innerRef={[Function: target]}>
+                    <InnerReference setReferenceNode={[Function (anonymous)]} innerRef={[Function: target]}>
+                      <Blueprint3.ResizeSensor onResize={[Function (anonymous)]}>
+                        <span onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]} className=\\"bp3-popover-target\\">
+                          <Blueprint3.Icon icon=\\"help\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                            <span icon=\\"help\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-help\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"help\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                <desc>
+                                  help
+                                </desc>
+                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm1.93-6.52c-.14.32-.35.64-.62.97L9.25 8.83c-.12.15-.24.29-.28.42-.04.13-.09.3-.09.52V10H7.12V8.88s.05-.51.21-.71L8.4 6.73c.22-.26.35-.49.44-.68.09-.19.12-.38.12-.58 0-.3-.1-.55-.28-.75-.18-.19-.44-.28-.76-.28-.33 0-.59.1-.78.29-.19.19-.33.46-.4.81-.03.11-.1.15-.2.14l-1.7-.25c-.12-.01-.16-.08-.14-.19.12-.82.46-1.47 1.03-1.94.57-.48 1.32-.72 2.25-.72.47 0 .9.07 1.29.22s.72.34 1 .59c.28.25.49.55.65.89.15.35.22.72.22 1.12s-.07.75-.21 1.08z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                        </span>
+                      </Blueprint3.ResizeSensor>
+                    </InnerReference>
+                  </Reference>
+                  <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function (anonymous)]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                </span>
+              </Manager>
+            </Blueprint3.Popover>
+          </Blueprint3.Tooltip>
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -32,12 +59,8 @@ exports[`Autograder renders autograder results with different statuses correctly
         </div>
       </div>
     </Blueprint3.Collapse>
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} icon={{...}} onClick={[Function (anonymous)]}>
       <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Autograder Results
-        </span>
         <Blueprint3.Icon icon={{...}}>
           <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
             <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
@@ -50,6 +73,10 @@ exports[`Autograder renders autograder results with different statuses correctly
             </span>
           </Blueprint3.Icon>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          Autograder Results
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -59,6 +86,7 @@ exports[`Autograder renders autograder results with different statuses correctly
             <div className=\\"results-header\\">
               <div className=\\"header-data\\">
                 <div className=\\"header-sn\\">
+                  S/N
                   <Blueprint3.Icon icon=\\"caret-down\\">
                     <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                       <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -69,9 +97,9 @@ exports[`Autograder renders autograder results with different statuses correctly
                       </svg>
                     </span>
                   </Blueprint3.Icon>
-                  S/N
                 </div>
                 <div className=\\"header-status\\">
+                  Testcase status
                   <Blueprint3.Icon icon=\\"caret-down\\">
                     <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                       <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -82,10 +110,10 @@ exports[`Autograder renders autograder results with different statuses correctly
                       </svg>
                     </span>
                   </Blueprint3.Icon>
-                  Testcase status
                 </div>
               </div>
               <div className=\\"header-expected\\">
+                Expected result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -96,9 +124,9 @@ exports[`Autograder renders autograder results with different statuses correctly
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Expected result
               </div>
               <div className=\\"header-actual\\">
+                Actual result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -109,7 +137,6 @@ exports[`Autograder renders autograder results with different statuses correctly
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Actual result
               </div>
             </div>
             <SideContentResultCard index={0} result={{...}}>
@@ -196,24 +223,51 @@ exports[`Autograder renders autograder results with different statuses correctly
 exports[`Autograder renders hidden testcases with different statuses correctly 1`] = `
 "<SideContentAutograder autogradingResults={{...}} testcases={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
   <div className=\\"Autograder\\">
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
-      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Testcases
-        </span>
-        <Blueprint3.Icon icon={{...}}>
-          <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
-            <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
-              <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                <desc>
-                  caret-down
-                </desc>
-                <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
-              </svg>
-            </span>
-          </Blueprint3.Icon>
+    <Blueprint3.Button className=\\"collapse-button\\" icon=\\"caret-down\\" minimal={true} onClick={[Function (anonymous)]}>
+      <button type=\\"button\\" className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} disabled={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon=\\"caret-down\\">
+          <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
+            <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+              <desc>
+                caret-down
+              </desc>
+              <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
+            </svg>
+          </span>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          <span>
+            Testcases
+          </span>
+          <Blueprint3.Tooltip content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+            <Blueprint3.Popover interactionKind=\\"hover-target\\" content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+              <Manager>
+                <span className=\\"bp3-popover-wrapper\\">
+                  <Reference innerRef={[Function: target]}>
+                    <InnerReference setReferenceNode={[Function (anonymous)]} innerRef={[Function: target]}>
+                      <Blueprint3.ResizeSensor onResize={[Function (anonymous)]}>
+                        <span onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]} className=\\"bp3-popover-target\\">
+                          <Blueprint3.Icon icon=\\"help\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                            <span icon=\\"help\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-help\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"help\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                <desc>
+                                  help
+                                </desc>
+                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm1.93-6.52c-.14.32-.35.64-.62.97L9.25 8.83c-.12.15-.24.29-.28.42-.04.13-.09.3-.09.52V10H7.12V8.88s.05-.51.21-.71L8.4 6.73c.22-.26.35-.49.44-.68.09-.19.12-.38.12-.58 0-.3-.1-.55-.28-.75-.18-.19-.44-.28-.76-.28-.33 0-.59.1-.78.29-.19.19-.33.46-.4.81-.03.11-.1.15-.2.14l-1.7-.25c-.12-.01-.16-.08-.14-.19.12-.82.46-1.47 1.03-1.94.57-.48 1.32-.72 2.25-.72.47 0 .9.07 1.29.22s.72.34 1 .59c.28.25.49.55.65.89.15.35.22.72.22 1.12s-.07.75-.21 1.08z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                        </span>
+                      </Blueprint3.ResizeSensor>
+                    </InnerReference>
+                  </Reference>
+                  <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function (anonymous)]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                </span>
+              </Manager>
+            </Blueprint3.Popover>
+          </Blueprint3.Tooltip>
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -222,6 +276,7 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
           <div>
             <div className=\\"testcases-header\\">
               <div className=\\"header-fn\\">
+                Testcase
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -232,9 +287,9 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Testcase (click to run)
               </div>
               <div className=\\"header-expected\\">
+                Expected result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -245,9 +300,9 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Expected result
               </div>
               <div className=\\"header-actual\\">
+                Actual result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -258,7 +313,6 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Actual result
               </div>
             </div>
             <SideContentAutograderCard index={0} testcase={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
@@ -317,12 +371,8 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
         </div>
       </div>
     </Blueprint3.Collapse>
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} icon={{...}} onClick={[Function (anonymous)]}>
       <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Autograder Results
-        </span>
         <Blueprint3.Icon icon={{...}}>
           <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
             <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
@@ -335,6 +385,10 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
             </span>
           </Blueprint3.Icon>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          Autograder Results
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -352,15 +406,20 @@ exports[`Autograder renders hidden testcases with different statuses correctly 1
 
 exports[`Autograder renders placeholders correctly when testcases and results are empty 1`] = `
 "<div className=\\"Autograder\\">
-  <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
-    Testcases
+  <Blueprint3.Button className=\\"collapse-button\\" icon=\\"caret-down\\" minimal={true} onClick={[Function (anonymous)]}>
+    <span>
+      Testcases
+    </span>
+    <Blueprint3.Tooltip content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+      <Blueprint3.Icon icon=\\"help\\" />
+    </Blueprint3.Tooltip>
   </Blueprint3.Button>
   <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
     <div className=\\"noResults\\">
       There are no testcases provided for this question.
     </div>
   </Blueprint3.Collapse>
-  <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
+  <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} icon={{...}} onClick={[Function (anonymous)]}>
     Autograder Results
   </Blueprint3.Button>
   <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -374,24 +433,51 @@ exports[`Autograder renders placeholders correctly when testcases and results ar
 exports[`Autograder renders private testcases with different statuses correctly 1`] = `
 "<SideContentAutograder autogradingResults={{...}} testcases={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
   <div className=\\"Autograder\\">
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
-      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Testcases
-        </span>
-        <Blueprint3.Icon icon={{...}}>
-          <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
-            <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
-              <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                <desc>
-                  caret-down
-                </desc>
-                <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
-              </svg>
-            </span>
-          </Blueprint3.Icon>
+    <Blueprint3.Button className=\\"collapse-button\\" icon=\\"caret-down\\" minimal={true} onClick={[Function (anonymous)]}>
+      <button type=\\"button\\" className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} disabled={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon=\\"caret-down\\">
+          <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
+            <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+              <desc>
+                caret-down
+              </desc>
+              <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
+            </svg>
+          </span>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          <span>
+            Testcases
+          </span>
+          <Blueprint3.Tooltip content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+            <Blueprint3.Popover interactionKind=\\"hover-target\\" content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+              <Manager>
+                <span className=\\"bp3-popover-wrapper\\">
+                  <Reference innerRef={[Function: target]}>
+                    <InnerReference setReferenceNode={[Function (anonymous)]} innerRef={[Function: target]}>
+                      <Blueprint3.ResizeSensor onResize={[Function (anonymous)]}>
+                        <span onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]} className=\\"bp3-popover-target\\">
+                          <Blueprint3.Icon icon=\\"help\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                            <span icon=\\"help\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-help\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"help\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                <desc>
+                                  help
+                                </desc>
+                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm1.93-6.52c-.14.32-.35.64-.62.97L9.25 8.83c-.12.15-.24.29-.28.42-.04.13-.09.3-.09.52V10H7.12V8.88s.05-.51.21-.71L8.4 6.73c.22-.26.35-.49.44-.68.09-.19.12-.38.12-.58 0-.3-.1-.55-.28-.75-.18-.19-.44-.28-.76-.28-.33 0-.59.1-.78.29-.19.19-.33.46-.4.81-.03.11-.1.15-.2.14l-1.7-.25c-.12-.01-.16-.08-.14-.19.12-.82.46-1.47 1.03-1.94.57-.48 1.32-.72 2.25-.72.47 0 .9.07 1.29.22s.72.34 1 .59c.28.25.49.55.65.89.15.35.22.72.22 1.12s-.07.75-.21 1.08z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                        </span>
+                      </Blueprint3.ResizeSensor>
+                    </InnerReference>
+                  </Reference>
+                  <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function (anonymous)]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                </span>
+              </Manager>
+            </Blueprint3.Popover>
+          </Blueprint3.Tooltip>
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -400,6 +486,7 @@ exports[`Autograder renders private testcases with different statuses correctly 
           <div>
             <div className=\\"testcases-header\\">
               <div className=\\"header-fn\\">
+                Testcase
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -410,9 +497,9 @@ exports[`Autograder renders private testcases with different statuses correctly 
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Testcase (click to run)
               </div>
               <div className=\\"header-expected\\">
+                Expected result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -423,9 +510,9 @@ exports[`Autograder renders private testcases with different statuses correctly 
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Expected result
               </div>
               <div className=\\"header-actual\\">
+                Actual result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -436,7 +523,6 @@ exports[`Autograder renders private testcases with different statuses correctly 
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Actual result
               </div>
             </div>
             <SideContentAutograderCard index={0} testcase={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
@@ -558,12 +644,8 @@ exports[`Autograder renders private testcases with different statuses correctly 
         </div>
       </div>
     </Blueprint3.Collapse>
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} icon={{...}} onClick={[Function (anonymous)]}>
       <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Autograder Results
-        </span>
         <Blueprint3.Icon icon={{...}}>
           <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
             <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
@@ -576,6 +658,10 @@ exports[`Autograder renders private testcases with different statuses correctly 
             </span>
           </Blueprint3.Icon>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          Autograder Results
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -594,24 +680,51 @@ exports[`Autograder renders private testcases with different statuses correctly 
 exports[`Autograder renders public testcases with different statuses correctly 1`] = `
 "<SideContentAutograder autogradingResults={{...}} testcases={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
   <div className=\\"Autograder\\">
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
-      <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Testcases
-        </span>
-        <Blueprint3.Icon icon={{...}}>
-          <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
-            <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
-              <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
-                <desc>
-                  caret-down
-                </desc>
-                <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
-              </svg>
-            </span>
-          </Blueprint3.Icon>
+    <Blueprint3.Button className=\\"collapse-button\\" icon=\\"caret-down\\" minimal={true} onClick={[Function (anonymous)]}>
+      <button type=\\"button\\" className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} disabled={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+        <Blueprint3.Icon icon=\\"caret-down\\">
+          <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
+            <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+              <desc>
+                caret-down
+              </desc>
+              <path d=\\"M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z\\" fillRule=\\"evenodd\\" />
+            </svg>
+          </span>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          <span>
+            Testcases
+          </span>
+          <Blueprint3.Tooltip content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100}>
+            <Blueprint3.Popover interactionKind=\\"hover-target\\" content={{...}} position=\\"left\\" boundary=\\"window\\" hoverCloseDelay={0} hoverOpenDelay={100} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp3-tooltip\\" portalContainer={[undefined]} captureDismiss={false} defaultIsOpen={false} disabled={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} minimal={false} modifiers={{...}} openOnTargetFocus={true} targetTagName=\\"span\\" usePortal={true} wrapperTagName=\\"span\\">
+              <Manager>
+                <span className=\\"bp3-popover-wrapper\\">
+                  <Reference innerRef={[Function: target]}>
+                    <InnerReference setReferenceNode={[Function (anonymous)]} innerRef={[Function: target]}>
+                      <Blueprint3.ResizeSensor onResize={[Function (anonymous)]}>
+                        <span onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]} className=\\"bp3-popover-target\\">
+                          <Blueprint3.Icon icon=\\"help\\" className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                            <span icon=\\"help\\" disabled={[undefined]} tabIndex={0} className=\\"bp3-icon bp3-icon-help\\" title={[undefined]}>
+                              <svg fill={[undefined]} data-icon=\\"help\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                                <desc>
+                                  help
+                                </desc>
+                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm1.93-6.52c-.14.32-.35.64-.62.97L9.25 8.83c-.12.15-.24.29-.28.42-.04.13-.09.3-.09.52V10H7.12V8.88s.05-.51.21-.71L8.4 6.73c.22-.26.35-.49.44-.68.09-.19.12-.38.12-.58 0-.3-.1-.55-.28-.75-.18-.19-.44-.28-.76-.28-.33 0-.59.1-.78.29-.19.19-.33.46-.4.81-.03.11-.1.15-.2.14l-1.7-.25c-.12-.01-.16-.08-.14-.19.12-.82.46-1.47 1.03-1.94.57-.48 1.32-.72 2.25-.72.47 0 .9.07 1.29.22s.72.34 1 .59c.28.25.49.55.65.89.15.35.22.72.22 1.12s-.07.75-.21 1.08z\\" fillRule=\\"evenodd\\" />
+                              </svg>
+                            </span>
+                          </Blueprint3.Icon>
+                        </span>
+                      </Blueprint3.ResizeSensor>
+                    </InnerReference>
+                  </Reference>
+                  <Blueprint3.Overlay autoFocus={false} backdropClassName=\\"bp3-popover-backdrop\\" backdropProps={{...}} canEscapeKeyClose={false} canOutsideClickClose={false} className={[undefined]} enforceFocus={false} hasBackdrop={false} isOpen={false} onClose={[Function (anonymous)]} onClosed={[undefined]} onClosing={[undefined]} onOpened={[undefined]} onOpening={[undefined]} transitionDuration={100} transitionName=\\"bp3-popover\\" usePortal={true} portalContainer={[undefined]} lazy={true} />
+                </span>
+              </Manager>
+            </Blueprint3.Popover>
+          </Blueprint3.Tooltip>
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>
@@ -620,6 +733,7 @@ exports[`Autograder renders public testcases with different statuses correctly 1
           <div>
             <div className=\\"testcases-header\\">
               <div className=\\"header-fn\\">
+                Testcase
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -630,9 +744,9 @@ exports[`Autograder renders public testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Testcase (click to run)
               </div>
               <div className=\\"header-expected\\">
+                Expected result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -643,9 +757,9 @@ exports[`Autograder renders public testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Expected result
               </div>
               <div className=\\"header-actual\\">
+                Actual result
                 <Blueprint3.Icon icon=\\"caret-down\\">
                   <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
                     <svg fill={[undefined]} data-icon=\\"caret-down\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
@@ -656,7 +770,6 @@ exports[`Autograder renders public testcases with different statuses correctly 1
                     </svg>
                   </span>
                 </Blueprint3.Icon>
-                Actual result
               </div>
             </div>
             <SideContentAutograderCard index={0} testcase={{...}} handleTestcaseEval={[Function: handleTestcaseEval]}>
@@ -778,12 +891,8 @@ exports[`Autograder renders public testcases with different statuses correctly 1
         </div>
       </div>
     </Blueprint3.Collapse>
-    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} rightIcon={{...}} onClick={[Function (anonymous)]}>
+    <Blueprint3.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className=\\"collapse-button\\" type={[undefined]} icon={{...}} onClick={[Function (anonymous)]}>
       <button type={[undefined]} disabled={[undefined]} className=\\"bp3-button bp3-minimal collapse-button\\" onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-        <Blueprint3.Icon icon={[undefined]} />
-        <span className=\\"bp3-button-text\\">
-          Autograder Results
-        </span>
         <Blueprint3.Icon icon={{...}}>
           <Blueprint3.Icon icon=\\"caret-down\\" color={[undefined]}>
             <span icon=\\"caret-down\\" className=\\"bp3-icon bp3-icon-caret-down\\" title={[undefined]}>
@@ -796,6 +905,10 @@ exports[`Autograder renders public testcases with different statuses correctly 1
             </span>
           </Blueprint3.Icon>
         </Blueprint3.Icon>
+        <span className=\\"bp3-button-text\\">
+          Autograder Results
+        </span>
+        <Blueprint3.Icon icon={[undefined]} />
       </button>
     </Blueprint3.Button>
     <Blueprint3.Collapse isOpen={true} keepChildrenMounted={true} component=\\"div\\" transitionDuration={200}>

--- a/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
+++ b/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
@@ -86,7 +86,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
         >
           <Icon icon="satellite" />
-          <div className="navbar-button-text hidden-xs hidden-sm hidden-md">Ground Control</div>
+          <div className="navbar-button-text hidden-xs hidden-sm">Ground Control</div>
         </NavLink>
 
         <NavLink
@@ -95,7 +95,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
         >
           <Icon icon="globe" />
-          <div className="navbar-button-text hidden-xs hidden-sm hidden-md">Dashboard</div>
+          <div className="navbar-button-text hidden-xs hidden-sm">Dashboard</div>
         </NavLink>
 
         <NavLink
@@ -104,7 +104,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
         >
           <Icon icon={IconNames.MOBILE_VIDEO} />
-          <div className="navbar-button-text hidden-xs hidden-sm hidden-md">Sourcereel</div>
+          <div className="navbar-button-text hidden-xs hidden-sm">Sourcereel</div>
         </NavLink>
 
         <NavLink
@@ -113,7 +113,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
         >
           <Icon icon={IconNames.ENDORSED} />
-          <div className="navbar-button-text hidden-xs hidden-sm hidden-md">Grading</div>
+          <div className="navbar-button-text hidden-xs hidden-sm">Grading</div>
           <NotificationBadgeContainer
             notificationFilter={filterNotificationsByType('Grading')}
             disableHover={true}
@@ -126,7 +126,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
         >
           <Icon icon={IconNames.CROWN} />
-          <div className="navbar-button-text hidden-xs hidden-sm hidden-md">Story Simulator</div>
+          <div className="navbar-button-text hidden-xs hidden-sm">Story Simulator</div>
         </NavLink>
       </NavbarGroup>
     ) : null}

--- a/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
+++ b/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
@@ -82,32 +82,32 @@ exports[`Grading NavLink renders for Role.Admin 1`] = `
   <Blueprint3.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/academy/groundcontrol\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"satellite\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Ground Control
       </div>
     </NavLink>
     <NavLink to=\\"/academy/dashboard\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"globe\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Dashboard
       </div>
     </NavLink>
     <NavLink to=\\"/academy/sourcereel\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"mobile-video\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Sourcereel
       </div>
     </NavLink>
     <NavLink to=\\"/academy/grading\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"endorsed\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Grading
       </div>
       <Connect(NotificationBadge) notificationFilter={[Function (anonymous)]} disableHover={true} />
     </NavLink>
     <NavLink to=\\"/academy/storysimulator\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"crown\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Story Simulator
       </div>
     </NavLink>
@@ -156,32 +156,32 @@ exports[`Grading NavLink renders for Role.Staff 1`] = `
   <Blueprint3.NavbarGroup align=\\"right\\">
     <NavLink to=\\"/academy/groundcontrol\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"satellite\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Ground Control
       </div>
     </NavLink>
     <NavLink to=\\"/academy/dashboard\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"globe\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Dashboard
       </div>
     </NavLink>
     <NavLink to=\\"/academy/sourcereel\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"mobile-video\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Sourcereel
       </div>
     </NavLink>
     <NavLink to=\\"/academy/grading\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"endorsed\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Grading
       </div>
       <Connect(NotificationBadge) notificationFilter={[Function (anonymous)]} disableHover={true} />
     </NavLink>
     <NavLink to=\\"/academy/storysimulator\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"crown\\" />
-      <div className=\\"navbar-button-text hidden-xs hidden-sm hidden-md\\">
+      <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
         Story Simulator
       </div>
     </NavLink>

--- a/src/styles/_academy.scss
+++ b/src/styles/_academy.scss
@@ -292,6 +292,10 @@
     justify-content: center;
     padding-left: 1em;
   }
+
+  &:not(.ag-header-cell-sortable) .ag-header-cell-label {
+    padding-right: 1em;
+  }
 }
 
 .ag-cell {

--- a/src/styles/_commons.scss
+++ b/src/styles/_commons.scss
@@ -7,6 +7,14 @@
     margin-left: 0px;
   }
 
+  .#{$ns}-non-ideal-state {
+    padding-bottom: 0.7rem;
+
+    > .#{$ns}-non-ideal-state-visual .#{$ns}-icon {
+      display: flex;
+    }
+  }
+
   .contentdisplay-content-parent {
     margin-top: 20px;
     margin-bottom: 20px;

--- a/src/styles/_navigationBar.scss
+++ b/src/styles/_navigationBar.scss
@@ -4,14 +4,17 @@
 .NavigationBar {
   width: 100%;
   flex: 0 0 auto;
+  padding: 0px 10px;
+
   .thin-divider {
     /* Used to lessen the space between icon-only buttons (on small displays). */
     margin-left: 0px;
     margin-right: 0px;
   }
+
   .navbar-button-text {
     /* This provides some space between the icon and the text on larger displays. */
-    margin-left: 0.2rem;
+    margin-left: 0.25rem;
   }
 }
 
@@ -19,17 +22,18 @@ a.NavigationBar__link {
   color: inherit;
   text-decoration: none;
 
-  .#{$ns}-button-text {
+  > :first-child {
+    /*
+     * Keep an even margin around the icon (instead of a larger right margin) to
+     * allow for even spacing when viewed on smaller viewports.
+     */
+    margin-left: 0.1rem;
+    margin-right: 0.1rem;
+  }
+
+  > .navbar-button-text {
     display: flex;
   }
-}
-
-.NavigationBar__link :first-child {
-  /* An even margin is kept (instead of the right side having a higher margin)
-     * to allow for even spacing when viewed on mobile.
-     */
-  margin-left: 0.1rem !important;
-  margin-right: 0.1rem !important;
 }
 
 /*
@@ -37,11 +41,12 @@ a.NavigationBar__link {
  */
 .primary-navbar {
   .#{$ns}-button {
-    font-weight: 500;
+    font-weight: 600;
   }
+
   .#{$ns}-navbar-heading {
     text-transform: uppercase;
-    padding: 1.5px 0 0 4px;
+    padding: 0 0 3.5px 4px;
   }
 
   .navbar-username {
@@ -66,11 +71,13 @@ a.NavigationBar__link {
  */
 .secondary-navbar {
   height: 40px;
+
   .#{$ns}-navbar-group {
     height: 40px;
   }
-  /* Create less emphasis on secondary navbar buttons */
+
   .#{$ns}-button {
+    /* Reduce emphasis on secondary navbar buttons */
     text-transform: initial;
     font-weight: 250;
   }

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -781,9 +781,24 @@ $code-color-error: #ff4444;
   .Autograder {
     min-width: 640px;
 
-    > .collapse-button {
+    *:focus {
+      /* Disable blue border when an Autograder sub-element is in focus */
+      outline: none;
+    }
+
+    .collapse-button {
       width: 100%;
       background: rgba(0, 0, 0, 0.2);
+
+      > .#{$ns}-button-text {
+        > span:not(:last-child) {
+          margin-right: 7px;
+        }
+
+        > span:not(:first-child) {
+          margin-left: 7px;
+        }
+      }
     }
 
     .testcases-header,
@@ -795,7 +810,7 @@ $code-color-error: #ff4444;
       padding: 0.4rem 0.6rem;
 
       .#{$ns}-icon {
-        margin-right: 4px;
+        margin-left: 4px;
       }
     }
 
@@ -1043,4 +1058,17 @@ $code-color-error: #ff4444;
 /* otherwise, a thick outline will show on click due to react-hotkeys */
 .workspace:focus {
   outline: 0;
+}
+
+/* Tooltip content is rendered in a Blueprint Portal outside the main body */
+.autograder-help-tooltip {
+  max-width: 275px;
+
+  > p {
+    margin-bottom: 6px;
+  }
+
+  > p:last-child {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
## Add minor UI fixes and Autograder help tooltip
Summary: Minor UI changes.

### Changelog
- Add CSS to centre the following UI elements
  - Default assessment list display when there are no assessments of the currently selected type
  - Datagrid column headers of columns that are unsortable
- Add a tooltip to the testcase header in the side-content Autograder to display usage instructions
  - The tooltip is displayed on hovering over the help icon
- Optimise primary and secondary navigation bar buttons for wider range of viewport sizes
  - Primary navigation bar buttons will now only hide their text at widths <= 768px, instead of 1024px
  - Secondary navigation bar buttons will now **all** hide their text at widths <= 1024px, instead of a mix of 768px and 1024px
  - Navigation bar buttons have approximately the same width on wide viewports, but are about 7.5% narrower on small viewports with text hidden
  - No navigation bar overflow occurs with viewport widths >= 412px
- Update navigation bar and side-content Autograder snapshots

### Verification
Please test on both **Firefox** (v70 or later) and **Chrome** (v75 or later):

1. Login to the development front-end and resize the viewport to verify that neither navigation bar overflows when the viewport width is at least 412px

### Screenshots

#### Adjusted default assessment list display
![image](https://user-images.githubusercontent.com/44989315/90128414-6c019800-dd99-11ea-8425-604cf1cb6b80.png)

#### Adjusted datagrid unsortable column headers
![image](https://user-images.githubusercontent.com/44989315/90128646-c7338a80-dd99-11ea-89ca-f176337157b3.png)

#### On-hover Autograder help tooltip 
![image](https://user-images.githubusercontent.com/44989315/90128287-3d83bd00-dd99-11ea-8b0d-e79fe13c5292.png)

Last updated 13 Aug 2020, 7:15PM