### PR TITLE
Bug fix and rotate_around_origin update

### DIFF
--- a/public/externalLibs/graphics/tempCodeRunnerFile.js
+++ b/public/externalLibs/graphics/tempCodeRunnerFile.js
@@ -1,0 +1,1 @@
+scale_x_y_z

--- a/public/externalLibs/graphics/tempCodeRunnerFile.js
+++ b/public/externalLibs/graphics/tempCodeRunnerFile.js
@@ -1,1 +1,0 @@
-scale_x_y_z

--- a/public/externalLibs/graphics/webGLcurve.js
+++ b/public/externalLibs/graphics/webGLcurve.js
@@ -139,31 +139,23 @@ function generateCurve(scaleMode, drawMode, numPoints, func, space, isFullView) 
     -0.5,// amount to rotate in radians
     [0, 0, 1])     // axis to rotate around Z (dynamic)
     cubeRotation += 0.1 * Math.PI
+  } else {
+    min_z = max_z = 0
   }
 
   if (scaleMode == 'fit') {
-    var center = space == '3D' ? [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2] : [(min_x + max_x) / 2, (min_y + max_y) / 2]
+    var center = [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2]
     var scale = Math.max(max_x - min_x, max_y - min_y, max_z - min_z)
     scale = scale === 0 ? 1 : scale;
-    space == '3D' 
-      ? mat4.scale(transMat, transMat, vec3.fromValues(2 / scale, 2 / scale, 2 / scale))
-      : mat4.scale(transMat, transMat, vec3.fromValues(2 / scale, 2 / scale, 0))
-                                     // use 2 because the value is in [-1, 1]
-    space == '3D' 
-      ? mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
-      : mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], 0))
+    mat4.scale(transMat, transMat, vec3.fromValues(2 / scale, 2 / scale, 2 / scale))
+    mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
   } else if (scaleMode == 'stretch') {
-    var center = space == '3D' ? [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2] : [(min_x + max_x) / 2, (min_y + max_y) / 2]
+    var center = [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2]
     var x_scale = max_x === min_x ? 1 : (max_x - min_x)
     var y_scale = max_y === min_y ? 1 : (max_y - min_y)
     var z_scale = max_z === min_z ? 1 : (max_z - min_z)
-    space == '3D'
-      ? mat4.scale(transMat, transMat, vec3.fromValues(2 / x_scale, 2 / y_scale, 2 / z_scale))
-      : mat4.scale(transMat, transMat, vec3.fromValues(2 / x_scale, 2 / y_scale, 0))
-                                    // use 2 because the value is in [-1, 1]
-    space == '3D' 
-      ? mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
-      : mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], 0))
+    mat4.scale(transMat, transMat, vec3.fromValues(2 / x_scale, 2 / y_scale, 2 / z_scale))
+    mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
   }
 
   if(space == '3D'){

--- a/public/externalLibs/graphics/webGLcurve.js
+++ b/public/externalLibs/graphics/webGLcurve.js
@@ -63,9 +63,6 @@ function generateCurve(scaleMode, drawMode, numPoints, func, space, isFullView) 
       max_y = Math.max(max_y, y)
       min_z = Math.min(min_z, z)
       max_z = Math.max(max_z, z)
-      if (Math.max(max_x, max_y, max_z, -min_x, -min_y, -min_z) > Math.pow(10, 32)) {
-        throw "The absolute value of the coordinates of the curve is too big!"
-      }
     }
   }
   evaluator(numPoints, func)

--- a/public/externalLibs/graphics/webGLcurve.js
+++ b/public/externalLibs/graphics/webGLcurve.js
@@ -84,7 +84,7 @@ function generateCurve(scaleMode, drawMode, numPoints, func, space, isFullView) 
   }
 
   // box generation
