### PR TITLE
Remove accessToken from Application props

### DIFF
--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -35,7 +35,6 @@ export type DispatchProps = {
 };
 
 export type StateProps = {
-  accessToken?: string;
   currentPlaygroundChapter: number;
   currentPlaygroundVariant: Variant;
   role?: Role;
@@ -53,13 +52,13 @@ class Application extends React.Component<ApplicationProps, {}> {
     const fullPaths = Constants.playgroundOnly
       ? null
       : [
-          <Route path="/academy" component={toAcademy(this.props)} key={0} />,
+          <Route path="/academy" render={toAcademy(this.props)} key={0} />,
           <Route
             path={'/mission-control/:assessmentId(-?\\d+)?/:questionId(\\d+)?'}
             render={toIncubator}
             key={1}
           />,
-          <Route path="/achievement" component={toAchievement(this.props)} key={2} />,
+          <Route path="/achievement" render={toAchievement(this.props)} key={2} />,
           <Route path="/login" render={toLogin(this.props)} key={3} />
         ];
 
@@ -98,20 +97,16 @@ class Application extends React.Component<ApplicationProps, {}> {
  *  1. If the user is logged in, render the Academy component
  *  2. If the user is not logged in, redirect to /login
  */
-const toAcademy = (props: ApplicationProps) =>
-  props.accessToken === undefined || props.role === undefined
-    ? () => <Redirect to="/login" />
-    : () => <Academy accessToken={props.accessToken} role={props.role!} />;
+const toAcademy = ({ role }: ApplicationProps) =>
+  role === undefined ? () => <Redirect to="/login" /> : () => <Academy role={role} />;
 
 /**
  * A user routes to /achievement,
  *  1. If the user is logged in, render the Achievement component
  *  2. If the user is not logged in, redirect to /login
  */
-const toAchievement = (props: ApplicationProps) =>
-  props.accessToken === undefined || props.role === undefined
-    ? () => <Redirect to="/login" />
-    : () => <Achievement />;
+const toAchievement = ({ role }: ApplicationProps) =>
+  role === undefined ? () => <Redirect to="/login" /> : () => <Achievement />;
 
 const toLogin = (props: ApplicationProps) => () => {
   const qstr = parseQuery(props.location.search);

--- a/src/commons/application/ApplicationContainer.ts
+++ b/src/commons/application/ApplicationContainer.ts
@@ -26,7 +26,6 @@ import { externalLibraries, ExternalLibraryName } from './types/ExternalTypes';
  */
 const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => ({
   title: state.application.title,
-  accessToken: state.session.accessToken,
   role: state.session.role,
   name: state.session.name,
   currentPlaygroundChapter: state.workspaces.playground.context.chapter,

--- a/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
@@ -8,9 +8,9 @@ exports[`Application renders correctly 1`] = `
       <Route path=\\"/playground\\" component={[Function: C]} />
       <Route path=\\"/contributors\\" component={[function]} />
       <Route path=\\"/sourcecast\\" component={{...}} />
-      <Route path=\\"/academy\\" component={[Function (anonymous)]} />
+      <Route path=\\"/academy\\" render={[Function (anonymous)]} />
       <Route path=\\"/mission-control/:assessmentId(-?\\\\\\\\d+)?/:questionId(\\\\\\\\d+)?\\" render={[Function: toIncubator]} />
-      <Route path=\\"/achievement\\" component={[Function (anonymous)]} />
+      <Route path=\\"/achievement\\" render={[Function (anonymous)]} />
       <Route path=\\"/login\\" render={[Function (anonymous)]} />
       <Route exact={true} path=\\"/\\" render={[Function (anonymous)]} />
       <Route component={[Function: NotFound]} />

--- a/src/pages/academy/Academy.tsx
+++ b/src/pages/academy/Academy.tsx
@@ -27,7 +27,6 @@ export type StateProps = {
 };
 
 export type OwnProps = {
-  accessToken?: string;
   role: Role;
 };
 


### PR DESCRIPTION
`Application` uses `accessToken` to check whether the user is logged in. This is redundant, and it causes the entire application to re-render whenever the access token is refreshed. Normally this would not be an issue, but many pages in cadet-frontend refresh the data from the backend every time the page is loaded.

This means that for `AssessmentWorkspace`, if the user's access token (valid for 1 hour) has expired, when the user hits Save, the following happens:

1. frontend attempts to save the answer
2. frontend gets 401-ed
3. frontend refreshes the token
4. frontend dispatches the new token to its Redux store
5a. repeats save
5b. AssessmentWorkspace re-mounts due to (4) and requests for student's answer

When (4) happens, the entire application is re-rendered from the root component (`Application`). Because the Academy route [uses the `component` prop on the `Route` instead of `render`](https://reactrouter.com/web/api/Route/render-func), the re-render of `Application` causes the `AssessmentWorkspace` to be re-mounted entirely. This causes (5b) to happen, and (5a) and (5b) happen concurrently, so it is a race for which request is served by the backend first. I suppose most of the time 5b is completed first, and the old answer is returned to the frontend, and the editor is reset to the old value.

Note that the save *does succeed*, but to the student it appears as if his work has been lost. (If he proceeds to save again, it would be lost.)

The same issue happens with the grading workspace.

Remove `accessToken` from `Application`'s props so that `Application` does not re-render when `accessToken` changes. Also change the `component` prop to `render` for the routes that use a function instead of a component directly.

This issue has been around ever since [June 2018](https://github.com/source-academy/cadet-frontend/pull/101/files#diff-f9508237541f6b31d4d7720108b7ad8fR29).

Fixes #934 and #985.