### PR TITLE
[Modules] Updated side contents to use new modules bundle and tabs system.

### DIFF
--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -40,18 +40,14 @@ export const getModuleTabs = (debuggerContext: DebuggerContext): SideContentTab[
   const rawModuleTabs = debuggerContext.context?.modules as Modules[] | undefined;
   if (rawModuleTabs == null) return [];
 
-  // Extract all the tabs from all the modules
-  const unprocessedTabs = rawModuleTabs.reduce<ModuleSideContent[]>((accumulator, current) => {
-    return accumulator.concat(current.sideContents);
-  }, []);
+  console.log(rawModuleTabs[0](React));
+  // Pass React into functions
+  const unprocessedTabs: ModuleSideContent[] = rawModuleTabs.map((tab: any) => tab(React));
 
   // Initialize module side contents to convert to SideContentTab type
   const moduleTabs: SideContentTab[] = unprocessedTabs.map((sideContent: ModuleSideContent) => ({
     ...sideContent,
-    /**
-     * @todo Convert the props_placeholder string to actual props or completely remove it.
-     */
-    body: sideContent.body(React)('props_placeholder')
+    body: sideContent.body(debuggerContext)
   }));
   return moduleTabs;
 };

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -39,11 +39,8 @@ export const getModuleTabs = (debuggerContext: DebuggerContext): SideContentTab[
   // Get module side contents from DebuggerContext
   const rawModuleTabs = debuggerContext.context?.modules as Modules[] | undefined;
   if (rawModuleTabs == null) return [];
-
-  console.log(rawModuleTabs[0](React));
   // Pass React into functions
   const unprocessedTabs: ModuleSideContent[] = rawModuleTabs.map((tab: any) => tab(React));
-
   // Initialize module side contents to convert to SideContentTab type
   const moduleTabs: SideContentTab[] = unprocessedTabs.map((sideContent: ModuleSideContent) => ({
     ...sideContent,

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -75,7 +75,7 @@ export type SideContentTab = {
 export type ModuleSideContent = {
   label: string;
   iconName: IconName;
-  body: (React: any) => (props: any) => JSX.Element;
+  body: (props: any) => JSX.Element;
   toSpawn: (context: DebuggerContext) => boolean;
 };
 
@@ -86,7 +86,4 @@ export type ModuleSideContent = {
  *
  * @property sideContents an array of side content tabs to display on the front end
  */
-export type Modules = {
-  functions: { [key: string]: Function };
-  sideContents: ModuleSideContent[];
-};
+export type Modules = (React: any) => ModuleSideContent;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import 'src/styles/index.scss';
 
 import * as Sentry from '@sentry/browser';
 import { ConnectedRouter } from 'connected-react-router';
-import { setBackendStaticURL } from 'js-slang/dist/modules/moduleLoader';
+import { setModulesStaticURL } from 'js-slang/dist/modules/moduleLoader';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import ApplicationContainer from 'src/commons/application/ApplicationContainer';
@@ -31,7 +31,7 @@ console.log(
   'font-weight: bold;'
 );
 
-setBackendStaticURL(Constants.moduleBackendUrl);
+setModulesStaticURL(Constants.moduleBackendUrl);
 console.log(`Using module backend: ${Constants.moduleBackendUrl}`);
 
 render(


### PR DESCRIPTION
### Description

Updated cadet frontend to use new modules system.
Updated the naming of the function to set default modules static URL to `setModulesStaticURL` from `setBackendStaticURL`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Clone [js-slang](https://github.com/source-academy/js-slang).
2. Checkout branch to `modules/seperate` by doing `git checkout modules/seperate`.
3. Checkout branch to `modules/seperate` by doing `git checkout modules/seperate`.
4. Build js-slang by doing `yarn build` (ensure that you are on a linux system).
5. Link js-slang to the cadet frontend by doing `yarn link` in the js-slang root folder and `yarn link "js-slang"` in the cadet frontend root folder.
6. Clone [modules](https://github.com/source-academy/modules).
7. Checkout branch to `modules/rollup` by doing `git checkout modules/rollup`.
8. Build modules by doing `yarn build`.
9. Serve the modules as static assests by doing `yarn serve`.
10. Ensure that `REACT_APP_MODULE_BACKEND_URL = http://localhost:8022` in the `.env` file of cadet frontend.
11. Run a local instance of cadet frontend by doing `yarn start`
12. In the Source Academy playround, run the following code: 
```
import { twice } from "repeat";

function add_one(x) {
  return x + 1;
}

twice(add_one)(1);
```
13. Check that the output is 3 in the REPL without any errors.

### Checklist

- [ ] I have tested this code
