### PR TITLE
Added instructions to Env Vis tab

### DIFF
--- a/src/commons/sideContent/SideContentEnvVisualizer.tsx
+++ b/src/commons/sideContent/SideContentEnvVisualizer.tsx
@@ -29,7 +29,8 @@ class SideContentEnvVisualizer extends React.Component<{}, State> {
           <br />
           <br />
           It is activated by clicking on the gutter of the editor (where all the line numbers are,
-          on the left) to set a breakpoint, and then running the program.
+          on the left) to set a breakpoint, and then running the program. Only the first line of a
+          statement can have a breakpoint. The program halts just before the statement is evaluated.
           <br />
           <br />
           The environment model diagram follows a notation introduced in{' '}


### PR DESCRIPTION
### Description

Added the statements "Only the first line of a statement can have a breakpoint. The program halts just before the statement is evaluated." to environment visualiser tab instructions.

Resolves source-academy/js-slang#364

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

N.A.

### Checklist

- [x] I have tested this
- [ ] I have updated the documentation
