### PR TITLE
Fix Selected MCQ Option being carried over to all questions

### DIFF
--- a/src/commons/mcqChooser/McqChooser.tsx
+++ b/src/commons/mcqChooser/McqChooser.tsx
@@ -10,24 +10,14 @@ export type McqChooserProps = {
   handleMCQSubmit: (choiceId: number) => void;
 };
 
-type State = {
-  mcqOption: number | null;
-};
-
-class McqChooser extends React.PureComponent<McqChooserProps, State> {
-  constructor(props: McqChooserProps) {
-    super(props);
-    this.state = {
-      mcqOption: props.mcq.answer
-    };
-  }
+class McqChooser extends React.PureComponent<McqChooserProps, {}> {
   public render() {
     const options = this.props.mcq.choices.map((choice, i) => (
       <Button
         key={i}
         className="mcq-option col-xs-12"
-        active={i === this.state.mcqOption}
-        intent={this.getButtonIntent(i, this.state.mcqOption, this.props.mcq.solution)}
+        active={i === this.props.mcq.answer}
+        intent={this.getButtonIntent(i, this.props.mcq.answer, this.props.mcq.solution)}
         onClick={this.onButtonClickFactory(i)}
         minimal={true}
       >
@@ -54,7 +44,7 @@ class McqChooser extends React.PureComponent<McqChooserProps, State> {
    * @param i the id of the answer
    */
   private onButtonClickFactory = (i: number) => (e: any) => {
-    if (i !== this.state.mcqOption) {
+    if (i !== this.props.mcq.answer) {
       this.props.handleMCQSubmit(i);
       this.setState({
         mcqOption: i

--- a/src/commons/mcqChooser/McqChooser.tsx
+++ b/src/commons/mcqChooser/McqChooser.tsx
@@ -46,9 +46,6 @@ class McqChooser extends React.PureComponent<McqChooserProps, {}> {
   private onButtonClickFactory = (i: number) => (e: any) => {
     if (i !== this.props.mcq.answer) {
       this.props.handleMCQSubmit(i);
-      this.setState({
-        mcqOption: i
-      });
     }
     const shouldDisplayMessage = this.props.mcq.solution !== null && this.props.mcq.choices[i].hint;
     if (shouldDisplayMessage) {


### PR DESCRIPTION
### Description

There is an issue where once we select an option for a MCQ question, it updates all the other questions. The reason is because the state `mcqOption` in `McqChooser.tsx` is not being updated even if the `props` change.

The state here is simply unnecessary, refer to: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html. 

Removing it fixes the problem (tested on staging backend)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to Test

1. Open any assessment with MCQ questions
2. Choose an option
3. See if it is carried over to other questions

### Checklist

Please delete options that are not relevant.

- [X] I have tested this code
- [ ] I have updated the documentation
