### PR TITLE
Move picture_mse to webGLgraphics and expose in CURVES too

### DIFF
--- a/public/externalLibs/graphics/webGLgraphics.js
+++ b/public/externalLibs/graphics/webGLgraphics.js
@@ -809,3 +809,23 @@ function drawCurve(drawMode, curvePosArray) {
 function ShapeDrawn(canvas) {
   this.$canvas = canvas;
 }
+
+/**
+ * compares two Pictures and returns the mean squared error of the pixel intensities.
+ * @param {Picture} picture1
+ * @param {Picture} picture2
+ * @return {number} mse
+ * example: picture_mse(show(heart), show(nova));
+ */
+function picture_mse(picture1, picture2) {
+  var width = picture1.$canvas.width
+  var height = picture1.$canvas.height
+  var data1 = picture1.$canvas.getContext('2d').getImageData(0, 0, width, height).data
+  var data2 = picture2.$canvas.getContext('2d').getImageData(0, 0, width, height).data
+  var sq_err = 0
+  for (var i = 0; i < data1.length; i++) {
+    var err = (data1[i] - data2[i]) / 255
+    sq_err += err * err
+  }
+  return sq_err / data1.length
+}

--- a/public/externalLibs/graphics/webGLrune.js
+++ b/public/externalLibs/graphics/webGLrune.js
@@ -516,26 +516,6 @@ function clearHollusion() {
   clearTimeout(hollusionTimeout)
 }
 
-/**
- * compares two Pictures and returns the mean squared error of the pixel intensities.
- * @param {Picture} picture1
- * @param {Picture} picture2
- * @return {number} mse
- * example: picture_mse(show(heart), show(nova));
- */
-function picture_mse(picture1, picture2) {
-  var width = picture1.$canvas.width
-  var height = picture1.$canvas.height
-  var data1 = picture1.$canvas.getContext('2d').getImageData(0, 0, width, height).data
-  var data2 = picture2.$canvas.getContext('2d').getImageData(0, 0, width, height).data
-  var sq_err = 0
-  for (var i = 0; i < data1.length; i++) {
-    var err = (data1[i] - data2[i]) / 255
-    sq_err += err * err
-  }
-  return sq_err / data1.length
-}
-
 /*-----------------------Transformation functions----------------------*/
 /**
  * scales a given Rune by separate factors in x and y direction

--- a/src/commons/application/types/ExternalTypes.ts
+++ b/src/commons/application/types/ExternalTypes.ts
@@ -105,7 +105,8 @@ const curvesLibrary = [
   'alternative_unit_circle', // undocumented
   'full_view_proportional', // undocumented
   'squeeze_full_view', // undocumented
-  'squeeze_rectangular_portion' // undocumented
+  'squeeze_rectangular_portion', // undocumented
+  'picture_mse'
 ];
 
 const soundsLibrary = [


### PR DESCRIPTION
### Description

Move picture_mse to webGLgraphics and expose in the CURVES library too.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Enable the CURVES library and see that `picture_mse` works there too.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
