### PR TITLE
Shift Repl buttons from ControlBar to Repl component

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -641,7 +641,7 @@ class AssessmentWorkspace extends React.Component<
 
     return {
       editorButtons: [runButton, saveButton, resetButton, chapterSelect],
-      flowButtons: [previousButton, questionView, nextButton],
+      flowButtons: [previousButton, questionView, nextButton]
     };
   };
 
@@ -661,7 +661,7 @@ class AssessmentWorkspace extends React.Component<
       />
     );
 
-    return [evalButton, clearButton]
+    return [evalButton, clearButton];
   }
 }
 

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -351,7 +351,8 @@ class AssessmentWorkspace extends React.Component<
         replValue: this.props.replValue,
         sourceChapter: question?.library?.chapter || 4,
         sourceVariant: 'default',
-        externalLibrary: question?.library?.external?.name || 'NONE'
+        externalLibrary: question?.library?.external?.name || 'NONE',
+        replButtons: this.replButtons()
       }
     };
     return (
@@ -580,21 +581,6 @@ class AssessmentWorkspace extends React.Component<
       this.setState({ showResetTemplateOverlay: true });
     };
 
-    const clearButton = (
-      <ControlBarClearButton
-        handleReplOutputClear={this.props.handleReplOutputClear}
-        key="clear_repl"
-      />
-    );
-
-    const evalButton = (
-      <ControlBarEvalButton
-        handleReplEval={this.props.handleReplEval}
-        isRunning={this.props.isRunning}
-        key="eval_repl"
-      />
-    );
-
     const nextButton = (
       <ControlBarNextButton
         onClickNext={
@@ -656,9 +642,27 @@ class AssessmentWorkspace extends React.Component<
     return {
       editorButtons: [runButton, saveButton, resetButton, chapterSelect],
       flowButtons: [previousButton, questionView, nextButton],
-      replButtons: [evalButton, clearButton]
     };
   };
+
+  private replButtons() {
+    const clearButton = (
+      <ControlBarClearButton
+        handleReplOutputClear={this.props.handleReplOutputClear}
+        key="clear_repl"
+      />
+    );
+
+    const evalButton = (
+      <ControlBarEvalButton
+        handleReplEval={this.props.handleReplEval}
+        isRunning={this.props.isRunning}
+        key="eval_repl"
+      />
+    );
+
+    return [evalButton, clearButton]
+  }
 }
 
 export default AssessmentWorkspace;

--- a/src/commons/controlBar/ControlBar.tsx
+++ b/src/commons/controlBar/ControlBar.tsx
@@ -6,7 +6,7 @@ export type ControlBarProps = OwnProps;
 type OwnProps = {
   editorButtons: Array<JSX.Element | null>;
   flowButtons?: Array<JSX.Element | null>;
-  replButtons: Array<JSX.Element | null>;
+  editingWorkspaceButtons?: Array<JSX.Element | null>;
 };
 
 function ControlBar(props: ControlBarProps) {
@@ -28,9 +28,9 @@ function ControlBar(props: ControlBarProps) {
     );
   };
 
-  const replControl = () => {
+  const editingWorkspaceControl = () => {
     return (
-      <div className={classNames('ControlBar_repl', Classes.BUTTON_GROUP)}>{props.replButtons}</div>
+      <div className={classNames('ControlBar_editingWorkspace', Classes.BUTTON_GROUP)}>{props.editingWorkspaceButtons}</div>
     );
   };
 
@@ -38,7 +38,7 @@ function ControlBar(props: ControlBarProps) {
     <div className="ControlBar">
       {editorControl()}
       {flowControl()}
-      {replControl()}
+      {editingWorkspaceControl()}
     </div>
   );
 }

--- a/src/commons/controlBar/ControlBar.tsx
+++ b/src/commons/controlBar/ControlBar.tsx
@@ -30,7 +30,9 @@ function ControlBar(props: ControlBarProps) {
 
   const editingWorkspaceControl = () => {
     return (
-      <div className={classNames('ControlBar_editingWorkspace', Classes.BUTTON_GROUP)}>{props.editingWorkspaceButtons}</div>
+      <div className={classNames('ControlBar_editingWorkspace', Classes.BUTTON_GROUP)}>
+        {props.editingWorkspaceButtons}
+      </div>
     );
   };
 

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -705,7 +705,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
       />
     );
 
