### PR TITLE
Fix grading editor not resetting on question change

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -99,13 +99,7 @@ const gradingEditorButtonClass = 'grading-editor-button';
 class GradingEditor extends React.Component<GradingEditorProps, State> {
   constructor(props: GradingEditorProps) {
     super(props);
-    this.state = {
-      gradeAdjustmentInput: props.gradeAdjustment.toString(),
-      xpAdjustmentInput: props.xpAdjustment.toString(),
-      editorValue: props.comments,
-      selectedTab: 'write',
-      currentlySaving: false
-    };
+    this.state = this.makeInitialState();
   }
 
   public render() {
@@ -286,6 +280,15 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
     );
   }
 
+  public componentDidUpdate(prevProps: GradingEditorProps, prevState: State) {
+    if (
+      prevProps.submissionId !== this.props.submissionId ||
+      prevProps.questionId !== this.props.questionId
+    ) {
+      this.setState(this.makeInitialState());
+    }
+  }
+
   /**
    * A custom icons provider. It uses a bulky mapping function
    * defined below.
@@ -445,6 +448,16 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
         openLinksInNewWindow={true}
       />
     );
+
+  private makeInitialState(): State {
+    return {
+      gradeAdjustmentInput: this.props.gradeAdjustment.toString(),
+      xpAdjustmentInput: this.props.xpAdjustment.toString(),
+      editorValue: this.props.comments,
+      selectedTab: 'write',
+      currentlySaving: false
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

Fix the grading editor not resetting when clicking next/previous.

Bug introduced by https://github.com/source-academy/cadet-frontend/commit/802a24b8ccdda4c23fb270dacc72c314ca885b04. The grading editor has been fundamentally broken though, and only worked because of the bug that was fixed in that commit.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Open the grading workspace and go between questions. See that the grading editor resets to show the comment of the question navigated to upon each navigation.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
