### PR TITLE
Update Array Representation of pixels in Pix&Flix

### DIFF
--- a/public/externalLibs/video/video_lib.js
+++ b/public/externalLibs/video/video_lib.js
@@ -237,9 +237,9 @@ _VD.draw = function(timestamp) {
 
 // we translate from the buffer to 2D array 
 _VD.readFromBuffer = function(pixelData, res) {
-    for (let i = 0; i < _WIDTH; i++) {
-        for (let j = 0; j < _HEIGHT; j++) {
-            const p = (j * _WIDTH * 4) + i * 4;
+    for (let i = 0; i < _HEIGHT; i++) {
+        for (let j = 0; j < _WIDTH; j++) {
+            const p = (i * _WIDTH * 4) + j * 4;
             res[i][j] = [
                 pixelData[p],
                 pixelData[p + 1],
@@ -252,9 +252,9 @@ _VD.readFromBuffer = function(pixelData, res) {
 
 // we write back to the buffer (to draw on frame)
 _VD.writeToBuffer = function(buffer, data) {
-    for (let i = 0; i < _WIDTH; i++) {
-        for (let j = 0; j < _HEIGHT; j++) {
-            const p = (j * _WIDTH * 4) + i * 4;
+    for (let i = 0; i < _HEIGHT; i++) {
+        for (let j = 0; j < _WIDTH; j++) {
+            const p = (i * _WIDTH * 4) + j * 4;
             buffer[p] = data[i][j][0]; 
             buffer[p + 1] = data[i][j][1]; 
             buffer[p + 2] = data[i][j][2]; 


### PR DESCRIPTION
### Description

We update the array representation such that `arr[i][j]` will refer to the pixel in the ith row and jth column.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Code quality improvements