-    return [clearButton, evalButton];
+    return [evalButton, clearButton];
   }
 }
 

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -207,7 +207,8 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
         replValue: this.props.replValue,
         sourceChapter: question?.library?.chapter || 4,
         sourceVariant: 'default',
-        externalLibrary: question?.library?.external?.name || 'NONE'
+        externalLibrary: question?.library?.external?.name || 'NONE',
+        replButtons: this.replButtons()
       }
     };
     return (
@@ -636,21 +637,6 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
       });
     };
 
-    const clearButton = (
-      <ControlBarClearButton
-        handleReplOutputClear={this.props.handleReplOutputClear}
-        key="clear_repl"
-      />
-    );
-
-    const evalButton = (
-      <ControlBarEvalButton
-        handleReplEval={this.props.handleReplEval}
-        isRunning={this.props.isRunning}
-        key="eval_repl"
-      />
-    );
-
     const nextButton = (
       <ControlBarNextButton
         onClickNext={onClickNext}
@@ -699,9 +685,28 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
     return {
       editorButtons: [runButton, saveButton, resetButton],
       flowButtons: [previousButton, questionView, nextButton],
-      replButtons: [evalButton, clearButton, toggleEditModeButton]
+      editingWorkspaceButtons: [toggleEditModeButton]
     };
   };
