### PR TITLE
SOUNDS: Use 16 bits per sample

### DIFF
--- a/public/externalLibs/sound/sounds.js
+++ b/public/externalLibs/sound/sounds.js
@@ -57,10 +57,11 @@ function discretize_from(wave, duration, elapsed_duration, sample_length, data) 
     }
 }
 
-// Quantize real amplitude values into standard 4-bit PCM levels
+// Quantize real amplitude values into standard 16-bit PCM levels
+// The range is [-32768, 32767] (see riffwave.js)
 function quantize(data) {
     for (var i = 0; i < data.length; i++) {
-        data[i] = Math.round((data[i] + 1) * 126);
+        data[i] = Math.floor(data[i] * 32767.999);
     }
     return data;
 }
@@ -101,6 +102,7 @@ function raw_to_audio(_data) {
     var riffwave = new RIFFWAVE();
     riffwave.header.sampleRate = FS;
     riffwave.header.numChannels = 1;
+    riffwave.header.bitsPerSample = 16;
     riffwave.Make(data);
     var audio = new Audio(riffwave.dataURI);
     return audio;


### PR DESCRIPTION
### Description

Makes sounds sound less bad.

Fixes #1514 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

Deploy locally and test following code on playground with sounds library enabled:

```
const test_sound = sine_sound(400, 0.4);

const soft_sound = make_sound(t => get_wave(test_sound)(t) / 2 / 2 / 2 / 2 / 2 / 2, get_duration(test_sound));
play(soft_sound);
```

It should not sound terrible (like a sawtooth/square wave) and instead should just sound like a soft sine wave.

### Checklist

Please delete options that are not relevant.

- [x] I have tested this code
