### PR TITLE
PixNFlix [Destination Array should still be image]

### DIFF
--- a/public/externalLibs/video/video_lib.js
+++ b/public/externalLibs/video/video_lib.js
@@ -241,18 +241,11 @@ _VD.draw = function(timestamp) {
 }
 
 // we translate from the buffer to 2D array 
-_VD.readFromBuffer = function(pixelData, src, dest) {
+_VD.readFromBuffer = function(pixelData, src) {
     for (let i = 0; i < _HEIGHT; i++) {
         for (let j = 0; j < _WIDTH; j++) {
             const p = (i * _WIDTH * 4) + j * 4;
             src[i][j] = [
-                pixelData[p],
-                pixelData[p + 1],
-                pixelData[p + 2],
-                pixelData[p + 3]
-            ];
-
-            dest[i][j] = [
                 pixelData[p],
                 pixelData[p + 1],
                 pixelData[p + 2],
@@ -305,7 +298,7 @@ _VD.drawFrame = function() {
     _VD.context.drawImage(_VD.video, 0, 0, _WIDTH, _HEIGHT);
    
     const pixelObj = _VD.context.getImageData(0, 0, _WIDTH, _HEIGHT);
-    _VD.readFromBuffer(pixelObj.data, _VD.pixels, _VD.temp);
+    _VD.readFromBuffer(pixelObj.data, _VD.pixels);
     
     //runtime check to guard against crashes 
     try {


### PR DESCRIPTION
### Description

Earlier fix, removed dependancy between frames. However, that means the destination array will not correspond to the image produced on the screen anymore. This might induce difficulty when solving certain problems.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

Please delete options that are not relevant.

- [X] I have tested this code
- [ ] I have updated the documentation
