### PR TITLE
Use backend response text as single source of truth

### DIFF
--- a/src/commons/application/actions/SessionActions.ts
+++ b/src/commons/application/actions/SessionActions.ts
@@ -6,7 +6,6 @@ import {
   Notification,
   NotificationFilterFunction
 } from '../../notificationBadge/NotificationBadgeTypes';
-import { GameState, Role, Story } from '../ApplicationTypes';
 import {
   ACKNOWLEDGE_NOTIFICATIONS,
   FETCH_ASSESSMENT,
@@ -32,7 +31,8 @@ import {
   UPDATE_GRADING,
   UPDATE_GRADING_OVERVIEWS,
   UPDATE_HISTORY_HELPERS,
-  UPDATE_NOTIFICATIONS
+  UPDATE_NOTIFICATIONS,
+  User
 } from '../types/SessionTypes';
 
 export const fetchAuth = (code: string, providerId?: string) =>
@@ -67,15 +67,7 @@ export const setTokens = ({
     refreshToken
   });
 
-export const setUser = (user: {
-  userId: number;
-  name: string;
-  role: Role;
-  group: string | null;
-  grade: number;
-  story?: Story;
-  gameState?: GameState;
-}) => action(SET_USER, user);
+export const setUser = (user: User) => action(SET_USER, user);
 
 export const setGoogleUser = (user?: string) => action(SET_GOOGLE_USER, user);
 

--- a/src/commons/application/types/SessionTypes.ts
+++ b/src/commons/application/types/SessionTypes.ts
@@ -51,3 +51,18 @@ export type SessionState = {
   readonly notifications: Notification[];
   readonly googleUser?: string;
 };
+
+export type Tokens = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type User = {
+  userId: number;
+  name: string;
+  role: Role;
+  group: string | null;
+  grade: number;
+  story?: Story;
+  gameState?: GameState;
+};

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -87,6 +87,13 @@ import {
 } from './RequestsSaga';
 import { safeTakeEvery as takeEvery } from './SafeEffects';
 
+function selectTokens() {
+  return select((state: OverallState) => ({
+    accessToken: state.session.accessToken,
+    refreshToken: state.session.refreshToken
+  }));
+}
+
 function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_AUTH, function* (action: ReturnType<typeof actions.fetchAuth>) {
     const { code, providerId: payloadProviderId } = action.payload;
@@ -119,10 +126,7 @@ function* BackendSaga(): SagaIterator {
   });
 
   yield takeEvery(FETCH_ASSESSMENT_OVERVIEWS, function* () {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const assessmentOverviews: AssessmentOverview[] | null = yield call(
       getAssessmentOverviews,
@@ -134,10 +138,7 @@ function* BackendSaga(): SagaIterator {
   });
 
   yield takeEvery(FETCH_ASSESSMENT, function* (action: ReturnType<typeof actions.fetchAssessment>) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const id = action.payload;
 
@@ -148,11 +149,7 @@ function* BackendSaga(): SagaIterator {
   });
 
   yield takeEvery(SUBMIT_ANSWER, function* (action: ReturnType<typeof actions.submitAnswer>) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
-
+    const tokens: Tokens = yield selectTokens();
     const questionId = action.payload.id;
     const answer = action.payload.answer;
 
@@ -188,10 +185,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(SUBMIT_ASSESSMENT, function* (
     action: ReturnType<typeof actions.submitAssessment>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const assessmentId = action.payload;
 
     const resp: Response | null = yield call(postAssessment, assessmentId, tokens);
@@ -218,10 +212,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_GRADING_OVERVIEWS, function* (
     action: ReturnType<typeof actions.fetchGradingOverviews>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const filterToGroup = action.payload;
 
@@ -236,10 +227,7 @@ function* BackendSaga(): SagaIterator {
   });
 
   yield takeEvery(FETCH_GRADING, function* (action: ReturnType<typeof actions.fetchGrading>) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const id = action.payload;
 
     const grading: Grading | null = yield call(getGrading, id, tokens);
@@ -254,10 +242,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(UNSUBMIT_SUBMISSION, function* (
     action: ReturnType<typeof actions.unsubmitSubmission>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const { submissionId } = action.payload;
 
     const resp: Response | null = yield postUnsubmit(submissionId, tokens);
@@ -290,10 +275,7 @@ function* BackendSaga(): SagaIterator {
     }
 
     const { submissionId, questionId, gradeAdjustment, xpAdjustment, comments } = action.payload;
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const resp: Response | null = yield postGrading(
       submissionId,
@@ -359,10 +341,7 @@ function* BackendSaga(): SagaIterator {
     action: ReturnType<typeof actions.reautogradeSubmission>
   ) {
     const submissionId = action.payload;
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const resp: Response | null = yield call(postReautogradeSubmission, submissionId, tokens);
 
     yield call(handleReautogradeResponse, resp);
@@ -372,10 +351,7 @@ function* BackendSaga(): SagaIterator {
     action: ReturnType<typeof actions.reautogradeAnswer>
   ) {
     const { submissionId, questionId } = action.payload;
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const resp: Response | null = yield call(
       postReautogradeAnswer,
       submissionId,
@@ -389,10 +365,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_NOTIFICATIONS, function* (
     action: ReturnType<typeof actions.fetchNotifications>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const notifications: Notification[] = yield call(getNotifications, tokens);
 
     yield put(actions.updateNotifications(notifications));
@@ -401,10 +374,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(ACKNOWLEDGE_NOTIFICATIONS, function* (
     action: ReturnType<typeof actions.acknowledgeNotifications>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const notificationFilter: NotificationFilterFunction | undefined = action.payload.withFilter;
     const notifications: Notification[] = yield select(
       (state: OverallState) => state.session.notifications
@@ -441,10 +411,7 @@ function* BackendSaga(): SagaIterator {
       return yield call(showWarningMessage, 'Only staff can delete sourcecasts.');
     }
 
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const { id } = action.payload;
 
     const resp: Response | null = yield deleteSourcecastEntry(id, tokens);
@@ -463,10 +430,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_SOURCECAST_INDEX, function* (
     action: ReturnType<typeof actions.fetchSourcecastIndex>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const sourcecastIndex: SourcecastData[] | null = yield call(getSourcecastIndex, tokens);
     if (sourcecastIndex) {
@@ -483,10 +447,7 @@ function* BackendSaga(): SagaIterator {
     }
 
     const { title, description, uid, audio, playbackData } = action.payload;
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const resp: Response | null = yield postSourcecast(
       title,
@@ -521,10 +482,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(CHANGE_SUBLANGUAGE, function* (
     action: ReturnType<typeof actions.changeSublanguage>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const { sublang } = action.payload;
 
     const resp: Response | null = yield call(
@@ -544,10 +502,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_GROUP_GRADING_SUMMARY, function* (
     action: ReturnType<typeof actions.fetchGroupGradingSummary>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
 
     const groupOverviews: GradingSummary | null = yield call(getGradingSummary, tokens);
     if (groupOverviews) {
@@ -558,10 +513,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(CHANGE_DATE_ASSESSMENT, function* (
     action: ReturnType<typeof actions.changeDateAssessment>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const id = action.payload.id;
     const closeAt = action.payload.closeAt;
     const openAt = action.payload.openAt;
@@ -578,10 +530,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(DELETE_ASSESSMENT, function* (
     action: ReturnType<typeof actions.deleteAssessment>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const id = action.payload;
 
     const resp: Response | null = yield deleteAssessment(id, tokens);
@@ -596,10 +545,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(PUBLISH_ASSESSMENT, function* (
     action: ReturnType<typeof actions.publishAssessment>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const id = action.payload.id;
     const togglePublishTo = action.payload.togglePublishTo;
 
@@ -620,10 +566,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(UPLOAD_ASSESSMENT, function* (
     action: ReturnType<typeof actions.uploadAssessment>
   ) {
-    const tokens: Tokens = yield select((state: OverallState) => ({
-      accessToken: state.session.accessToken,
-      refreshToken: state.session.refreshToken
-    }));
+    const tokens: Tokens = yield selectTokens();
     const file = action.payload.file;
     const forceUpdate = action.payload.forceUpdate;
 

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -21,7 +21,10 @@ import {
   FETCH_SUBLANGUAGE,
   WorkspaceLocation
 } from '../../commons/workspace/WorkspaceTypes';
-import { FETCH_GROUP_GRADING_SUMMARY } from '../../features/dashboard/DashboardTypes';
+import {
+  FETCH_GROUP_GRADING_SUMMARY,
+  GradingSummary
+} from '../../features/dashboard/DashboardTypes';
 import { Grading, GradingOverview, GradingQuestion } from '../../features/grading/GradingTypes';
 import {
   CHANGE_DATE_ASSESSMENT,
@@ -30,7 +33,10 @@ import {
   UPLOAD_ASSESSMENT
 } from '../../features/groundControl/GroundControlTypes';
 import { FETCH_SOURCECAST_INDEX } from '../../features/sourceRecorder/sourcecast/SourcecastTypes';
-import { SAVE_SOURCECAST_DATA } from '../../features/sourceRecorder/SourceRecorderTypes';
+import {
+  SAVE_SOURCECAST_DATA,
+  SourcecastData
+} from '../../features/sourceRecorder/SourceRecorderTypes';
 import { DELETE_SOURCECAST_ENTRY } from '../../features/sourceRecorder/sourcereel/SourcereelTypes';
 import {
   ACKNOWLEDGE_NOTIFICATIONS,
@@ -44,7 +50,9 @@ import {
   SUBMIT_ANSWER,
   SUBMIT_GRADING,
   SUBMIT_GRADING_AND_CONTINUE,
-  UNSUBMIT_SUBMISSION
+  Tokens,
+  UNSUBMIT_SUBMISSION,
+  User
 } from '../application/types/SessionTypes';
 import { actions } from '../utils/ActionsHelper';
 import { computeRedirectUri, getClientId, getDefaultProvider } from '../utils/AuthHelper';
@@ -83,6 +91,7 @@ import { safeTakeEvery as takeEvery } from './SafeEffects';
 function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_AUTH, function* (action: ReturnType<typeof actions.fetchAuth>) {
     const { code, providerId: payloadProviderId } = action.payload;
+
     const providerId = payloadProviderId || (getDefaultProvider() || [null])[0];
     if (!providerId) {
       yield call(
@@ -91,74 +100,76 @@ function* BackendSaga(): SagaIterator {
       );
       return yield history.push('/');
     }
+
     const clientId = getClientId(providerId);
     const redirectUrl = computeRedirectUri(providerId);
-    const tokens = yield call(postAuth, code, providerId, clientId, redirectUrl);
+
+    const tokens: Tokens | null = yield call(postAuth, code, providerId, clientId, redirectUrl);
     if (!tokens) {
       return yield history.push('/');
     }
 
-    const user = yield call(getUser, tokens);
+    const user: User | null = yield call(getUser, tokens);
     if (!user) {
       return yield history.push('/');
     }
 
-    // Old: Use dispatch instead of saga's put to guarantee the reducer has
-    // finished setting values in the state before /academy begins rendering
-    // New: Changed to yield put
     yield put(actions.setTokens(tokens));
     yield put(actions.setUser(user));
     yield history.push('/academy');
   });
 
   yield takeEvery(FETCH_ASSESSMENT_OVERVIEWS, function* () {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const assessmentOverviews = yield call(getAssessmentOverviews, tokens);
+
+    const assessmentOverviews: AssessmentOverview[] | null = yield call(
+      getAssessmentOverviews,
+      tokens
+    );
     if (assessmentOverviews) {
       yield put(actions.updateAssessmentOverviews(assessmentOverviews));
     }
   });
 
   yield takeEvery(FETCH_ASSESSMENT, function* (action: ReturnType<typeof actions.fetchAssessment>) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
+
     const id = action.payload;
-    const assessment: Assessment = yield call(getAssessment, id, tokens);
+
+    const assessment: Assessment | null = yield call(getAssessment, id, tokens);
     if (assessment) {
       yield put(actions.updateAssessment(assessment));
     }
   });
 
   yield takeEvery(SUBMIT_ANSWER, function* (action: ReturnType<typeof actions.submitAnswer>) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
 
     const questionId = action.payload.id;
     const answer = action.payload.answer;
-    const resp = yield call(postAnswer, questionId, answer, tokens);
 
-    const codes: Map<number, string> = new Map([
-      [400, "Answer rejected - can't save an empty answer."],
-      [403, 'Answer rejected - assessment not open or already finalised.']
-    ]);
+    const resp: Response | null = yield call(postAnswer, questionId, answer, tokens);
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, codes);
+      yield handleResponseError(resp);
       return;
     }
 
     yield call(showSuccessMessage, 'Saved!', 1000);
+
     // Now, update the answer for the question in the assessment in the store
-    const assessmentId = yield select(
+    const assessmentId: number = yield select(
       (state: OverallState) => state.workspaces.assessment.currentAssessment!
     );
-    const assessment = yield select((state: OverallState) =>
+    const assessment: any = yield select((state: OverallState) =>
       state.session.assessments.get(assessmentId)
     );
     const newQuestions = assessment.questions.slice().map((question: Question) => {
@@ -171,6 +182,7 @@ function* BackendSaga(): SagaIterator {
       ...assessment,
       questions: newQuestions
     };
+
     yield put(actions.updateAssessment(newAssessment));
     return yield put(actions.updateHasUnsavedChanges('assessment' as WorkspaceLocation, false));
   });
@@ -178,23 +190,20 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(SUBMIT_ASSESSMENT, function* (
     action: ReturnType<typeof actions.submitAssessment>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const assessmentId = action.payload;
-    const resp = yield call(postAssessment, assessmentId, tokens);
 
-    const codes: Map<number, string> = new Map([
-      [400, 'Not allowed to finalise - some questions are unattempted.'],
-      [403, 'Not allowed to finalise - assessment not open or already finalised.']
-    ]);
+    const resp: Response | null = yield call(postAssessment, assessmentId, tokens);
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, codes);
+      yield handleResponseError(resp);
       return;
     }
 
     yield call(showSuccessMessage, 'Submitted!', 2000);
+
     // Now, update the status of the assessment overview in the store
     const overviews: AssessmentOverview[] = yield select(
       (state: OverallState) => state.session.assessmentOverviews
@@ -205,32 +214,38 @@ function* BackendSaga(): SagaIterator {
       }
       return overview;
     });
+
     return yield put(actions.updateAssessmentOverviews(newOverviews));
   });
 
   yield takeEvery(FETCH_GRADING_OVERVIEWS, function* (
     action: ReturnType<typeof actions.fetchGradingOverviews>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
 
     const filterToGroup = action.payload;
 
-    const gradingOverviews = yield call(getGradingOverviews, tokens, filterToGroup);
+    const gradingOverviews: GradingOverview[] | null = yield call(
+      getGradingOverviews,
+      tokens,
+      filterToGroup
+    );
     if (gradingOverviews) {
       yield put(actions.updateGradingOverviews(gradingOverviews));
     }
   });
 
   yield takeEvery(FETCH_GRADING, function* (action: ReturnType<typeof actions.fetchGrading>) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const id = action.payload;
-    const grading = yield call(getGrading, id, tokens);
+
+    const grading: Grading | null = yield call(getGrading, id, tokens);
     if (grading) {
       yield put(actions.updateGrading(id, grading));
     }
@@ -242,30 +257,28 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(UNSUBMIT_SUBMISSION, function* (
     action: ReturnType<typeof actions.unsubmitSubmission>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const { submissionId } = action.payload;
 
-    const resp: Response = yield postUnsubmit(submissionId, tokens);
-
-    const codes: Map<number, string> = new Map([
-      [400, 'Not allowed to unsubmit - submission incomplete or not submitted.'],
-      [403, "Not allowed to unsubmit - not this student's Avenger or an Admin."]
-    ]);
+    const resp: Response | null = yield postUnsubmit(submissionId, tokens);
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, codes);
+      yield handleResponseError(resp);
       return;
     }
 
-    const overviews = yield select((state: OverallState) => state.session.gradingOverviews || []);
-    const newOverviews = (overviews as GradingOverview[]).map(overview => {
+    const overviews: GradingOverview[] = yield select(
+      (state: OverallState) => state.session.gradingOverviews || []
+    );
+    const newOverviews = overviews.map(overview => {
       if (overview.submissionId === submissionId) {
         return { ...overview, submissionStatus: 'attempted' };
       }
       return overview;
     });
+
     yield call(showSuccessMessage, 'Unsubmit successful', 1000);
     yield put(actions.updateGradingOverviews(newOverviews));
   });
@@ -275,16 +288,18 @@ function* BackendSaga(): SagaIterator {
       | ReturnType<typeof actions.submitGrading>
       | ReturnType<typeof actions.submitGradingAndContinue>
   ) {
-    const role = yield select((state: OverallState) => state.session.role!);
+    const role: Role = yield select((state: OverallState) => state.session.role!);
     if (role === Role.Student) {
       return yield call(showWarningMessage, 'Only staff can submit answers.');
     }
+
     const { submissionId, questionId, gradeAdjustment, xpAdjustment, comments } = action.payload;
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const resp = yield postGrading(
+
+    const resp: Response | null = yield postGrading(
       submissionId,
       questionId,
       gradeAdjustment,
@@ -292,17 +307,13 @@ function* BackendSaga(): SagaIterator {
       tokens,
       comments
     );
-
-    const codes: Map<number, string> = new Map([
-      [400, 'Grading rejected - missing permissions or invalid grade parameters.'],
-      [405, 'Not allowed to grade - submission incomplete or not submitted.']
-    ]);
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, codes);
+      yield handleResponseError(resp);
       return;
     }
 
     yield call(showSuccessMessage, 'Submitted!', 1000);
+
     // Now, update the grade for the question in the Grading in the store
     const grading: Grading = yield select((state: OverallState) =>
       state.session.gradings.get(submissionId)
@@ -320,18 +331,20 @@ function* BackendSaga(): SagaIterator {
       }
       return gradingQuestion;
     });
+
     yield put(actions.updateGrading(submissionId, newGrading));
   };
 
   const sendGradeAndContinue = function* (
     action: ReturnType<typeof actions.submitGradingAndContinue>
   ) {
-    const { submissionId } = action.payload;
     yield* sendGrade(action);
 
-    const currentQuestion = yield select(
+    const { submissionId } = action.payload;
+    const currentQuestion: number | undefined = yield select(
       (state: OverallState) => state.workspaces.grading.currentQuestion
     );
+
     /**
      * Move to next question for grading: this only works because the
      * SUBMIT_GRADING_AND_CONTINUE Redux action is currently only
@@ -351,11 +364,16 @@ function* BackendSaga(): SagaIterator {
     action: ReturnType<typeof actions.reautogradeSubmission>
   ) {
     const submissionId = action.payload;
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const result = yield call(postReautogradeSubmission, submissionId, tokens);
+    const result: AsyncReturnType<typeof postReautogradeSubmission> = yield call(
+      postReautogradeSubmission,
+      submissionId,
+      tokens
+    );
+
     yield call(handleReautogradeResponse, result);
   });
 
@@ -363,23 +381,28 @@ function* BackendSaga(): SagaIterator {
     action: ReturnType<typeof actions.reautogradeAnswer>
   ) {
     const { submissionId, questionId } = action.payload;
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const result = yield call(postReautogradeAnswer, submissionId, questionId, tokens);
+    const result: AsyncReturnType<typeof postReautogradeSubmission> = yield call(
+      postReautogradeAnswer,
+      submissionId,
+      questionId,
+      tokens
+    );
+
     yield call(handleReautogradeResponse, result);
   });
 
   yield takeEvery(FETCH_NOTIFICATIONS, function* (
     action: ReturnType<typeof actions.fetchNotifications>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-
-    const notifications = yield call(getNotifications, tokens);
+    const notifications: Notification[] = yield call(getNotifications, tokens);
 
     yield put(actions.updateNotifications(notifications));
   });
@@ -387,13 +410,11 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(ACKNOWLEDGE_NOTIFICATIONS, function* (
     action: ReturnType<typeof actions.acknowledgeNotifications>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-
     const notificationFilter: NotificationFilterFunction | undefined = action.payload.withFilter;
-
     const notifications: Notification[] = yield select(
       (state: OverallState) => state.session.notifications
     );
@@ -409,7 +430,6 @@ function* BackendSaga(): SagaIterator {
     }
 
     const ids = notificationsToAcknowledge.map(n => n.id);
-
     const newNotifications: Notification[] = notifications.filter(
       notification => !ids.includes(notification.id)
     );
@@ -417,7 +437,6 @@ function* BackendSaga(): SagaIterator {
     yield put(actions.updateNotifications(newNotifications));
 
     const resp: Response | null = yield call(postAcknowledgeNotifications, tokens, ids);
-
     if (!resp || !resp.ok) {
       yield handleResponseError(resp);
       return;
@@ -432,33 +451,35 @@ function* BackendSaga(): SagaIterator {
       return yield call(showWarningMessage, 'Only staff can delete sourcecasts.');
     }
 
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const { id } = action.payload;
-    const resp: Response = yield deleteSourcecastEntry(id, tokens);
 
+    const resp: Response | null = yield deleteSourcecastEntry(id, tokens);
     if (!resp || !resp.ok) {
       yield handleResponseError(resp);
       return;
     }
 
-    const sourcecastIndex = yield call(getSourcecastIndex, tokens);
+    const sourcecastIndex: SourcecastData[] | null = yield call(getSourcecastIndex, tokens);
     if (sourcecastIndex) {
       yield put(actions.updateSourcecastIndex(sourcecastIndex, action.payload.workspaceLocation));
     }
+
     yield call(showSuccessMessage, 'Deleted successfully!', 1000);
   });
 
   yield takeEvery(FETCH_SOURCECAST_INDEX, function* (
     action: ReturnType<typeof actions.fetchSourcecastIndex>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const sourcecastIndex = yield call(getSourcecastIndex, tokens);
+
+    const sourcecastIndex: SourcecastData[] | null = yield call(getSourcecastIndex, tokens);
     if (sourcecastIndex) {
       yield put(actions.updateSourcecastIndex(sourcecastIndex, action.payload.workspaceLocation));
     }
@@ -467,19 +488,27 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(SAVE_SOURCECAST_DATA, function* (
     action: ReturnType<typeof actions.saveSourcecastData>
   ) {
-    const role = yield select((state: OverallState) => state.session.role!);
+    const role: Role = yield select((state: OverallState) => state.session.role!);
     if (role === Role.Student) {
       return yield call(showWarningMessage, 'Only staff can save sourcecasts.');
     }
+
     const { title, description, uid, audio, playbackData } = action.payload;
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const resp = yield postSourcecast(title, description, uid, audio, playbackData, tokens);
 
+    const resp: Response | null = yield postSourcecast(
+      title,
+      description,
+      uid,
+      audio,
+      playbackData,
+      tokens
+    );
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, new Map());
+      yield handleResponseError(resp);
       return;
     }
 
@@ -491,7 +520,6 @@ function* BackendSaga(): SagaIterator {
     action: ReturnType<typeof actions.fetchSublanguage>
   ) {
     const sublang: SourceLanguage | null = yield call(getSublanguage);
-
     if (!sublang) {
       yield call(showWarningMessage, `Failed to load default Source sublanguage for Playground!`);
       return;
@@ -503,20 +531,20 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(CHANGE_SUBLANGUAGE, function* (
     action: ReturnType<typeof actions.changeSublanguage>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-
     const { sublang } = action.payload;
-    const resp: Response = yield call(postSublanguage, sublang.chapter, sublang.variant, tokens);
 
-    const codes: Map<number, string> = new Map([
-      [400, 'Request rejected - invalid chapter-variant combination.'],
-      [403, 'Request rejected - only staff are allowed to set the default sublanguage.']
-    ]);
+    const resp: Response | null = yield call(
+      postSublanguage,
+      sublang.chapter,
+      sublang.variant,
+      tokens
+    );
     if (!resp || !resp.ok) {
-      yield handleResponseError(resp, codes);
+      yield handleResponseError(resp);
       return;
     }
 
@@ -527,11 +555,12 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_GROUP_GRADING_SUMMARY, function* (
     action: ReturnType<typeof actions.fetchGroupGradingSummary>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
-    const groupOverviews = yield call(getGradingSummary, tokens);
+
+    const groupOverviews: GradingSummary | null = yield call(getGradingSummary, tokens);
     if (groupOverviews) {
       yield put(actions.updateGroupGradingSummary(groupOverviews));
     }
@@ -540,19 +569,17 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(CHANGE_DATE_ASSESSMENT, function* (
     action: ReturnType<typeof actions.changeDateAssessment>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const id = action.payload.id;
     const closeAt = action.payload.closeAt;
     const openAt = action.payload.openAt;
-    const respMsg: string | null = yield changeDateAssessment(id, closeAt, openAt, tokens);
-    if (respMsg == null) {
-      yield handleResponseError(respMsg);
-      return;
-    } else if (respMsg !== 'OK') {
-      yield call(showWarningMessage, respMsg, 5000);
+
+    const resp: Response | null = yield changeDateAssessment(id, closeAt, openAt, tokens);
+    if (!resp || !resp.ok) {
+      yield handleResponseError(resp);
       return;
     }
 
@@ -563,13 +590,13 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(DELETE_ASSESSMENT, function* (
     action: ReturnType<typeof actions.deleteAssessment>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const id = action.payload;
-    const resp: Response = yield deleteAssessment(id, tokens);
 
+    const resp: Response | null = yield deleteAssessment(id, tokens);
     if (!resp || !resp.ok) {
       yield handleResponseError(resp);
       return;
@@ -582,14 +609,14 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(PUBLISH_ASSESSMENT, function* (
     action: ReturnType<typeof actions.publishAssessment>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const id = action.payload.id;
     const togglePublishTo = action.payload.togglePublishTo;
-    const resp: Response = yield publishAssessment(id, togglePublishTo, tokens);
 
+    const resp: Response | null = yield publishAssessment(id, togglePublishTo, tokens);
     if (!resp || !resp.ok) {
       yield handleResponseError(resp);
       return;
@@ -607,23 +634,26 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(UPLOAD_ASSESSMENT, function* (
     action: ReturnType<typeof actions.uploadAssessment>
   ) {
-    const tokens = yield select((state: OverallState) => ({
+    const tokens: Tokens = yield select((state: OverallState) => ({
       accessToken: state.session.accessToken,
       refreshToken: state.session.refreshToken
     }));
     const file = action.payload.file;
     const forceUpdate = action.payload.forceUpdate;
-    const respMsg = yield uploadAssessment(file, tokens, forceUpdate);
-    if (!respMsg) {
-      yield handleResponseError(respMsg);
-    } else if (respMsg === 'OK') {
-      yield call(showSuccessMessage, 'Uploaded successfully!', 2000);
-    } else if (respMsg === 'Force Update OK') {
-      yield call(showSuccessMessage, 'Assessment force updated successfully!', 2000);
-    } else {
-      yield call(showWarningMessage, respMsg, 10000);
+
+    const resp: Response | null = yield uploadAssessment(file, tokens, forceUpdate);
+    if (!resp || !resp.ok) {
+      yield handleResponseError(resp);
       return;
     }
+
+    const respText: string = yield resp.text();
+    if (respText === 'OK') {
+      yield call(showSuccessMessage, 'Uploaded successfully!', 2000);
+    } else if (respText === 'Force Update OK') {
+      yield call(showSuccessMessage, 'Assessment force updated successfully!', 2000);
+    }
+
     yield put(actions.fetchAssessmentOverviews());
   });
 }

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -56,12 +56,12 @@ type RequestOptions = {
 /**
  * POST /auth
  */
-export async function postAuth(
+export const postAuth = async (
   code: string,
   providerId: string,
   clientId?: string,
   redirectUri?: string
-): Promise<Tokens | null> {
+): Promise<Tokens | null> => {
   const resp = await request('auth', 'POST', {
     body: {
       code,
@@ -79,29 +79,31 @@ export async function postAuth(
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token
   };
-}
+};
 
 /**
  * POST /auth/refresh
  */
-async function postRefresh(refreshToken: string): Promise<Tokens | null> {
+const postRefresh = async (refreshToken: string): Promise<Tokens | null> => {
   const resp = await request('auth/refresh', 'POST', {
     body: { refresh_token: refreshToken }
   });
   if (!resp) {
     return null;
   }
+
   const tokens = await resp.json();
+
   return {
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token
   };
-}
+};
 
 /**
  * GET /user
  */
-export async function getUser(tokens: Tokens): Promise<User | null> {
+export const getUser = async (tokens: Tokens): Promise<User | null> => {
   const resp = await request('user', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -110,16 +112,17 @@ export async function getUser(tokens: Tokens): Promise<User | null> {
   if (!resp || !resp.ok) {
     return null;
   }
+
   return await resp.json();
-}
+};
 
 /**
  * GET /achievements
  *
  * Will be updated after a separate db for student progress is ready
  */
-export async function getAchievements(tokens: Tokens): Promise<AchievementItem[] | null> {
-  const resp = await request('achievements/', 'GET', {
+export const getAchievements = async (tokens: Tokens): Promise<AchievementItem[] | null> => {
+  const resp = await request('achievements', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
@@ -143,15 +146,15 @@ export async function getAchievements(tokens: Tokens): Promise<AchievementItem[]
         prerequisiteIds: achievement.prerequisiteIds || []
       } as AchievementItem)
   );
-}
+};
 
 /**
- * GET achievements/goals/user_id
+ * GET achievements/goals/{studentId}
  */
-export async function getGoals(
+export const getGoals = async (
   tokens: Tokens,
   studentId: number
-): Promise<AchievementGoal[] | null> {
+): Promise<AchievementGoal[] | null> => {
   const resp = await request(`achievements/goals/${studentId}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -172,13 +175,13 @@ export async function getGoals(
         meta: goal.meta as GoalMeta
       } as AchievementGoal)
   );
-}
+};
 
 /**
  * GET achievements/goals
  */
-export async function getOwnGoals(tokens: Tokens): Promise<AchievementGoal[] | null> {
-  const resp = await request(`achievements/goals/`, 'GET', {
+export const getOwnGoals = async (tokens: Tokens): Promise<AchievementGoal[] | null> => {
+  const resp = await request('achievements/goals', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
@@ -198,15 +201,15 @@ export async function getOwnGoals(tokens: Tokens): Promise<AchievementGoal[] | n
         meta: goal.meta as GoalMeta
       } as AchievementGoal)
   );
-}
+};
 
 /**
- * POST /achievements/:achievement_id
+ * POST /achievements/{achievementId}
  */
-export async function editAchievement(
+export const editAchievement = async (
   achievement: AchievementItem,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`achievements/${achievement.id}`, 'POST', {
     accessToken: tokens.accessToken,
     body: { achievement: achievement },
@@ -217,15 +220,15 @@ export async function editAchievement(
   });
 
   return resp;
-}
+};
 
 /**
- * POST /achievements/goals/:goal_id/
+ * POST /achievements/goals/{goalId}
  */
-export async function editGoal(
+export const editGoal = async (
   definition: GoalDefinition,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${definition.id}`, 'POST', {
     accessToken: tokens.accessToken,
     body: { definition: definition },
@@ -236,16 +239,16 @@ export async function editGoal(
   });
 
   return resp;
-}
+};
 
 /**
- * POST /achievements/goals/:goal_id/:student_id
+ * POST /achievements/goals/{goalId}/{studentId}
  */
-export async function updateGoalProgress(
+export const updateGoalProgress = async (
   studentId: number,
   progress: GoalProgress,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${progress.id}/${studentId}`, 'POST', {
     accessToken: tokens.accessToken,
     body: { progress: progress },
@@ -256,15 +259,15 @@ export async function updateGoalProgress(
   });
 
   return resp;
-}
+};
 
 /**
- * DELETE /achievements/:achievement_id
+ * DELETE /achievements/{achievementId}
  */
-export async function removeAchievement(
+export const removeAchievement = async (
   achievement: AchievementItem,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`achievements/${achievement.id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     body: { achievement: achievement },
@@ -275,16 +278,16 @@ export async function removeAchievement(
   });
 
   return resp;
-}
+};
 
 /**
  * DELETE /achievements/goals
  *
  */
-export async function removeGoal(
+export const removeGoal = async (
   definition: GoalDefinition,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${definition.id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     body: { definition: definition },
@@ -295,12 +298,14 @@ export async function removeGoal(
   });
 
   return resp;
-}
+};
 
 /**
  * GET /assessments
  */
-export async function getAssessmentOverviews(tokens: Tokens): Promise<AssessmentOverview[] | null> {
+export const getAssessmentOverviews = async (
+  tokens: Tokens
+): Promise<AssessmentOverview[] | null> => {
   const resp = await request('assessments', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -329,12 +334,12 @@ export async function getAssessmentOverviews(tokens: Tokens): Promise<Assessment
 
     return overview as AssessmentOverview;
   });
-}
+};
 
 /**
- * GET /assessments/${assessmentId}
+ * GET /assessments/{assessmentId}
  */
-export async function getAssessment(id: number, tokens: Tokens): Promise<Assessment | null> {
+export const getAssessment = async (id: number, tokens: Tokens): Promise<Assessment | null> => {
   let resp = await request(`assessments/${id}`, 'POST', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -397,19 +402,21 @@ export async function getAssessment(id: number, tokens: Tokens): Promise<Assessm
       } catch (e) {}
       return entry;
     });
+
     return q;
   });
+
   return assessment;
-}
+};
 
 /**
- * POST /assessments/question/${questionId}/submit
+ * POST /assessments/question/{questionId}/submit
  */
-export async function postAnswer(
+export const postAnswer = async (
   id: number,
   answer: string | number,
   tokens: Tokens
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const resp = await request(`assessments/question/${id}/submit`, 'POST', {
     accessToken: tokens.accessToken,
     body: { answer: `${answer}` },
@@ -419,12 +426,12 @@ export async function postAnswer(
     shouldRefresh: true
   });
   return resp;
-}
+};
 
 /**
- * POST /assessments/${assessmentId}/submit
+ * POST /assessments/{assessmentId}/submit
  */
-export async function postAssessment(id: number, tokens: Tokens): Promise<Response | null> {
+export const postAssessment = async (id: number, tokens: Tokens): Promise<Response | null> => {
   const resp = await request(`assessments/${id}/submit`, 'POST', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
@@ -432,18 +439,17 @@ export async function postAssessment(id: number, tokens: Tokens): Promise<Respon
     shouldAutoLogout: false, // 400 if some questions unattempted
     shouldRefresh: true
   });
+
   return resp;
-}
+};
 
 /*
  * GET /grading
- * @params group - a boolean if true gets the submissions from the grader's group
- * @returns {Array} GradingOverview[]
  */
-export async function getGradingOverviews(
+export const getGradingOverviews = async (
   tokens: Tokens,
   group: boolean
-): Promise<GradingOverview[] | null> {
+): Promise<GradingOverview[] | null> => {
   const resp = await request(`grading?group=${group}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -493,25 +499,25 @@ export async function getGradingOverviews(
         ? subY.assessmentId - subX.assessmentId
         : subY.submissionId - subX.submissionId
     );
-}
+};
 
 /**
- * GET /grading/${submissionId}
- * @returns {Grading}
+ * GET /grading/{submissionId}
  */
-export async function getGrading(submissionId: number, tokens: Tokens): Promise<Grading | null> {
+export const getGrading = async (submissionId: number, tokens: Tokens): Promise<Grading | null> => {
   const resp = await request(`grading/${submissionId}`, 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldRefresh: true
   });
+
   if (!resp) {
     return null;
   }
+
   const gradingResult = await resp.json();
   const grading: Grading = gradingResult.map((gradingQuestion: any) => {
     const { student, question, grade } = gradingQuestion;
-
     const result = {
       question: {
         answer: question.answer,
@@ -548,8 +554,9 @@ export async function getGrading(submissionId: number, tokens: Tokens): Promise<
 
     return result;
   });
+
   return grading;
-}
+};
 
 /**
  * POST /grading/{submissionId}/{questionId}
@@ -561,7 +568,7 @@ export const postGrading = async (
   xpAdjustment: number,
   tokens: Tokens,
   comments?: string
-) => {
+): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/${questionId}`, 'POST', {
     accessToken: tokens.accessToken,
     body: {
@@ -576,29 +583,17 @@ export const postGrading = async (
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
 };
-
-function handleReautogradeResponse(
-  resp: Response | null
-): true | 'not_found' | 'not_submitted' | false {
-  if (!resp || resp.ok) {
-    return !!resp?.ok;
-  }
-
-  switch (resp.status) {
-    case 400:
-      return 'not_submitted';
-    case 404:
-      return 'not_found';
-  }
-  return false;
-}
 
 /**
  * POST /grading/{submissionId}/autograde
  */
-export const postReautogradeSubmission = async (submissionId: number, tokens: Tokens) => {
+export const postReautogradeSubmission = async (
+  submissionId: number,
+  tokens: Tokens
+): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/autograde`, 'POST', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -606,7 +601,8 @@ export const postReautogradeSubmission = async (submissionId: number, tokens: To
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return handleReautogradeResponse(resp);
+
+  return resp;
 };
 
 /**
@@ -616,7 +612,7 @@ export const postReautogradeAnswer = async (
   submissionId: number,
   questionId: number,
   tokens: Tokens
-) => {
+): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/${questionId}/autograde`, 'POST', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -624,13 +620,17 @@ export const postReautogradeAnswer = async (
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return handleReautogradeResponse(resp);
+
+  return resp;
 };
 
 /**
  * POST /grading/{submissionId}/unsubmit
  */
-export async function postUnsubmit(submissionId: number, tokens: Tokens) {
+export const postUnsubmit = async (
+  submissionId: number,
+  tokens: Tokens
+): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/unsubmit`, 'POST', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
@@ -638,18 +638,20 @@ export async function postUnsubmit(submissionId: number, tokens: Tokens) {
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
-}
+};
 
 /**
  * GET /notification
  */
-export async function getNotifications(tokens: Tokens) {
+export const getNotifications = async (tokens: Tokens): Promise<Notification[]> => {
   const resp: Response | null = await request('notification', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     shouldAutoLogout: false
   });
+
   let notifications: Notification[] = [];
 
   if (!resp || !resp.ok) {
@@ -657,6 +659,7 @@ export async function getNotifications(tokens: Tokens) {
   }
 
   const result = await resp.json();
+
   notifications = result.map((notification: any) => {
     return {
       id: notification.id,
@@ -671,13 +674,16 @@ export async function getNotifications(tokens: Tokens) {
   });
 
   return notifications;
-}
+};
 
 /**
  * POST /notification/acknowledge
  */
-export async function postAcknowledgeNotifications(tokens: Tokens, ids: number[]) {
-  const resp: Response | null = await request(`notification/acknowledge`, 'POST', {
+export const postAcknowledgeNotifications = async (
+  tokens: Tokens,
+  ids: number[]
+): Promise<Response | null> => {
+  const resp: Response | null = await request('notification/acknowledge', 'POST', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     body: { notificationIds: ids },
@@ -685,12 +691,15 @@ export async function postAcknowledgeNotifications(tokens: Tokens, ids: number[]
   });
 
   return resp;
-}
+};
 
 /**
- * DELETE /sourcecast
+ * DELETE /sourcecast/{sourcecastId}
  */
-export async function deleteSourcecastEntry(id: number, tokens: Tokens) {
+export const deleteSourcecastEntry = async (
+  id: number,
+  tokens: Tokens
+): Promise<Response | null> => {
   const resp = await request(`sourcecast/${id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
@@ -698,13 +707,14 @@ export async function deleteSourcecastEntry(id: number, tokens: Tokens) {
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
-}
+};
 
 /**
  * GET /sourcecast
  */
-export async function getSourcecastIndex(tokens: Tokens): Promise<SourcecastData[] | null> {
+export const getSourcecastIndex = async (tokens: Tokens): Promise<SourcecastData[] | null> => {
   const resp = await request('sourcecast', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -714,9 +724,9 @@ export async function getSourcecastIndex(tokens: Tokens): Promise<SourcecastData
   if (!resp || !resp.ok) {
     return null;
   }
-  const index = await resp.json();
-  return index;
-}
+
+  return await resp.json();
+};
 
 /**
  * POST /sourcecast
@@ -728,7 +738,7 @@ export const postSourcecast = async (
   audio: Blob,
   playbackData: PlaybackData,
   tokens: Tokens
-) => {
+): Promise<Response | null> => {
   const formData = new FormData();
   const filename = Date.now().toString() + '.wav';
   formData.append('sourcecast[title]', title);
@@ -745,15 +755,19 @@ export const postSourcecast = async (
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
 };
 
-export async function changeDateAssessment(
+/**
+ * POST /assessments/update/{assessmentId}
+ */
+export const changeDateAssessment = async (
   id: number,
   closeAt: string,
   openAt: string,
   tokens: Tokens
-) {
+): Promise<Response | null> => {
   const resp = await request(`assessments/update/${id}`, 'POST', {
     accessToken: tokens.accessToken,
     body: { closeAt, openAt },
@@ -762,10 +776,14 @@ export async function changeDateAssessment(
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return resp;
-}
 
-export async function deleteAssessment(id: number, tokens: Tokens) {
+  return resp;
+};
+
+/**
+ * DELETE /assessments/{assessmentId}
+ */
+export const deleteAssessment = async (id: number, tokens: Tokens): Promise<Response | null> => {
   const resp = await request(`assessments/${id}`, 'DELETE', {
     accessToken: tokens.accessToken,
     noHeaderAccept: true,
@@ -773,10 +791,18 @@ export async function deleteAssessment(id: number, tokens: Tokens) {
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return resp;
-}
 
-export async function publishAssessment(id: number, togglePublishTo: boolean, tokens: Tokens) {
+  return resp;
+};
+
+/**
+ * POST /assessments/publish/{assessmentId}
+ */
+export const publishAssessment = async (
+  id: number,
+  togglePublishTo: boolean,
+  tokens: Tokens
+): Promise<Response | null> => {
   const resp = await request(`assessments/publish/${id}`, 'POST', {
     accessToken: tokens.accessToken,
     body: { togglePublishTo },
@@ -785,10 +811,18 @@ export async function publishAssessment(id: number, togglePublishTo: boolean, to
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-  return resp;
-}
 
-export const uploadAssessment = async (file: File, tokens: Tokens, forceUpdate: boolean) => {
+  return resp;
+};
+
+/**
+ * POST /assessments
+ */
+export const uploadAssessment = async (
+  file: File,
+  tokens: Tokens,
+  forceUpdate: boolean
+): Promise<Response | null> => {
   const formData = new FormData();
   formData.append('assessment[file]', file);
   formData.append('forceUpdate', String(forceUpdate));
@@ -801,10 +835,14 @@ export const uploadAssessment = async (file: File, tokens: Tokens, forceUpdate: 
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
 };
 
-export async function getGradingSummary(tokens: Tokens): Promise<GradingSummary | null> {
+/**
+ * GET /grading/summary
+ */
+export const getGradingSummary = async (tokens: Tokens): Promise<GradingSummary | null> => {
   const resp = await request('grading/summary', 'GET', {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -815,33 +853,37 @@ export async function getGradingSummary(tokens: Tokens): Promise<GradingSummary 
   }
 
   return await resp.json();
-}
+};
 
 /**
  * GET /settings/sublanguage
  */
-export async function getSublanguage(): Promise<SourceLanguage | null> {
+export const getSublanguage = async (): Promise<SourceLanguage | null> => {
   const resp = await request('settings/sublanguage', 'GET', {
     noHeaderAccept: true,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
-
   if (!resp || !resp.ok) {
     return null;
   }
 
   const sublang = (await resp.json()).sublanguage;
+
   return {
     ...sublang,
     displayName: styliseSublanguage(sublang.chapter, sublang.variant)
   };
-}
+};
 
 /**
  * PUT /settings/sublanguage
  */
-export async function postSublanguage(chapter: number, variant: string, tokens: Tokens) {
+export const postSublanguage = async (
+  chapter: number,
+  variant: string,
+  tokens: Tokens
+): Promise<Response | null> => {
   const resp = await request(`settings/sublanguage`, 'PUT', {
     accessToken: tokens.accessToken,
     body: { chapter, variant },
@@ -850,8 +892,9 @@ export async function postSublanguage(chapter: number, variant: string, tokens: 
     shouldAutoLogout: false,
     shouldRefresh: true
   });
+
   return resp;
-}
+};
 
 /**
  * @returns {(Response|null)} Response if successful, otherwise null.
@@ -865,11 +908,11 @@ export async function postSublanguage(chapter: number, variant: string, tokens: 
  * If fetch throws an error, or final response has status code < 200 or > 299,
  * this function will cause the user to logout.
  */
-export async function request(
+export const request = async (
   path: string,
   method: string,
   opts: RequestOptions
-): Promise<Response | null> {
+): Promise<Response | null> => {
   const headers = new Headers();
   if (!opts.noHeaderAccept) {
     headers.append('Accept', 'application/json');
@@ -877,6 +920,7 @@ export async function request(
   if (opts.accessToken) {
     headers.append('Authorization', `Bearer ${opts.accessToken}`);
   }
+
   const fetchOpts: any = { method, headers };
   if (opts.body) {
     if (opts.noContentType) {
@@ -887,8 +931,10 @@ export async function request(
       fetchOpts.body = JSON.stringify(opts.body);
     }
   }
+
   try {
     const resp = await fetch(`${Constants.backendUrl}/v1/${path}`, fetchOpts);
+
     // response.ok is (200 <= response.status <= 299)
     // response.status of > 299 does not raise error; so deal with in in the try clause
     if (opts.shouldRefresh && resp && resp.status === 401) {
@@ -901,28 +947,32 @@ export async function request(
       };
       return request(path, method, newOpts);
     }
+
     if (resp && !resp.ok && opts.shouldAutoLogout === false) {
       // this clause is mostly for SUBMIT_ANSWER; show an error message instead
       // and ask student to manually logout, so that they have a chance to save
       // their answers
       return resp;
     }
+
     if (!resp || !resp.ok) {
       throw new Error('API call failed or got non-OK response');
     }
+
     return resp;
   } catch (e) {
     store.dispatch(actions.logOut());
     showWarningMessage(opts.errorMessage ? opts.errorMessage : 'Please login again.');
+
     return null;
   }
-}
+};
 
 /**
  * Handles display of warning notifications for failed HTTP requests, i.e. those with no response
  * or a HTTP error status code (not 2xx).
  *
- * @param   {(Response|null)}     resp    Result of the failed HTTP request
+ * @param {(Response|null)} resp Result of the failed HTTP request
  */
 export function* handleResponseError(resp: Response | null) {
   // Default: check if the response is null

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -105,8 +105,7 @@ const postRefresh = async (refreshToken: string): Promise<Tokens | null> => {
  */
 export const getUser = async (tokens: Tokens): Promise<User | null> => {
   const resp = await request('user', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
   if (!resp || !resp.ok) {
@@ -123,8 +122,7 @@ export const getUser = async (tokens: Tokens): Promise<User | null> => {
  */
 export const getAchievements = async (tokens: Tokens): Promise<AchievementItem[] | null> => {
   const resp = await request('achievements', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
 
@@ -156,8 +154,7 @@ export const getGoals = async (
   studentId: number
 ): Promise<AchievementGoal[] | null> => {
   const resp = await request(`achievements/goals/${studentId}`, 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
 
@@ -182,8 +179,7 @@ export const getGoals = async (
  */
 export const getOwnGoals = async (tokens: Tokens): Promise<AchievementGoal[] | null> => {
   const resp = await request('achievements/goals', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
 
@@ -211,10 +207,9 @@ export const editAchievement = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`achievements/${achievement.id}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { achievement: achievement },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -230,10 +225,9 @@ export const editGoal = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${definition.id}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { definition: definition },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -250,10 +244,9 @@ export const updateGoalProgress = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${progress.id}/${studentId}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { progress: progress },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -269,10 +262,9 @@ export const removeAchievement = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`achievements/${achievement.id}`, 'DELETE', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { achievement: achievement },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -289,10 +281,9 @@ export const removeGoal = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`achievements/goals/${definition.id}`, 'DELETE', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { definition: definition },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -307,8 +298,7 @@ export const getAssessmentOverviews = async (
   tokens: Tokens
 ): Promise<AssessmentOverview[] | null> => {
   const resp = await request('assessments', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
   if (!resp || !resp.ok) {
@@ -341,8 +331,7 @@ export const getAssessmentOverviews = async (
  */
 export const getAssessment = async (id: number, tokens: Tokens): Promise<Assessment | null> => {
   let resp = await request(`assessments/${id}`, 'POST', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -357,8 +346,7 @@ export const getAssessment = async (id: number, tokens: Tokens): Promise<Assessm
     }
 
     resp = await request(`assessments/${id}`, 'POST', {
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
+      ...tokens,
       body: {
         password: input
       },
@@ -418,10 +406,9 @@ export const postAnswer = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`assessments/question/${id}/submit`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { answer: `${answer}` },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -433,9 +420,8 @@ export const postAnswer = async (
  */
 export const postAssessment = async (id: number, tokens: Tokens): Promise<Response | null> => {
   const resp = await request(`assessments/${id}/submit`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false, // 400 if some questions unattempted
     shouldRefresh: true
   });
@@ -451,8 +437,7 @@ export const getGradingOverviews = async (
   group: boolean
 ): Promise<GradingOverview[] | null> => {
   const resp = await request(`grading?group=${group}`, 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
   if (!resp) {
@@ -506,8 +491,7 @@ export const getGradingOverviews = async (
  */
 export const getGrading = async (submissionId: number, tokens: Tokens): Promise<Grading | null> => {
   const resp = await request(`grading/${submissionId}`, 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
 
@@ -570,7 +554,7 @@ export const postGrading = async (
   comments?: string
 ): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/${questionId}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: {
       grading: {
         adjustment: gradeAdjustment,
@@ -579,7 +563,6 @@ export const postGrading = async (
       }
     },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -595,8 +578,7 @@ export const postReautogradeSubmission = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/autograde`, 'POST', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     noHeaderAccept: true,
     shouldAutoLogout: false,
     shouldRefresh: true
@@ -614,8 +596,7 @@ export const postReautogradeAnswer = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/${questionId}/autograde`, 'POST', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     noHeaderAccept: true,
     shouldAutoLogout: false,
     shouldRefresh: true
@@ -632,9 +613,8 @@ export const postUnsubmit = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`grading/${submissionId}/unsubmit`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -647,8 +627,7 @@ export const postUnsubmit = async (
  */
 export const getNotifications = async (tokens: Tokens): Promise<Notification[]> => {
   const resp: Response | null = await request('notification', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldAutoLogout: false
   });
 
@@ -684,8 +663,7 @@ export const postAcknowledgeNotifications = async (
   ids: number[]
 ): Promise<Response | null> => {
   const resp: Response | null = await request('notification/acknowledge', 'POST', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     body: { notificationIds: ids },
     shouldAutoLogout: false
   });
@@ -701,9 +679,8 @@ export const deleteSourcecastEntry = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`sourcecast/${id}`, 'DELETE', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -716,8 +693,7 @@ export const deleteSourcecastEntry = async (
  */
 export const getSourcecastIndex = async (tokens: Tokens): Promise<SourcecastData[] | null> => {
   const resp = await request('sourcecast', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -747,11 +723,10 @@ export const postSourcecast = async (
   formData.append('sourcecast[audio]', audio, filename);
   formData.append('sourcecast[playbackData]', JSON.stringify(playbackData));
   const resp = await request(`sourcecast`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: formData,
     noContentType: true,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -769,10 +744,9 @@ export const changeDateAssessment = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`assessments/update/${id}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { closeAt, openAt },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -785,9 +759,8 @@ export const changeDateAssessment = async (
  */
 export const deleteAssessment = async (id: number, tokens: Tokens): Promise<Response | null> => {
   const resp = await request(`assessments/${id}`, 'DELETE', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -804,10 +777,9 @@ export const publishAssessment = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`assessments/publish/${id}`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { togglePublishTo },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -827,11 +799,10 @@ export const uploadAssessment = async (
   formData.append('assessment[file]', file);
   formData.append('forceUpdate', String(forceUpdate));
   const resp = await request(`assessments`, 'POST', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: formData,
     noContentType: true,
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });
@@ -844,8 +815,7 @@ export const uploadAssessment = async (
  */
 export const getGradingSummary = async (tokens: Tokens): Promise<GradingSummary | null> => {
   const resp = await request('grading/summary', 'GET', {
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
+    ...tokens,
     shouldRefresh: true
   });
   if (!resp || !resp.ok) {
@@ -885,10 +855,9 @@ export const postSublanguage = async (
   tokens: Tokens
 ): Promise<Response | null> => {
   const resp = await request(`settings/sublanguage`, 'PUT', {
-    accessToken: tokens.accessToken,
+    ...tokens,
     body: { chapter, variant },
     noHeaderAccept: true,
-    refreshToken: tokens.refreshToken,
     shouldAutoLogout: false,
     shouldRefresh: true
   });

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -97,6 +97,7 @@ const mockStates = {
 };
 
 const okResp = { ok: true };
+const errorResp = { ok: false };
 // ----------------------------------------
 
 describe('Test FETCH_AUTH action', () => {
@@ -496,7 +497,7 @@ describe('Test REAUTOGRADE_SUBMISSION Action', () => {
   test('when successful', () => {
     return expectSaga(BackendSaga)
       .withState({ session: { ...mockTokens, role: Role.Staff } })
-      .provide([[call(postReautogradeSubmission, submissionId, mockTokens), true]])
+      .provide([[call(postReautogradeSubmission, submissionId, mockTokens), okResp]])
       .call(postReautogradeSubmission, submissionId, mockTokens)
       .call.fn(showSuccessMessage)
       .not.call.fn(showWarningMessage)
@@ -507,7 +508,7 @@ describe('Test REAUTOGRADE_SUBMISSION Action', () => {
   test('when unsuccessful', () => {
     return expectSaga(BackendSaga)
       .withState({ session: { ...mockTokens, role: Role.Staff } })
-      .provide([[call(postReautogradeSubmission, submissionId, mockTokens), false]])
+      .provide([[call(postReautogradeSubmission, submissionId, mockTokens), errorResp]])
       .call(postReautogradeSubmission, submissionId, mockTokens)
       .not.call.fn(showSuccessMessage)
       .call.fn(showWarningMessage)
@@ -523,7 +524,7 @@ describe('Test REAUTOGRADE_ANSWER Action', () => {
   test('when successful', () => {
     return expectSaga(BackendSaga)
       .withState({ session: { ...mockTokens, role: Role.Staff } })
-      .provide([[call(postReautogradeAnswer, submissionId, questionId, mockTokens), true]])
+      .provide([[call(postReautogradeAnswer, submissionId, questionId, mockTokens), okResp]])
       .call(postReautogradeAnswer, submissionId, questionId, mockTokens)
       .call.fn(showSuccessMessage)
       .not.call.fn(showWarningMessage)
@@ -535,7 +536,7 @@ describe('Test REAUTOGRADE_ANSWER Action', () => {
     const submissionId = 123;
     return expectSaga(BackendSaga)
       .withState({ session: { ...mockTokens, role: Role.Staff } })
-      .provide([[call(postReautogradeAnswer, submissionId, questionId, mockTokens), false]])
+      .provide([[call(postReautogradeAnswer, submissionId, questionId, mockTokens), errorResp]])
       .call(postReautogradeAnswer, submissionId, questionId, mockTokens)
       .not.call.fn(showSuccessMessage)
       .call.fn(showWarningMessage)

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -97,7 +97,6 @@ const mockStates = {
 };
 
 const okResp = { ok: true };
-const errorResp = { ok: false };
 // ----------------------------------------
 
 describe('Test FETCH_AUTH action', () => {
@@ -196,7 +195,7 @@ describe('Test FETCH_ASSESSMENT_OVERVIEWS action', () => {
 });
 
 describe('Test FETCH_ASSESSMENT action', () => {
-  test('when assesment is obtained', () => {
+  test('when assessment is obtained', () => {
     const mockId = mockAssessment.id;
     return expectSaga(BackendSaga)
       .withState({ session: mockTokens })
@@ -207,7 +206,7 @@ describe('Test FETCH_ASSESSMENT action', () => {
       .silentRun();
   });
 
-  test('when assesment is null', () => {
+  test('when assessment is null', () => {
     const mockId = mockAssessment.id;
     return expectSaga(BackendSaga)
       .withState({ session: mockTokens })
@@ -334,30 +333,6 @@ describe('Test SUBMIT_ANSWER action', () => {
       .dispatch({ type: SUBMIT_ANSWER, payload: mockAnsweredAssessmentQuestion })
       .silentRun();
   });
-
-  test('when response has HTTP status code 403 (Forbidden)', () => {
-    const mockAnsweredAssessmentQuestion = { ...mockAssessmentQuestion, answer: '42' };
-    return expectSaga(BackendSaga)
-      .withState({ session: { ...mockTokens, role: Role.Student } })
-      .provide([
-        [
-          call(
-            postAnswer,
-            mockAnsweredAssessmentQuestion.id,
-            mockAnsweredAssessmentQuestion.answer,
-            mockTokens
-          ),
-          { ...errorResp, status: 403 }
-        ]
-      ])
-      .call(showWarningMessage, 'Answer rejected - assessment not open or already finalised.')
-      .not.call.fn(showSuccessMessage)
-      .not.put.actionType(UPDATE_ASSESSMENT)
-      .not.put.actionType(UPDATE_HAS_UNSAVED_CHANGES)
-      .hasFinalState({ session: { ...mockTokens, role: Role.Student } })
-      .dispatch({ type: SUBMIT_ANSWER, payload: mockAnsweredAssessmentQuestion })
-      .silentRun();
-  });
 });
 
 describe('Test SUBMIT_ASSESSMENT action', () => {
@@ -381,21 +356,6 @@ describe('Test SUBMIT_ASSESSMENT action', () => {
     return expect(mockStates.session.assessmentOverviews[0].status).not.toEqual(
       AssessmentStatuses.submitted
     );
-  });
-
-  test('when response has HTTP status code 403 (Forbidden)', () => {
-    return expectSaga(BackendSaga)
-      .withState({ session: { ...mockTokens, role: Role.Student } })
-      .provide([[call(postAssessment, 0, mockTokens), { ...errorResp, status: 403 }]])
-      .call(postAssessment, 0, mockTokens)
-      .call(
-        showWarningMessage,
-        'Not allowed to finalise - assessment not open or already finalised.'
-      )
-      .not.put.actionType(UPDATE_ASSESSMENT_OVERVIEWS)
-      .hasFinalState({ session: { ...mockTokens, role: Role.Student } })
-      .dispatch({ type: SUBMIT_ASSESSMENT, payload: 0 })
-      .silentRun();
   });
 
   test('when response is null', () => {
@@ -460,18 +420,6 @@ describe('Test ACKNOWLEDGE_NOTIFICATIONS action', () => {
             notifications.filter(notification => ids.includes(notification.id))
         }
       })
-      .silentRun();
-  });
-
-  test('when response has HTTP status code 404 (Not Found)', () => {
-    const ids = mockNotifications.map(n => n.id);
-    return expectSaga(BackendSaga)
-      .withState(mockStates)
-      .provide([
-        [call(postAcknowledgeNotifications, mockTokens, ids), { ...errorResp, status: 404 }]
-      ])
-      .call(showWarningMessage, 'Something went wrong (got 404 response)')
-      .dispatch({ type: ACKNOWLEDGE_NOTIFICATIONS, payload: {} })
       .silentRun();
   });
 });


### PR DESCRIPTION
### Description

- Use backend response text as single source of truth for frontend display, to avoid inconsistent prompts in frontend
- Fix some missing typings
- Add whitespaces for logical grouping in `BackendSaga.ts`
- Clean up and standardize syntax in `RequestSaga.ts`
- Remove test cases that are no longer needed

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to Test

Backend requests should display backend response text as prompts, e.g. attempts to unsubmit missions that have passed deadline should receive prompt 'Assessment not open' instead of 'Not avenger of the student'.

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code