### PR TITLE
Alerts for Spawned Module Tabs

### DIFF
--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -79,13 +79,21 @@ const SideContent = (props: SideContentProps) => {
    */
   const generateIconId = (tabId: TabId) => `${tabId}-icon`;
 
+  /**
+   * Adds'side-content-tab-alert' style to newly spawned module tabs
+   */
+  const generateClassName = (id: string | undefined) =>
+    id === SideContentType.module
+      ? 'side-content-tooltip side-content-tab-alert'
+      : 'side-content-tooltip';
+
   const renderedTabs = React.useMemo(() => {
     const renderTab = (tab: SideContentTab, workspaceLocation?: WorkspaceLocation) => {
       const iconSize = 20;
-      const tabId = tab.id === undefined ? tab.label : tab.id;
+      const tabId = tab.id === undefined || tab.id === SideContentType.module ? tab.label : tab.id;
       const tabTitle: JSX.Element = (
         <Tooltip2 content={tab.label}>
-          <div className="side-content-tooltip" id={generateIconId(tabId)}>
+          <div className={generateClassName(tab.id)} id={generateIconId(tabId)}>
             <Icon icon={tab.iconName} iconSize={iconSize} />
           </div>
         </Tooltip2>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added alerts for spawned module tabs,
* Tab will flash until clicked when spawned
* Done by adding `side-content-tab-alert` to the classname, if the newly spawned tab has an id of `SideContentType.module

&nbsp;
Removed unused methods in `SideContentHelper.ts`
* from the previous module system

&nbsp;
Added some documentation for methods in `SideContentHelper.ts`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

When a module is imported and the toSpawn condition is fufilled, the module tab will spawn with an alert until it is clicked

Example (new spawned tab at top right)
![image](https://user-images.githubusercontent.com/50147457/109374152-226c3b00-78ee-11eb-96ad-642cab800c32.png)

Alert disappears after it is clicked
![image](https://user-images.githubusercontent.com/50147457/109374179-521b4300-78ee-11eb-88f0-609b9994f4e9.png)

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
