### PR TITLE
Fix playground failing to load if saved library is ALL

### DIFF
--- a/src/commons/sideContent/SideContentVideoDisplay.tsx
+++ b/src/commons/sideContent/SideContentVideoDisplay.tsx
@@ -24,21 +24,34 @@ class SideContentVideoDisplay extends React.Component<{}, State> {
     this.handleHeightChange = this.handleHeightChange.bind(this);
   }
   public componentDidMount() {
-    if (this.$video && this.$canvas) {
-      (window as any).VD.init(this.$video, this.$canvas);
+    const VD = (window as any).VD;
+    if (this.$video && this.$canvas && VD) {
+      VD.init(this.$video, this.$canvas);
     }
   }
   public componentWillUnmount() {
-    (window as any).VD.deinit();
+    const VD = (window as any).VD;
+    if (VD) {
+      VD.deinit();
+    }
   }
   public handleStartVideo() {
-    (window as any).VD.handleStartVideo();
+    const VD = (window as any).VD;
+    if (VD) {
+      VD.handleStartVideo();
+    }
   }
   public handleSnapPicture() {
-    (window as any).VD.handleSnapPicture();
+    const VD = (window as any).VD;
+    if (VD) {
+      VD.handleSnapPicture();
+    }
   }
   public handleCloseVideo() {
-    (window as any).VD.handleCloseVideo();
+    const VD = (window as any).VD;
+    if (VD) {
+      VD.handleCloseVideo();
+    }
   }
   public handleWidthChange(n: number) {
     if (n > 0) {
@@ -59,7 +72,10 @@ class SideContentVideoDisplay extends React.Component<{}, State> {
     }
   }
   public handleUpdateDimensions(n: number, m: number) {
-    (window as any).VD.handleUpdateDimensions(n, m);
+    const VD = (window as any).VD;
+    if (VD) {
+      VD.handleUpdateDimensions(n, m);
+    }
   }
   // UI can be improved
   public render() {

--- a/src/commons/sideContent/SideContentVideoDisplay.tsx
+++ b/src/commons/sideContent/SideContentVideoDisplay.tsx
@@ -30,28 +30,16 @@ class SideContentVideoDisplay extends React.Component<{}, State> {
     }
   }
   public componentWillUnmount() {
-    const VD = (window as any).VD;
-    if (VD) {
-      VD.deinit();
-    }
+    (window as any).VD?.deinit();
   }
   public handleStartVideo() {
-    const VD = (window as any).VD;
-    if (VD) {
-      VD.handleStartVideo();
-    }
+    (window as any).VD?.handleStartVideo();
   }
   public handleSnapPicture() {
-    const VD = (window as any).VD;
-    if (VD) {
-      VD.handleSnapPicture();
-    }
+    (window as any).VD?.handleSnapPicture();
   }
   public handleCloseVideo() {
-    const VD = (window as any).VD;
-    if (VD) {
-      VD.handleCloseVideo();
-    }
+    (window as any).VD?.handleCloseVideo();
   }
   public handleWidthChange(n: number) {
     if (n > 0) {
@@ -72,10 +60,7 @@ class SideContentVideoDisplay extends React.Component<{}, State> {
     }
   }
   public handleUpdateDimensions(n: number, m: number) {
-    const VD = (window as any).VD;
-    if (VD) {
-      VD.handleUpdateDimensions(n, m);
-    }
+    (window as any).VD?.handleUpdateDimensions(n, m);
   }
   // UI can be improved
   public render() {


### PR DESCRIPTION
### Description

If the playground is set to ALL mode, and you refresh, it will fail to load until the library is somehow changed from ALL.

Fix this.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Set playground library to ALL and refresh.

It should load properly.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