-  if(space == '3D'){
+  if (space == '3D') {
     drawCubeArray.push(
       -1, 1, 1, -1, -1, 1,
       -1, -1, -1, -1, 1, -1,
@@ -95,50 +95,6 @@ function generateCurve(scaleMode, drawMode, numPoints, func, space, isFullView) 
       -1, 1, 1, -1, 1, -1,
       1, 1, -1, 1, 1, 1
     )
-    var scale_x, scale_y, scale_z
-    scale_x = scale_y = scale_z = 2
-    var translate_x, translate_y, translate_z
-    translate_x = translate_y = translate_z = 0
-    if (scaleMode == 'fit') {
-      var scale = Math.max(max_x - min_x, max_y - min_y, max_z - min_z)
-      scale = scale === 0 ? 1 : scale;
-      scale_x = scale_y = scale_z = scale
-      translate_x = (min_x + max_x) / 2
-      translate_y = (min_y + max_y) / 2
-      translate_z = (min_z + max_z) / 2
-    } else if (scaleMode == 'stretch') {
-      var scale_x = max_x === min_x ? 1 : (max_x - min_x)
-      var scale_y = max_y === min_y ? 1 : (max_y - min_y)
-      var scale_z = max_z === min_z ? 1 : (max_z - min_z)
-      translate_x = (min_x + max_x) / 2
-      translate_y = (min_y + max_y) / 2
-      translate_z = (min_z + max_z) / 2
-    }
-
-    for (var i = 0; i < drawCubeArray.length; i++) {
-      if (i % 3 == 0) {
-        drawCubeArray[i] /= 2 / scale_x
-        drawCubeArray[i] += translate_x
-      } else if (i % 3 == 1) {
-        drawCubeArray[i] /= 2 / scale_y
-        drawCubeArray[i] += translate_y
-      } else {
-        drawCubeArray[i] /= 2 / scale_z
-        drawCubeArray[i] += translate_z
-      }
-    }
-    var scale = Math.sqrt(1 / 3.1) 
-    mat4.scale(transMat, transMat, vec3.fromValues(scale, scale, scale))
-    curveObject.drawCube = drawCubeArray
-
-    mat4.translate(transMat, transMat, [0, 0, -5])
-    //Rotation
-    mat4.rotate(transMat, transMat, -(Math.PI/2), [1, 0, 0]) // axis to rotate around X (static)
-    mat4.rotate(transMat, transMat,
-    // cubeRotation * .7,// amount to rotate in radians
-    -0.5,// amount to rotate in radians
-    [0, 0, 1])     // axis to rotate around Z (dynamic)
-    cubeRotation += 0.1 * Math.PI
   } else {
     min_z = max_z = 0
   }
@@ -147,18 +103,70 @@ function generateCurve(scaleMode, drawMode, numPoints, func, space, isFullView) 
     var center = [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2]
     var scale = Math.max(max_x - min_x, max_y - min_y, max_z - min_z)
     scale = scale === 0 ? 1 : scale;
-    mat4.scale(transMat, transMat, vec3.fromValues(2 / scale, 2 / scale, 2 / scale))
-    mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
+    if (space == '3D') {
+      for (var i = 0; i < curvePosArray.length; i++) {
+        if (i % 3 == 0) {
+          curvePosArray[i] -= center[0]
+          curvePosArray[i] /= scale/2
+        } else if (i % 3 == 1) {
+          curvePosArray[i] -= center[1]
+          curvePosArray[i] /= scale/2
+        } else {
+          curvePosArray[i] -= center[2]
+          curvePosArray[i] /= scale/2
+        }
+      }
+    } else {
+      for (var i = 0; i < curvePosArray.length; i++) {
+        if (i % 2 == 0) {
+          curvePosArray[i] -= center[0]
+          curvePosArray[i] /= scale/2
+        } else {
+          curvePosArray[i] -= center[1]
+          curvePosArray[i] /= scale/2
+        }
+      }
+    }
   } else if (scaleMode == 'stretch') {
     var center = [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2]
     var x_scale = max_x === min_x ? 1 : (max_x - min_x)
     var y_scale = max_y === min_y ? 1 : (max_y - min_y)
     var z_scale = max_z === min_z ? 1 : (max_z - min_z)
-    mat4.scale(transMat, transMat, vec3.fromValues(2 / x_scale, 2 / y_scale, 2 / z_scale))
-    mat4.translate(transMat, transMat, vec3.fromValues(-center[0], -center[1], -center[2]))
+    if (space == '3D') {
+      for (var i = 0; i < curvePosArray.length; i++) {
+        if (i % 3 == 0) {
+          curvePosArray[i] -= center[0]
+          curvePosArray[i] /= x_scale/2
+        } else if (i % 3 == 1) {
+          curvePosArray[i] -= center[1]
+          curvePosArray[i] /= y_scale/2
+        } else {
+          curvePosArray[i] -= center[2]
+          curvePosArray[i] /= z_scale/2
+        }
+      }
+    } else {
+      for (var i = 0; i < curvePosArray.length; i++) {
+        if (i % 2 == 0) {
+          curvePosArray[i] -= center[0]
+          curvePosArray[i] /= x_scale/2
+        } else {
+          curvePosArray[i] -= center[1]
+          curvePosArray[i] /= y_scale/2
+        }
+      }
+    }
   }
 
