### PR TITLE
Don't fail CI if uploading to Coveralls fails

### DIFF
--- a/scripts/test-coveralls.sh
+++ b/scripts/test-coveralls.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
+TEMPFILE="$(mktemp)"
+
 ./scripts/coverage-fix.sh do && \
   craco test --coverage --coverageReporters=text-lcov \
-    --collectCoverageFrom='!**/src/features/game/**' | \
-  coveralls
+    --collectCoverageFrom='!**/src/features/game/**' > "$TEMPFILE"
+coveralls < "$TEMPFILE" || echo "Warning: Coveralls upload failed"


### PR DESCRIPTION
Travis has been having hiccups recently, causing uploads to Coveralls to return 422 even though the upload actually succeeded. For now, allow the build to pass even if uploading to Coveralls fails.

Maybe we should just switch to GitHub Actions instead..