### PR TITLE
bumping js-slang

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "connected-react-router": "^6.8.0",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.4.69",
+    "js-slang": "^0.4.70",
     "lodash": "^4.17.20",
     "lz-string": "^1.4.4",
     "moment": "^2.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7467,10 +7467,26 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
-js-slang@^0.4.60, js-slang@^0.4.69:
+js-slang@^0.4.60:
   version "0.4.69"
   resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.69.tgz#b8ae4157bf476f491511bf140e98c22531a22beb"
   integrity sha512-VnIdOKJZ4AkxHzMpDJBNe+3tLZKhKtb9fKHn/75fxBIprgmzKZWG74CaNCH61uU1ac/ItmscD7Tfb2TcFcdRww==
+  dependencies:
+    "@types/estree" "0.0.45"
+    acorn "^8.0.3"
+    acorn-loose "^8.0.0"
+    acorn-walk "^8.0.0"
+    astring "^1.4.3"
+    gpu.js "^2.10.4"
+    lodash "^4.17.20"
+    node-getopt "^0.3.2"
+    source-map "^0.7.3"
+    xmlhttprequest-ts "^1.0.1"
+
+js-slang@^0.4.70:
+  version "0.4.70"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.4.70.tgz#75dfebefd7d94c45c0b2cad62737c483e0384209"
+  integrity sha512-WxNMsCg9daDZ9Z5reT0w/iNYU75UfCNd1TQT0qXKwd9YYKb4m2+MecmwYXaJzFljcfxP/yNYyZ2XGQwi2g+Ulw==
   dependencies:
     "@types/estree" "0.0.45"
     acorn "^8.0.3"


### PR DESCRIPTION
### Description

Bumping js-slang version. Background: SICPJS needs to differentiate between unary and binary operator combinations. New version of js-slang: 0.4.70.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation
