### PR TITLE
Fix wrong function call in letter_name_to_frequency in SOUNDS library

### DIFF
--- a/public/externalLibs/sound/soundToneMatrix.js
+++ b/public/externalLibs/sound/soundToneMatrix.js
@@ -409,7 +409,7 @@ function letter_name_to_midi_note(note) {
 }
 
 function letter_name_to_frequency(note) {
-  return midi_note_to_frequency(note_to_midi_note(note));
+  return midi_note_to_frequency(letter_name_to_midi_note(note));
 }
 
 function midi_note_to_frequency(note) {

--- a/public/externalLibs/sound/sounds.js
+++ b/public/externalLibs/sound/sounds.js
@@ -495,7 +495,7 @@ function letter_name_to_midi_note(note) {
  * @returns {Number} frequency of corresponding note in Hz
  */
 function letter_name_to_frequency(note) {
-    return midi_note_to_frequency(note_to_midi_note(note));
+    return midi_note_to_frequency(letter_name_to_midi_note(note));
 }
 
 /**


### PR DESCRIPTION
## Fix wrong function call in letter_name_to_frequency in SOUNDS library
Summary: Fixes #1474.

### Changelog
- Replace obsolete `note_to_midi_note` with `letter_name_to_midi_note` in definition of predeclared function `letter_name_to_frequency` in the SOUNDS library
  - This includes the special TONE MATRIX library, which also declares `letter_name_to_frequency`

### Verification instructions
1. Proceed to the Playground in the development environment, and invoke `letter_name_to_frequency` with any musical note, e.g. `letter_name_to_frequency` should give 440 Hz (Stuttgart pitch)

### Screenshots

#### Working invocation of `letter_name_to_frequency`
![image](https://user-images.githubusercontent.com/44989315/90778335-13994000-e32f-11ea-8066-3567e9491648.png)

Last updated 20 Aug 2020, 9:45 PM