-  if(space == '3D'){
+  if (space == '3D') {
+    var scale = Math.sqrt(1 / 3.1)
+    mat4.scale(transMat, transMat, vec3.fromValues(scale, scale, scale))
+    curveObject.drawCube = drawCubeArray
+    mat4.translate(transMat, transMat, [0, 0, -5])
+    mat4.rotate(transMat, transMat, -(Math.PI / 2), [1, 0, 0])  // axis to rotate around X
+    mat4.rotate(transMat, transMat, -0.5, [0, 0, 1])            // axis to rotate around Z
+    cubeRotation += 0.1 * Math.PI
+
     const fieldOfView = 45 * Math.PI / 180;
     const aspect = gl.canvas.width / gl.canvas.height;
     const zNear = 0;

--- a/public/externalLibs/graphics/webGLhi_graph_ce.js
+++ b/public/externalLibs/graphics/webGLhi_graph_ce.js
@@ -40,10 +40,6 @@ function unit_line_at(y) {
   }
 }
 
-function alternative_unit_circle(t) {
-  return make_point(Math.sin(2 * Math.PI * square(t)), Math.cos(2 * Math.PI * square(t)))
-}
-
 // made available for Mission 6
 function arc(t) {
   return make_point(Math.sin(Math.PI * t), Math.cos(Math.PI * t))
@@ -149,58 +145,6 @@ function scale_curve(a1, b1, c1) {
 
 function scale_proportional(s) {
   return scale_curve(s, s, s)
-}
-
-// SQUEEZE-RECTANGULAR-PORTION translates and scales a curve
-// so the portion of the curve in the rectangle
-// with corners xlo xhi ylo yhi will appear in a display window
-// which has x, y coordinates from 0 to 1.
-// It is of type (JS-Num, JS-Num, JS-Num, JS-Num --> Curve-Transform).
-
-function squeeze_rectangular_portion(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    return compose(scale_x_y(1 / width, 1 / height), translate_curve(-xlo, -ylo))
-  }
-}
-
-// SQUEEZE-FULL-VIEW translates and scales a curve such that
-// the ends are fully visible.
-// It is very similar to the squeeze-rectangular-portion procedure
-// only that that procedure does not allow the edges to be easily seen
-
-function squeeze_full_view(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    return compose(
-      scale_x_y(0.99 * 1 / width, 0.99 * 1 / height),
-      translate_curve(-(xlo - 0.01), -(ylo - 0.01))
-    )
-  }
-}
-
-// FULL-VIEW
-
-function full_view_proportional(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    var scale_factor = Math.min(0.9 * 1 / width, 0.9 * 1 / height)
-    var new_mid_x = scale_factor * (xlo + xhi) / 2
-    var new_mid_y = scale_factor * (ylo + yhi) / 2
-    return compose(
-      translate_curve(0.5 - new_mid_x, 0.5 - new_mid_y),
-      scale_x_y(scale_factor, scale_factor)
-    )
-  }
 }
 
 // PUT-IN-STANDARD-POSITION is a Curve-Transform.

