### PR TITLE
Fix dialog box disabling mobile workspace while on non-mobile device

### DIFF
--- a/src/commons/controlBar/ControlBarAutorunButtons.tsx
+++ b/src/commons/controlBar/ControlBarAutorunButtons.tsx
@@ -27,9 +27,9 @@ type StateProps = {
 };
 
 export function ControlBarAutorunButtons(props: ControlBarAutorunButtonProps) {
-  const isMobile = useMediaQuery({ maxWidth: 768 });
+  const isMobileBreakpoint = useMediaQuery({ maxWidth: 768 });
 
-  return isMobile ? (
+  return isMobileBreakpoint ? (
     <>
       {props.isRunning && controlButton('Stop', IconNames.STOP, props.handleInterruptEval)}
       {(!props.pauseDisabled &&

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -34,6 +34,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
   const [isDraggableReplDisabled, setIsDraggableReplDisabled] = React.useState(false);
 
   const isPortrait = useMediaQuery({ orientation: 'portrait' });
+  const isMobile = /iPhone|iPad|Android/.test(navigator.userAgent);
 
   /**
    * Stores the mobile browser's portrait dimensions.
@@ -256,7 +257,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       ) : null}
 
       <Dialog
-        isOpen={!isPortrait}
+        isOpen={!isPortrait && isMobile}
         canEscapeKeyClose={false}
         canOutsideClickClose={false}
         isCloseButtonShown={false}

--- a/src/commons/navigationBar/NavigationBar.tsx
+++ b/src/commons/navigationBar/NavigationBar.tsx
@@ -37,7 +37,7 @@ type StateProps = {
 const NavigationBar: React.FC<NavigationBarProps> = props => {
   const [mobileSideMenuOpen, setMobileSideMenuOpen] = React.useState(false);
   const [desktopMenuOpen, setDesktopMenuOpen] = React.useState(true);
-  const isMobile = useMediaQuery({ maxWidth: 768 });
+  const isMobileBreakpoint = useMediaQuery({ maxWidth: 768 });
 
   const playgroundOnlyNavbarLeft = (
     <NavbarGroup align={Alignment.LEFT}>
@@ -130,7 +130,7 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
         <div className="navbar-button-text hidden-sm hidden-xs">Contributors</div>
       </NavLink>
 
-      {!Constants.playgroundOnly && props.role && !isMobile && (
+      {!Constants.playgroundOnly && props.role && !isMobileBreakpoint && (
         <>
           <NavbarDivider className="default-divider" />
           <Tooltip content="Toggle Menu" position={Position.BOTTOM}>
@@ -160,13 +160,13 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
       <Navbar className={classNames('NavigationBar', 'primary-navbar', Classes.DARK)}>
         {Constants.playgroundOnly
           ? playgroundOnlyNavbarLeft
-          : isMobile
+          : isMobileBreakpoint
           ? mobileNavbarLeft
           : desktopNavbarLeft}
         {commonNavbarRight}
       </Navbar>
 
-      {!Constants.playgroundOnly && props.role && !isMobile && desktopMenuOpen && (
+      {!Constants.playgroundOnly && props.role && !isMobileBreakpoint && desktopMenuOpen && (
         <AcademyNavigationBar role={props.role} />
       )}
     </>

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -158,7 +158,7 @@ function handleHash(hash: string, props: PlaygroundProps) {
 }
 
 const Playground: React.FC<PlaygroundProps> = props => {
-  const isMobile = useMediaQuery({ maxWidth: 768 });
+  const isMobileBreakpoint = useMediaQuery({ maxWidth: 768 });
   const propsRef = React.useRef(props);
   propsRef.current = props;
   const [lastEdit, setLastEdit] = React.useState(new Date());
@@ -216,21 +216,21 @@ const Playground: React.FC<PlaygroundProps> = props => {
    */
   React.useEffect(() => {
     if (
-      isMobile &&
+      isMobileBreakpoint &&
       (selectedTab === SideContentType.introduction ||
         selectedTab === SideContentType.remoteExecution)
     ) {
       props.handleActiveTabChange(SideContentType.mobileEditor);
       setSelectedTab(SideContentType.mobileEditor);
     } else if (
-      !isMobile &&
+      !isMobileBreakpoint &&
       (selectedTab === SideContentType.mobileEditor ||
         selectedTab === SideContentType.mobileEditorRun)
     ) {
       setSelectedTab(SideContentType.introduction);
       props.handleActiveTabChange(SideContentType.introduction);
     }
-  }, [isMobile, props, selectedTab]);
+  }, [isMobileBreakpoint, props, selectedTab]);
 
   const handlers = React.useMemo(
     () => ({
@@ -757,7 +757,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     }
   };
 
-  return isMobile ? (
+  return isMobileBreakpoint ? (
     <MobileWorkspace {...mobileWorkspaceProps} />
   ) : (
     <HotKeys


### PR DESCRIPTION
### Description

Fixed the above bug, and renamed isMobile booleans to isMobileBreakpoint to clearly denote that these booleans only check for the mobile breakpoint of 768px.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously (dialog box pops up even on non-mobile device):
<img width="714" alt="image" src="https://user-images.githubusercontent.com/53928333/108308970-a84ffe00-71eb-11eb-85a6-1aeac4cb18bf.png">

Now:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/53928333/108308898-835b8b00-71eb-11eb-801e-064b168e2bb6.png">

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- Resize desktop browser such that width > height. The dialog box should not appear.
- Dialog box should still appear in the mobile workspace on mobile devices when in landscape

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