+
+  private replButtons() {
+    const clearButton = (
+      <ControlBarClearButton
+        handleReplOutputClear={this.props.handleReplOutputClear}
+        key="clear_repl"
+      />
+    );
+
+    const evalButton = (
+      <ControlBarEvalButton
+        handleReplEval={this.props.handleReplEval}
+        isRunning={this.props.isRunning}
+        key="eval_repl"
+      />
+    );
+
+    return [clearButton, evalButton];
+  }
 }
 
 function uniq(a: string[]) {

--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -34,7 +34,7 @@ type DispatchProps = {
 
 type OwnProps = {
   replButtons: Array<JSX.Element | null>;
-}
+};
 
 class Repl extends React.PureComponent<ReplProps, {}> {
   public constructor(props: ReplProps) {

--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -12,7 +12,7 @@ import SideContentCanvasOutput from '../sideContent/SideContentCanvasOutput';
 import ReplInput from './ReplInput';
 import { OutputProps } from './ReplTypes';
 
-export type ReplProps = DispatchProps & StateProps;
+export type ReplProps = DispatchProps & StateProps & OwnProps;
 
 type StateProps = {
   output: InterpreterOutput[];
@@ -31,6 +31,10 @@ type DispatchProps = {
   handleReplEval: () => void;
   handleReplValueChange: (newCode: string) => void;
 };
+
+type OwnProps = {
+  replButtons: Array<JSX.Element | null>;
+}
 
 class Repl extends React.PureComponent<ReplProps, {}> {
   public constructor(props: ReplProps) {

--- a/src/commons/repl/ReplInput.tsx
+++ b/src/commons/repl/ReplInput.tsx
@@ -1,12 +1,15 @@
+import { Classes } from '@blueprintjs/core';
+import classNames from 'classnames';
 import { Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 import AceEditor from 'react-ace';
+import MediaQuery from 'react-responsive';
 
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
 import { getModeString, selectMode } from '../utils/AceHelper';
 // source mode and chapter imported in Editor.tsx
 
-export type ReplInputProps = DispatchProps & StateProps;
+export type ReplInputProps = DispatchProps & StateProps & OwnProps;
 
 type DispatchProps = {
   handleBrowseHistoryDown: () => void;
@@ -21,6 +24,10 @@ type StateProps = {
   sourceVariant: Variant;
   externalLibrary: ExternalLibraryName;
 };
+
+type OwnProps = {
+  replButtons: Array<JSX.Element | null>;
+}
 
 class ReplInput extends React.PureComponent<ReplInputProps, {}> {
   private replInputBottom?: HTMLDivElement;
@@ -63,6 +70,10 @@ class ReplInput extends React.PureComponent<ReplInputProps, {}> {
   public render() {
     // see the comment above this same call in Editor.tsx
     selectMode(this.props.sourceChapter, this.props.sourceVariant, this.props.externalLibrary);
+
+    const replButtons = () => (
+       this.props.replButtons
+    )
 
     return (
       <>
@@ -114,7 +125,10 @@ class ReplInput extends React.PureComponent<ReplInputProps, {}> {
             fontFamily: "'Inconsolata', 'Consolas', monospace"
           }}
         />
-        <div className="replInputBottom" ref={e => (this.replInputBottom = e!)} />
+        <div className={classNames(Classes.BUTTON_GROUP, Classes.DARK)}>{replButtons()}</div>
+        <MediaQuery minWidth={769}>
+          <div className="replInputBottom" ref={e => (this.replInputBottom = e!)} />
+        </MediaQuery>
       </>
     );
   }

--- a/src/commons/repl/ReplInput.tsx
+++ b/src/commons/repl/ReplInput.tsx
@@ -27,7 +27,7 @@ type StateProps = {
 
 type OwnProps = {
   replButtons: Array<JSX.Element | null>;
-}
+};
 
 class ReplInput extends React.PureComponent<ReplInputProps, {}> {
   private replInputBottom?: HTMLDivElement;
@@ -71,9 +71,7 @@ class ReplInput extends React.PureComponent<ReplInputProps, {}> {
     // see the comment above this same call in Editor.tsx
     selectMode(this.props.sourceChapter, this.props.sourceVariant, this.props.externalLibrary);
 
-    const replButtons = () => (
-       this.props.replButtons
-    )
+    const replButtons = () => this.props.replButtons;
 
     return (
       <>

--- a/src/commons/repl/__tests__/Repl.tsx
+++ b/src/commons/repl/__tests__/Repl.tsx
@@ -45,7 +45,8 @@ test('Repl renders correctly', () => {
     replValue: '',
     sourceChapter: 1,
     sourceVariant: 'default' as const,
-    externalLibrary: ExternalLibraryName.NONE
+    externalLibrary: ExternalLibraryName.NONE,
+    replButtons: []
   };
   const app = <Repl {...props} />;
   const tree = shallow(app);

--- a/src/commons/repl/__tests__/__snapshots__/Repl.tsx.snap
+++ b/src/commons/repl/__tests__/__snapshots__/Repl.tsx.snap
@@ -45,7 +45,7 @@ exports[`Repl renders correctly 1`] = `
     <Output output={{...}} usingSubst={false} />
     <Output output={{...}} usingSubst={false} />
     <HotKeysEnabled className=\\"repl-input-parent row bp3-card bp3-elevation-0\\" handlers={{...}}>
-      <ReplInput handleBrowseHistoryDown={[Function: handleBrowseHistoryDown]} handleBrowseHistoryUp={[Function: handleBrowseHistoryUp]} handleReplValueChange={[Function: handleReplValueChange]} handleReplEval={[Function: handleReplEval]} handleReplOutputClear={[Function: handleReplOutputClear]} output={{...}} replValue=\\"\\" sourceChapter={1} sourceVariant=\\"default\\" externalLibrary=\\"NONE\\" />
+      <ReplInput handleBrowseHistoryDown={[Function: handleBrowseHistoryDown]} handleBrowseHistoryUp={[Function: handleBrowseHistoryUp]} handleReplValueChange={[Function: handleReplValueChange]} handleReplEval={[Function: handleReplEval]} handleReplOutputClear={[Function: handleReplOutputClear]} output={{...}} replValue=\\"\\" sourceChapter={1} sourceVariant=\\"default\\" externalLibrary=\\"NONE\\" replButtons={{...}} />
     </HotKeysEnabled>
   </div>
 </div>"

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -422,7 +422,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       />
     );
 
-    return [clearButton, evalButton];
+    return [evalButton, clearButton];
   }
 }
 

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -402,7 +402,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
 
     return {
       editorButtons: [runButton],
-      flowButtons: [previousButton, questionView, nextButton],
+      flowButtons: [previousButton, questionView, nextButton]
     };
   };
 

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -207,7 +207,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
         replValue: this.props.replValue,
         sourceChapter: question?.library?.chapter || 4,
         sourceVariant: 'default',
-        externalLibrary: question?.library?.external?.name || 'NONE'
+        externalLibrary: question?.library?.external?.name || 'NONE',
+        replButtons: this.replButtons()
       }
     };
     return (
@@ -374,21 +375,6 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
       history.push(gradingWorkspacePath + `/${(questionId + 1).toString()}`);
     const onClickReturn = () => history.push(listingPath);
 
-    const clearButton = (
-      <ControlBarClearButton
-        handleReplOutputClear={this.props.handleReplOutputClear}
-        key="clear_repl"
-      />
-    );
-
-    const evalButton = (
-      <ControlBarEvalButton
-        handleReplEval={this.props.handleReplEval}
-        isRunning={this.props.isRunning}
-        key="eval_repl"
-      />
-    );
-
     const nextButton = (
       <ControlBarNextButton
         onClickNext={onClickNext}
@@ -417,9 +403,27 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps> {
     return {
       editorButtons: [runButton],
       flowButtons: [previousButton, questionView, nextButton],
-      replButtons: [evalButton, clearButton]
     };
   };
+
+  private replButtons() {
+    const clearButton = (
+      <ControlBarClearButton
+        handleReplOutputClear={this.props.handleReplOutputClear}
+        key="clear_repl"
+      />
+    );
+
+    const evalButton = (
+      <ControlBarEvalButton
+        handleReplEval={this.props.handleReplEval}
+        isRunning={this.props.isRunning}
+        key="eval_repl"
+      />
+    );
+
+    return [clearButton, evalButton];
+  }
 }
 
 export default GradingWorkspace;

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -268,8 +268,7 @@ class Sourcereel extends React.Component<SourcereelProps> {
 
     const workspaceProps: WorkspaceProps = {
       controlBarProps: {
-        editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect],
-        replButtons: [evalButton, clearButton]
+        editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]
       },
       customEditor: <SourcecastEditor {...editorProps} />,
       editorHeight: this.props.editorHeight,
@@ -286,7 +285,8 @@ class Sourcereel extends React.Component<SourcereelProps> {
         handleReplValueChange: this.props.handleReplValueChange,
         sourceChapter: this.props.sourceChapter,
         sourceVariant: this.props.sourceVariant,
-        externalLibrary: this.props.externalLibraryName
+        externalLibrary: this.props.externalLibraryName,
+        replButtons: [evalButton, clearButton]
       },
       sideContentHeight: this.props.sideContentHeight,
       sideContentProps: {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -698,7 +698,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
     handleReplValueChange: props.handleReplValueChange,
     hidden: selectedTab === SideContentType.substVisualizer,
     inputHidden: replDisabled,
-    usingSubst: props.usingSubst
+    usingSubst: props.usingSubst,
+    replButtons: [replDisabled ? null : evalButton, clearButton]
   };
 
   const workspaceProps: WorkspaceProps = {
@@ -712,7 +713,6 @@ const Playground: React.FC<PlaygroundProps> = props => {
         persistenceButtons,
         usingRemoteExecution ? null : props.usingSubst ? stepperStepLimit : executionTime
       ],
-      replButtons: [replDisabled ? null : evalButton, clearButton]
     },
     editorProps: editorProps,
     editorHeight: props.editorHeight,
@@ -746,10 +746,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
           sessionButtons,
           persistenceButtons
         ],
-        // TODO: Repl buttons to be removed
-        replButtons: [replDisabled ? null : evalButton, clearButton]
       },
-      // TODO: Abstract this duplicate away
       defaultSelectedTabId: selectedTab,
       selectedTabId: selectedTab,
       handleActiveTabChange: props.handleActiveTabChange,

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -712,7 +712,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         sessionButtons,
         persistenceButtons,
         usingRemoteExecution ? null : props.usingSubst ? stepperStepLimit : executionTime
-      ],
+      ]
     },
     editorProps: editorProps,
     editorHeight: props.editorHeight,
@@ -745,7 +745,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
           shareButton,
           sessionButtons,
           persistenceButtons
-        ],
+        ]
       },
       defaultSelectedTabId: selectedTab,
       selectedTabId: selectedTab,

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -210,7 +210,6 @@ class Sourcecast extends React.Component<SourcecastProps> {
     const workspaceProps: WorkspaceProps = {
       controlBarProps: {
         editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect],
-        replButtons: [evalButton, clearButton]
       },
       customEditor: <SourceRecorderEditor {...editorProps} />,
       editorHeight: this.props.editorHeight,
@@ -227,7 +226,8 @@ class Sourcecast extends React.Component<SourcecastProps> {
         handleReplValueChange: this.props.handleReplValueChange,
         sourceChapter: this.props.sourceChapter,
         sourceVariant: this.props.sourceVariant,
-        externalLibrary: this.props.externalLibraryName
+        externalLibrary: this.props.externalLibraryName,
+        replButtons: [evalButton, clearButton]
       },
       sideContentHeight: this.props.sideContentHeight,
       sideContentProps: {

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -209,7 +209,7 @@ class Sourcecast extends React.Component<SourcecastProps> {
     };
     const workspaceProps: WorkspaceProps = {
       controlBarProps: {
-        editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect],
+        editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]
       },
       customEditor: <SourceRecorderEditor {...editorProps} />,
       editorHeight: this.props.editorHeight,

--- a/src/styles/_mobileworkspace.scss
+++ b/src/styles/_mobileworkspace.scss
@@ -138,6 +138,10 @@ $shadow-light: rgba(0, 0, 0, 0.2);
       opacity: 0.8; // for background shadow to pass through
     }
 
+    .Repl {
+      margin: 0;
+    }
+
     canvas {
       // only rune shown in repl so this override will not affect others
       width: 100% !important;

--- a/src/styles/_playground.scss
+++ b/src/styles/_playground.scss
@@ -3,6 +3,14 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 100%;
+
+  .workspace {
+    .ControlBar {
+      .ControlBar_editingWorkspace {
+        width: 0;
+      }
+    }
+  }
 }
 
 .kineticjs-content {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -770,6 +770,7 @@ $code-color-error: #ff4444;
     .repl-input-parent {
       padding: 0;
       margin-bottom: 0rem;
+      flex-wrap: nowrap;
     }
 
     .repl-react-ace {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -32,6 +32,10 @@ $code-color-error: #ff4444;
     margin-right: 0.5rem;
     margin-top: 0.5rem;
     margin-bottom: 0.6rem;
+
+    .ControlBar_editingWorkspace {
+      width: 18%;
+    }
   }
 
   .workspace-parent {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -34,7 +34,7 @@ $code-color-error: #ff4444;
     margin-bottom: 0.6rem;
 
     .ControlBar_editingWorkspace {
-      width: 18%;
+      width: 10%;
     }
   }
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Shifted the Repl buttons from ControlBar component to the Repl component. Repl buttons are now right beside the Repl itself.

Reason:
- The Repl buttons were previously 'out of place' and sat at the top right of the app inside the ControlBar (shifting them beside the Repl itself would make them more intuitive to use)
- Repl buttons are now also accessible in the new Mobile Playground component (and other mobile friendly workspaces in the future)

Previously:
![image](https://user-images.githubusercontent.com/53928333/107538157-9e803680-6bfe-11eb-892e-d3d74c42cad9.png)

Now:
![image](https://user-images.githubusercontent.com/53928333/107538075-8c05fd00-6bfe-11eb-896b-1c9c3ecb5670.png)
![image](https://user-images.githubusercontent.com/53928333/107539090-97a5f380-6bff-11eb-9f5c-a83059f22e49.png)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Test the usage of the newly positioned Repl buttons in both desktop and mobile workspaces (note that the Playground is the only mobile friendly workspace as of now)

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