--- a/public/externalLibs/graphics/webGLhi_graph_ce.js
+++ b/public/externalLibs/graphics/webGLhi_graph_ce.js
@@ -76,18 +76,49 @@ function translate_curve(x0, y0, z0) {
 
 // ROTATE-AROUND-ORIGIN is of type (JS-Num --> Curve-Transform)
 
-function rotate_around_origin(theta) {
-  var cth = Math.cos(theta)
-  var sth = Math.sin(theta)
-  return function(curve) {
-    var transformation = c => (function(t) {
-      var ct = c(t)
-      var x = x_of(ct)
-      var y = y_of(ct)
-      var z = z_of(ct)
-      return make_3D_color_point(cth * x - sth * y, sth * x + cth * y, z, r_of(ct), g_of(ct), b_of(ct))
-    })
-    return transformation(curve)
+function rotate_around_origin(theta1, theta2, theta3) {
+  if (theta3 == undefined && theta1 != undefined && theta2 != undefined) {
+    // 2 args
+    throw new Error('Expected 1 or 3 arguments, but received 2')
+  } else if (theta1 != undefined && theta2 == undefined && theta3 == undefined) {
+    // 1 args
+    var cth = Math.cos(theta1)
+    var sth = Math.sin(theta1)
+    return function(curve) {
+      var transformation = c => (function(t) {
+        var ct = c(t)
+        var x = x_of(ct)
+        var y = y_of(ct)
+        var z = z_of(ct)
+        return make_3D_color_point(cth * x - sth * y, sth * x + cth * y, z, r_of(ct), g_of(ct), b_of(ct))
+      })
+      return transformation(curve)
+    }
+  } else {
+    var cthx = Math.cos(theta1)
+    var sthx = Math.sin(theta1)
+    var cthy = Math.cos(theta2)
+    var sthy = Math.sin(theta2)
+    var cthz = Math.cos(theta3)
+    var sthz = Math.sin(theta3)
+    return function(curve) {
+      var transformation = c => (function(t) {
+        var ct = c(t)
+        var coord = [x_of(ct), y_of(ct), z_of(ct)]
+        var mat = [
+          [cthz * cthy, cthz * sthy * sthx - sthz * cthx, cthz * sthy * cthx + sthz * sthx],
+          [sthz * cthy, sthz * sthy * sthx + cthz * cthx, sthz * sthy * cthx - cthz * sthx],
+          [-sthy, cthy * sthx, cthy * cthx]]
+        var xf = 0, yf = 0, zf = 0;
+        for (var i = 0; i < 3; i++) {
+          xf += mat[0][i] * coord[i]
+          yf += mat[1][i] * coord[i]
+          zf += mat[2][i] * coord[i]
+        }
+        return make_3D_color_point(xf, yf, zf, r_of(ct), g_of(ct), b_of(ct))
+      })
+      return transformation(curve)
+    }
   }
 }
 


### PR DESCRIPTION
### Description

#### `generateCurve`

The function now handles scaling and translation of curves manually on the coordinates of each generated point, and the cube no longer needs to be scaled or translated to fit the curve. This solves the following problem of the range of a certain axes being too small for the curve to render properly:
```
draw_3D_connected_full_view(1000)(t => make_3D_point(math_exp(-15)*t, math_sin(2*math_PI*t), math_pow(1-t, 2)));
```
If '-15' is further decreased pass a threshold, the program will treat the range of x to be exactly 0. This change also fixes the problem regarding cube not rendering when values of the coordinates are too large.
```
draw_3D_connected_full_view(1000)(t => make_3D_point(math_exp(111111)*t, math_sin(2*math_PI*t), math_pow(1-t, 2)));
```
Hence, the limitation on the coordinates has been removed. It will be documented that WebGL stops rendering points beyond a certain limit.
However, this change does not fix the following problem of rotations not working properly on `draw_3D_connected_full_view`:
```
let curve1 = t => make_3D_point(0, 0.5*math_cos(2*math_PI*t)+0.5, 0.5*math_sin(2*math_PI*t)+0.5);
// curve1 is a circle
let curve2 = rotate_around_origin(math_PI/4*(-2))(curve1);
// curve2 is a rotation of curve1 by 90 degrees clockwise
draw_3D_connected_full_view(1000)(curve2);
```
Users can go about this issue by adding a small value (e.g. '0.0000001') to the rotation, but that will incur a non-zero range (for y-axis in this case) and the curve will not be rendered parallel to the x-axis, as opposed to `draw_3D_connected_full_view_proportional`.

#### `rotate_around_origin`

The function now accepts 1 or 3 arguments (throwing error for 2 arguments). However, users have to understand that rotations in 3D are generally not commutative, and that the rotation called on 3 arguments (a, b, c) is an extrinsic rotation with Euler angles (a, b, c) about x, y, and z axis.

#### Removed Functions

Removed the following undocumented and unused functions:
    * `alternative_unit_circle`
    * `squeeze_rectangular_portion`
    * `squeeze_full_view`
    * `full_view_proportional`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Pull and build js-slang from master branch, and [follow the steps here](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) to link it to the cadet-front end.
2. Run an instance of cadet-frontend, and navigate to playground
3. Include CURVES library

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
