### PR TITLE
Rename 'Practical' assessment tab to 'Other'

### DIFF
--- a/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
+++ b/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
@@ -75,7 +75,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
         className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
       >
         <Icon icon={IconNames.MANUAL} />
-        <div className="navbar-button-text hidden-xs hidden-sm">Practical</div>
+        <div className="navbar-button-text hidden-xs hidden-sm">Other</div>
       </NavLink>
     </NavbarGroup>
     {props.role === Role.Admin || props.role === Role.Staff ? (

--- a/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
+++ b/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
@@ -34,7 +34,7 @@ exports[`Grading NavLink does NOT renders for Role.Student 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Practical
+        Other
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>
@@ -75,7 +75,7 @@ exports[`Grading NavLink renders for Role.Admin 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Practical
+        Other
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>
@@ -149,7 +149,7 @@ exports[`Grading NavLink renders for Role.Staff 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Practical
+        Other
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>


### PR DESCRIPTION
## Rename 'Practical' assessment tab to 'Other'
Summary: Minor UI change.

### Changelog
- Rename 'Practical' assessment tab to 'Other'
  - The tab still displays all assessments of type `Practical` - this assessment type should be reserved for formal assessment purposes (e.g. studio participation, practical assessments)
- Update academy navigation bar snapshots

### Screenshots

#### Updated navigation bar
![image](https://user-images.githubusercontent.com/44989315/90307163-7a20f700-df06-11ea-93c4-71334e78be83.png)

Last updated 15 Aug 2020, 2:45PM