### PR TITLE
bump js-slang to 0.4.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "connected-react-router": "^6.8.0",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.4.62",
+    "js-slang": "^0.4.64",
     "lodash": "^4.17.19",
     "lz-string": "^1.4.4",
     "moment": "^2.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7343,10 +7343,26 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
-js-slang@^0.4.60, js-slang@^0.4.62:
+js-slang@^0.4.60:
   version "0.4.62"
   resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.62.tgz#3ad777435b74f1d8d2006f8aa6f7a85e065e7f71"
   integrity sha512-dyKPz7LNrxAmqW0LjpRiL0b17g8HyQHlDtCOHkoUFlgefpF5b0ziah2IMfJFygbRvhCIpGDeUNUueI5ZSbNTkQ==
+  dependencies:
+    "@types/estree" "0.0.45"
+    acorn "^7.4.0"
+    acorn-loose "^7.1.0"
+    acorn-walk "^7.2.0"
+    astring "^1.4.3"
+    gpu.js "^2.9.5"
+    lodash "^4.17.19"
+    node-getopt "^0.3.2"
+    source-map "^0.7.3"
+    xmlhttprequest-ts "^1.0.1"
+
+js-slang@^0.4.64:
+  version "0.4.64"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.64.tgz#4ca54d830f386184017428a841fc1fb7dac82f06"
+  integrity sha512-ywFVW1uN8ct34odgjJiGjOhlonKwQj7KtZGfWZo8Sf9zLUqNaIgk1zxp6DR5L/feCSlyqjiLDRO9uzCGfHXk6w==
   dependencies:
     "@types/estree" "0.0.45"
     acorn "^7.4.0"


### PR DESCRIPTION
### Description

Bumps js-slang to 0.4.64, to enable display_list and backtick strings

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

use display_list and `...` in playground

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
- [x] I have updated the documentation
