### PR TITLE
Fix draw_data side content tab overflow on desktop playground

### DIFF
--- a/src/styles/_playground.scss
+++ b/src/styles/_playground.scss
@@ -13,6 +13,6 @@
   }
 }
 
-.kineticjs-content {
+.konvajs-content {
   width: 100% !important;
 }


### PR DESCRIPTION
### Description

Fix overflow and UI break when large lists are displayed using draw data.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

- [X] I have tested this code
- [ ] I have updated the documentation
