### PR TITLE
Add `picture_mse` to runes library

### DIFF
--- a/public/externalLibs/graphics/webGLrune.js
+++ b/public/externalLibs/graphics/webGLrune.js
@@ -516,6 +516,26 @@ function clearHollusion() {
   clearTimeout(hollusionTimeout)
 }
 
+/**
+ * compares two Pictures and returns the mean squared error of the pixel intensities.
+ * @param {Picture} picture1
+ * @param {Picture} picture2
+ * @return {number} mse
+ * example: picture_mse(show(heart), show(nova));
+ */
+function picture_mse(picture1, picture2) {
+  var width = picture1.$canvas.width
+  var height = picture1.$canvas.height
+  var data1 = picture1.$canvas.getContext('2d').getImageData(0, 0, width, height).data
+  var data2 = picture2.$canvas.getContext('2d').getImageData(0, 0, width, height).data
+  var sq_err = 0
+  for (var i = 0; i < data1.length; i++) {
+    var err = (data1[i] - data2[i]) / 255
+    sq_err += err * err
+  }
+  return sq_err / data1.length
+}
+
 /*-----------------------Transformation functions----------------------*/
 /**
  * scales a given Rune by separate factors in x and y direction

--- a/src/commons/application/types/ExternalTypes.ts
+++ b/src/commons/application/types/ExternalTypes.ts
@@ -68,7 +68,8 @@ const runesLibrary = [
   'anaglyph',
   'overlay_frac',
   'overlay',
-  'hollusion' // currently not documented; animation not working
+  'hollusion', // currently not documented; animation not working
+  'picture_mse'
 ];
 
 const curvesLibrary = [


### PR DESCRIPTION
### Description

Add `picture_mse` to the runes library, which can be used for autograding purposes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

[Runes grading test.xml.txt](https://github.com/source-academy/cadet-frontend/files/5079636/Runes.grading.test.xml.txt)

Run this in mission control (http://localhost:4000/mission-control), and try the test case provided.

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
- [ ] I have updated the documentation (is it in js-slang?)
