### PR TITLE
Handle global app height on mobile devices

### DIFF
--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -31,6 +31,9 @@ export type StateProps = {
 const Application: React.FC<ApplicationProps> = props => {
   const intervalId = React.useRef<number | undefined>(undefined);
   const [isDisabled, setIsDisabled] = React.useState(computeDisabledState());
+  const isMobile = /iPhone|iPad|Android/.test(navigator.userAgent);
+  const isPWA = window.matchMedia('(display-mode: standalone)').matches; // Checks if user is accessing from the PWA
+  const browserDimensions = React.useRef({ height: 0, width: 0 });
 
   React.useEffect(() => {
     if (Constants.disablePeriods.length > 0) {
@@ -48,6 +51,45 @@ const Application: React.FC<ApplicationProps> = props => {
       }
     };
   }, [isDisabled]);
+
+  /**
+   * The following effect prevents the mobile browser interface from hiding on scroll by setting the
+   * application height to the window's innerHeight, even after orientation changes. This ensures that
+   * the app UI does not break due to the hiding of the browser interface when the user is not on the PWA.
+   *
+   * Note: When the soft keyboard is up on Android devices, the viewport height decreases and triggers
+   * the 'resize' event. The conditional in orientationChangeHandler checks specifically for this, and
+   * does not update the application height when the Android keyboard triggers the resize event. IOS
+   * devices are not affected.
+   */
+  React.useEffect(() => {
+    const orientationChangeHandler = () => {
+      if (
+        !(
+          window.innerHeight < browserDimensions.current.height &&
+          window.innerWidth === browserDimensions.current.width
+        )
+      ) {
+        // If it is not an Android soft keyboard triggering the resize event, update the application height.
+        document.documentElement.style.setProperty(
+          '--application-height',
+          window.innerHeight + 'px'
+        );
+      }
+      browserDimensions.current = { height: window.innerHeight, width: window.innerWidth };
+    };
+
+    if (!isPWA && isMobile) {
+      orientationChangeHandler();
+      window.addEventListener('resize', orientationChangeHandler);
+    }
+
+    return () => {
+      if (!isPWA && isMobile) {
+        window.removeEventListener('resize', orientationChangeHandler);
+      }
+    };
+  }, [isPWA, isMobile]);
 
   const loginPath = <Route path="/login" render={toLogin(props)} key="login" />;
   const fullPaths = Constants.playgroundOnly

--- a/src/commons/application/__tests__/Application.tsx
+++ b/src/commons/application/__tests__/Application.tsx
@@ -5,6 +5,17 @@ import Constants from 'src/commons/utils/Constants';
 import { mockRouterProps } from '../../mocks/ComponentMocks';
 import Application, { ApplicationProps } from '../Application';
 
+// JSDOM does not implement window.matchMedia, so we have to mock it.
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {}
+    };
+  };
+
 const props: ApplicationProps = {
   ...mockRouterProps('/academy', {}),
   title: 'Cadet',

--- a/src/commons/application/__tests__/ApplicationContainer.tsx
+++ b/src/commons/application/__tests__/ApplicationContainer.tsx
@@ -5,6 +5,17 @@ import { MemoryRouter } from 'react-router';
 import { mockInitialStore } from '../../mocks/StoreMocks';
 import ApplicationContainer from '../ApplicationContainer';
 
+// JSDOM does not implement window.matchMedia, so we have to mock it.
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {}
+    };
+  };
+
 /* TODO: currently crashes w/ ReferenceError---PIXI libraries are not loaded in this test
 test('ApplicationContainer redirects from / to /academy', () => {
   const store = mockInitialStore()

--- a/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
@@ -27,7 +27,7 @@ exports[`Application shows disabled when in disabled period 1`] = `
       <Route path=\\"/login\\" render={[Function (anonymous)]} />
       <Route path=\\"/academy\\" render={[Function: redirectToLogin]} />
       <Route exact={true} path=\\"/\\" render={[Function: redirectToLogin]} />
-      <Route render={[Function: bound ]} />
+      <Route render={[Function: renderDisabled]} />
     </Switch>
   </div>
 </div>"

--- a/src/styles/_application.scss
+++ b/src/styles/_application.scss
@@ -21,4 +21,5 @@ html {
   height: 100%;
   display: flex;
   flex: 1 1 100%;
+  overflow: auto;
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Refactored Application.tsx to a functional component to support React.useEffect for the handling of global app height on mobile devices
- Handled global application height on mobile devices:
    - Prevent mobile browser interface from hiding on scroll (when SA is accessed from the mobile browser) to prevent UI bugs due to the hiding/ showing of the mobile browser interface. This is not an issue in the progressive web app as the mobile browser interface is not shown in the PWA.
    - This was previously only handled in the Mobile Workspace, and has been refactored and shifted into Application.tsx
- Added `overflow: auto` to the Application component. This, coupled with the handling of the global application height, fixes the scroll issues on the Contributors page (see #1628), and in the Missions list page (Assessment.tsx)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- See point 6 and 7 [here](https://github.com/source-academy/cadet-frontend/wiki/Mobile-Development-Guide#manual-browser-resizing-checks)
- Contributor's Page does not have any scroll issues
- Missions list page does not have any scroll issues (`localhost:8000/academy/missions`)
- Check the above on both the mobile browser and the progressive web app
- Mobile browser only: mobile browser's interface does not 'hide' when accessing any page in the app (even after orientation changes)

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
