### PR TITLE
Rename 'Other' assessments tab to 'Others'

### DIFF
--- a/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
+++ b/src/pages/academy/subcomponents/AcademyNavigationBar.tsx
@@ -75,7 +75,7 @@ const AcademyNavigationBar: React.FunctionComponent<OwnProps> = props => (
         className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
       >
         <Icon icon={IconNames.MANUAL} />
-        <div className="navbar-button-text hidden-xs hidden-sm">Other</div>
+        <div className="navbar-button-text hidden-xs hidden-sm">Others</div>
       </NavLink>
     </NavbarGroup>
     {props.role === Role.Admin || props.role === Role.Staff ? (

--- a/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
+++ b/src/pages/academy/subcomponents/__tests__/__snapshots__/AcademyNavigationBar.tsx.snap
@@ -34,7 +34,7 @@ exports[`Grading NavLink does NOT renders for Role.Student 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Other
+        Others
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>
@@ -75,7 +75,7 @@ exports[`Grading NavLink renders for Role.Admin 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Other
+        Others
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>
@@ -149,7 +149,7 @@ exports[`Grading NavLink renders for Role.Staff 1`] = `
     <NavLink to=\\"/academy/practicals\\" activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\">
       <Blueprint3.Icon icon=\\"manual\\" />
       <div className=\\"navbar-button-text hidden-xs hidden-sm\\">
-        Other
+        Others
       </div>
     </NavLink>
   </Blueprint3.NavbarGroup>


### PR DESCRIPTION
## Rename 'Other' assessments tab to 'Others'
Summary: Minor UI change.

### Changelog
- Rename 'Other' assessment tab to 'Others'
  - The tab still displays all assessments of type `Practical` - this assessment type should be reserved for formal assessment purposes (e.g. studio participation, practical assessments)
- Update academy navigation bar snapshots

### Screenshots

#### Updated navigation bar
![image](https://user-images.githubusercontent.com/44989315/90343876-18b47180-e047-11ea-9cb9-db0810975851.png)

Last updated 17 Aug 2020, 5:00AM