### PR TITLE
Remove references to `roomId` in Answer and Grade

### DIFF
--- a/src/commons/XMLParser/XMLParserHelper.ts
+++ b/src/commons/XMLParser/XMLParserHelper.ts
@@ -155,7 +155,6 @@ const makeQuestions = (task: XmlParseStrTask): [Question[], number, number] => {
     const localMaxXp = problem.$.maxxp ? parseInt(problem.$.maxxp, 10) : 0;
     const question: BaseQuestion = {
       answer: null,
-      roomId: null,
       content: problem.TEXT[0],
       id: curId,
       library: makeLibrary(problem.DEPLOYMENT),

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -229,8 +229,6 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): Wo
   debuggerContext: {} as DebuggerContext
 });
 
-export const defaultRoomId = null;
-
 export const defaultWorkspaceManager: WorkspaceManagerState = {
   assessment: {
     ...createDefaultWorkspace('assessment'),

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -400,7 +400,6 @@ test('updateGrading generates correct action object', () => {
         id: 234
       },
       grade: {
-        roomId: 'test roomId',
         grade: 10,
         gradeAdjustment: 0,
         xp: 100,

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -295,7 +295,6 @@ const gradingTest1: Grading = [
       id: 234
     },
     grade: {
-      roomId: '19422030',
       grade: 10,
       gradeAdjustment: 0,
       xp: 100,
@@ -313,7 +312,6 @@ const gradingTest2: Grading = [
       id: 345
     },
     grade: {
-      roomId: '19422030',
       grade: 30,
       gradeAdjustment: 10,
       xp: 500,

--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -130,7 +130,6 @@ export type BaseQuestion = {
   library: Library;
   maxGrade: number;
   maxXp: number;
-  roomId: string | null;
   type: QuestionType;
   xp: number;
 };
@@ -225,7 +224,6 @@ export const programmingTemplate = (): IProgrammingQuestion => {
   return {
     autogradingResults: [],
     answer: '// [Marking Scheme]\n// 1 mark for correct answer',
-    roomId: '19422043',
     content: 'Enter content here',
     id: 0,
     library: emptyLibrary(),
@@ -255,7 +253,6 @@ export const testcaseTemplate = (): Testcase => {
 export const mcqTemplate = (): IMCQQuestion => {
   return {
     answer: 3,
-    roomId: null,
     content: 'This is a mock MCQ question',
     choices: [
       {

--- a/src/commons/mocks/AssessmentMocks.ts
+++ b/src/commons/mocks/AssessmentMocks.ts
@@ -267,7 +267,6 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
   What's your favourite dinner food?
   \`\`\`
   `,
-    roomId: null,
     id: 0,
     library: mockSoundLibrary,
     prepend: `const pizza = "pizza";
@@ -313,7 +312,6 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
   function volumeOfSphere(x) {
       return 4 / 3 * cube(x) * pi;
   }`,
-    roomId: '19422043',
     content: 'Hello and welcome to this assessment! This is the 1st question.',
     id: 1,
     library: mockRuneLibrary,
@@ -350,7 +348,6 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
   },
   {
     answer: 3,
-    roomId: '19422046',
     content:
       'This is the 3rd question. Oddly enough, it is an ungraded MCQ question that uses the curves library! Option C has a null hint!',
     choices: [
@@ -382,7 +379,6 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
   },
   {
     answer: 3,
-    roomId: null,
     content:
       'This is the 4rth question. Oddly enough, it is a graded MCQ question that uses the curves library!',
     choices: [
@@ -415,7 +411,6 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
   {
     autogradingResults: [],
     answer: null,
-    roomId: '19422032',
     content: 'You have reached the last question! Have some fun with the tone matrix...',
     id: 4,
     library: mockToneMatrixLibrary,
@@ -440,7 +435,6 @@ export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQue
           return fibonacci(n-1) + fibonacci(n-2);
       }
   }`,
-    roomId: '19422032',
     content: 'You can see autograding results!!!',
     id: 0,
     library: mockCurveLibrary,
@@ -533,7 +527,6 @@ export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQue
     answer: `function recurse(rune, n) {
       return n <= 1 ? rune : make_cross(recurse(rune, n - 1));
   }`,
-    roomId: '19422033',
     content: 'This is a runes question - there are no testcases nor autograding results.',
     id: 1,
     library: mockRuneLibrary,
@@ -594,7 +587,6 @@ export const mockClosedAssessmentQuestions: Array<IProgrammingQuestion | IMCQQue
 export const mockPathQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
   {
     answer: null,
-    roomId: null,
     content: 'As a recap: which of the following is not a valid logic gate?',
     choices: [
       {
@@ -626,7 +618,6 @@ export const mockPathQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
   {
     autogradingResults: [],
     answer: null,
-    roomId: null,
     content: `An AND gate is a digital logic gate that implements logical conjunction on its inputs. It returns a single output that is HIGH (active) iff all the inputs to the AND gate are HIGH (active).
   
   In this question, let us model an AND gate as a function, and treat HIGH (active) inputs as the boolean value \`true\` and LOW (inactive) inputs as the boolean value \`false\`.
@@ -705,7 +696,6 @@ export const mockPathQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
   {
     autogradingResults: [],
     answer: null,
-    roomId: null,
     content: `The XOR (exclusive-OR) gate is a digital logic gate that accepts two inputs and returns a single output that is HIGH (active) iff one of the inputs are HIGH (active), but not both.
   
   In this question, let us model the XOR gate as a function. Implement the function \`XOR(x, y)\` which takes two boolean inputs \`x\` and \`y\` and which returns the output of the XOR gate as a boolean.
@@ -766,7 +756,6 @@ export const mockPathQuestions: Array<IProgrammingQuestion | IMCQQuestion> = [
   {
     autogradingResults: [],
     answer: null,
-    roomId: null,
     content: `The NOR logic gate is special in that it is an _universal logic gate_, that is to say, they can be composed to form any other logic gate.
   
   Implement the AND logic gate **using ONLY the NOR logic gate**, as the \`NOR_AND(x, y)\` function that takes in two booleans as input.

--- a/src/commons/mocks/BackendMocks.ts
+++ b/src/commons/mocks/BackendMocks.ts
@@ -151,7 +151,6 @@ export function* mockBackendSaga(): SagaIterator {
         gradingQuestion.grade = {
           gradeAdjustment,
           xpAdjustment,
-          roomId: gradingQuestion.grade.roomId,
           grade: gradingQuestion.grade.grade,
           xp: gradingQuestion.grade.xp,
           comments

--- a/src/commons/mocks/GradingMocks.ts
+++ b/src/commons/mocks/GradingMocks.ts
@@ -123,7 +123,6 @@ Hello and welcome to this assessment! This is the *0th question*.
       prepend: '// THIS IS A PREPEND',
       postpend: '// THIS IS A POSTPEND',
       testcases: mockTestcases,
-      roomId: null,
       id: 0,
       library: mockRuneLibrary,
       solutionTemplate: '0th question mock solution template',
@@ -190,7 +189,6 @@ function remainder(n, d) {
       xpAdjustment: 0,
       grade: 0,
       xp: 0,
-      roomId: '19422040',
       comments: `Good job. You are awarded the full marks!
 
 ----
@@ -233,7 +231,6 @@ _italics_
       postpend: '',
       testcases: [],
       answer: "This student's answer to the 1st question",
-      roomId: null,
       content: 'Hello and welcome to this assessment! This is the 1st question.',
       id: 1,
       library: mockRuneLibrary,
@@ -280,7 +277,6 @@ _italics_
       xpAdjustment: 0,
       grade: 100,
       xp: 100,
-      roomId: '19422040',
       comments: `You open the Report Card, not knowing what to expect...
 
 ## WOW!
@@ -329,7 +325,6 @@ New message from **Avenger**!
       postpend: '',
       testcases: [],
       answer: 3,
-      roomId: null,
       solution: 2,
       content:
         'Hello and welcome to this assessment! This is the 2nd question. Oddly enough, it is an MCQ question!',
@@ -393,8 +388,7 @@ New message from **Avenger**!
       gradeAdjustment: 0,
       xpAdjustment: 0,
       grade: 50,
-      xp: 50,
-      roomId: '19422030'
+      xp: 50
     },
     student: {
       name: 'Al Gorithm',

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -303,7 +303,6 @@ function* BackendSaga(): SagaIterator {
         gradingQuestion.grade = {
           gradeAdjustment,
           xpAdjustment,
-          roomId: gradingQuestion.grade.roomId,
           grade: gradingQuestion.grade.grade,
           xp: gradingQuestion.grade.xp,
           comments

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -562,7 +562,6 @@ export const getGrading = async (submissionId: number, tokens: Tokens): Promise<
         autogradingResults: question.autogradingResults || [],
         choices: question.choices,
         content: question.content,
-        roomId: null,
         id: question.id,
         library: castLibrary(question.library),
         solution: gradingQuestion.solution || question.solution || null,
@@ -578,7 +577,6 @@ export const getGrading = async (submissionId: number, tokens: Tokens): Promise<
       grade: {
         grade: grade.grade,
         xp: grade.xp,
-        roomId: grade.roomId || '',
         gradeAdjustment: grade.adjustment,
         xpAdjustment: grade.xpAdjustment,
         comments: grade.comments

--- a/src/features/grading/GradingTypes.ts
+++ b/src/features/grading/GradingTypes.ts
@@ -57,7 +57,6 @@ export type GradingQuestion = {
     id: number;
   };
   grade: {
-    roomId: string;
     grade: number;
     gradeAdjustment: number;
     xp: number;
@@ -77,15 +76,12 @@ export type GradingQuestion = {
  * either of (library & solutionTemplate) xor (choices) must
  * be present, and either of (solution) xor (answer) must be present.
  *
- * @property roomId This property is already present in GradingQuestion,
- *   and thus does not need to be used here, and is set to null
  * @property solution this can be either the answer to the MCQ, the solution to
  *   a programming question, or null.
  */
 export type AnsweredQuestion = Question & Answer;
 
 type Answer = {
-  roomId: null;
   autogradingResults: AutogradingResult[];
   prepend: string;
   postpend: string;


### PR DESCRIPTION
### Description

This feature was removed from the backend in https://github.com/source-academy/cadet/commit/3642f04ff72b636ed399b7bd45d20730d6e6ce17.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Code quality improvements

### How to test

Running the current testsuite.

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
