### PR TITLE
Hide autograding results until submission is manually graded

### DIFF
--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -341,55 +341,56 @@ class Assessment extends React.Component<AssessmentProps, State> {
     index: number,
     renderAttemptButton: boolean,
     renderGradingStatus: boolean
-  ) => (
-    <div key={index}>
-      <Card className="row listing" elevation={Elevation.ONE}>
-        <div className="col-xs-3 listing-picture">
-          <NotificationBadge
-            className="badge"
-            notificationFilter={filterNotificationsByAssessment(overview.id)}
-            large={true}
-          />
-          <img
-            alt="Assessment"
-            className={`cover-image-${overview.status}`}
-            src={overview.coverImage ? overview.coverImage : defaultCoverImage}
-          />
-        </div>
-        <div className="col-xs-9 listing-text">
-          {this.makeOverviewCardTitle(overview, index, renderGradingStatus)}
-          <div className="listing-grade">
-            <H6>
-              {beforeNow(overview.openAt)
-                ? `Grade: ${overview.grade} / ${overview.maxGrade}`
-                : `Max Grade: ${overview.maxGrade}`}
-            </H6>
+  ) => {
+    const showGrade = overview.gradingStatus === 'graded' || overview.category === 'Path';
+    return (
+      <div key={index}>
+        <Card className="row listing" elevation={Elevation.ONE}>
+          <div className="col-xs-3 listing-picture">
+            <NotificationBadge
+              className="badge"
+              notificationFilter={filterNotificationsByAssessment(overview.id)}
+              large={true}
+            />
+            <img
+              alt="Assessment"
+              className={`cover-image-${overview.status}`}
+              src={overview.coverImage ? overview.coverImage : defaultCoverImage}
+            />
           </div>
-          <div className="listing-xp">
-            <H6>
-              {beforeNow(overview.openAt)
-                ? `XP: ${overview.xp} / ${overview.maxXp}`
-                : `Max XP: ${overview.maxXp}`}
-            </H6>
-          </div>
-          <div className="listing-description">
-            <Markdown content={overview.shortSummary} />
-          </div>
-          <div className="listing-footer">
-            <Text className="listing-due-date">
-              <Icon className="listing-due-icon" iconSize={12} icon={IconNames.TIME} />
-              {beforeNow(overview.openAt)
-                ? `Due: ${getPrettyDate(overview.closeAt)}`
-                : `Opens at: ${getPrettyDate(overview.openAt)}`}
-            </Text>
-            <div className="listing-button">
-              {renderAttemptButton ? this.makeAssessmentInteractButton(overview) : null}
+          <div className="col-xs-9 listing-text">
+            {this.makeOverviewCardTitle(overview, index, renderGradingStatus)}
+            <div className="listing-grade">
+              <H6>
+                {showGrade
+                  ? `Grade: ${overview.grade} / ${overview.maxGrade}`
+                  : `Max Grade: ${overview.maxGrade}`}
+              </H6>
+            </div>
+            <div className="listing-xp">
+              <H6>
+                {showGrade ? `XP: ${overview.xp} / ${overview.maxXp}` : `Max XP: ${overview.maxXp}`}
+              </H6>
+            </div>
+            <div className="listing-description">
+              <Markdown content={overview.shortSummary} />
+            </div>
+            <div className="listing-footer">
+              <Text className="listing-due-date">
+                <Icon className="listing-due-icon" iconSize={12} icon={IconNames.TIME} />
+                {beforeNow(overview.openAt)
+                  ? `Due: ${getPrettyDate(overview.closeAt)}`
+                  : `Opens at: ${getPrettyDate(overview.openAt)}`}
+              </Text>
+              <div className="listing-button">
+                {renderAttemptButton ? this.makeAssessmentInteractButton(overview) : null}
+              </div>
             </div>
           </div>
-        </div>
-      </Card>
-    </div>
-  );
+        </Card>
+      </div>
+    );
+  };
 
   private makeOverviewCardTitle = (
     overview: AssessmentOverview,

--- a/src/commons/assessment/__tests__/__snapshots__/Assessment.tsx.snap
+++ b/src/commons/assessment/__tests__/__snapshots__/Assessment.tsx.snap
@@ -387,14 +387,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -504,14 +504,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -621,14 +621,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 3 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 2 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -740,14 +740,14 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 2 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 1 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -1270,14 +1270,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -1387,14 +1387,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 4 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 3 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -1504,14 +1504,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 3 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 2 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>
@@ -1623,14 +1623,14 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                   <div className=\\"listing-grade\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        Grade: 2 / 3000
+                                        Max Grade: 3000
                                       </h6>
                                     </Component>
                                   </div>
                                   <div className=\\"listing-xp\\">
                                     <Component>
                                       <h6 className=\\"bp3-heading\\">
-                                        XP: 1 / 1000
+                                        Max XP: 1000
                                       </h6>
                                     </Component>
                                   </div>

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -352,6 +352,7 @@ class AssessmentWorkspace extends React.Component<
     props: AssessmentWorkspaceProps,
     questionId: number
   ) => {
+    const isGraded = props.assessment!.questions[questionId].grader !== undefined;
     const tabs: SideContentTab[] = [
       {
         label: `Task ${questionId + 1}`,
@@ -373,7 +374,9 @@ class AssessmentWorkspace extends React.Component<
         body: (
           <SideContentAutograder
             testcases={props.editorTestcases}
-            autogradingResults={props.autogradingResults}
+            autogradingResults={
+              isGraded || props.assessment!.category === 'Path' ? props.autogradingResults : []
+            }
             handleTestcaseEval={this.props.handleTestcaseEval}
           />
         ),
@@ -381,7 +384,6 @@ class AssessmentWorkspace extends React.Component<
         toSpawn: () => true
       }
     ];
-    const isGraded = props.assessment!.questions[questionId].grader !== undefined;
     if (isGraded) {
       tabs.push({
         label: `Report Card`,


### PR DESCRIPTION
You may want to ignore whitespace changes when reviewing this PR.

### Description

Hide autograding results until submission is manually graded.

The profile tab needs to be updated too. @Aulud 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Look at an assessment that has been autograded but not manually graded.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
