### PR TITLE
Upgrade Sourceror for REPL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "redux-mock-store": "^1.5.4",
     "redux-saga": "^1.1.3",
     "showdown": "^1.9.1",
-    "sourceror": "^0.7.3",
+    "sourceror": "^0.8.0",
     "typesafe-actions": "^5.1.0",
     "uuid": "^8.3.2",
     "xml2js": "^0.4.23",

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -653,20 +653,25 @@ export function* evalCode(
         useSubst: substActiveAndCorrectChapter
       });
     } else if (variant === 'wasm') {
-      return call(wasm_compile_and_run, code, context);
+      return call(wasm_compile_and_run, code, context, actionType === EVAL_REPL);
     } else {
       throw new Error('Unknown variant: ' + variant);
     }
   }
-  async function wasm_compile_and_run(wasmCode: string, wasmContext: Context): Promise<Result> {
-    return Sourceror.compile(wasmCode, wasmContext)
+  async function wasm_compile_and_run(
+    wasmCode: string,
+    wasmContext: Context,
+    isRepl: boolean
+  ): Promise<Result> {
+    return Sourceror.compile(wasmCode, wasmContext, isRepl)
       .then((wasmModule: WebAssembly.Module) => {
         const transcoder = new Sourceror.Transcoder();
         return Sourceror.run(
           wasmModule,
           Sourceror.makePlatformImports(makeSourcerorExternalBuiltins(wasmContext), transcoder),
           transcoder,
-          wasmContext
+          wasmContext,
+          isRepl
         );
       })
       .then(

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -695,8 +695,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     [selectedTab]
   );
 
-  const replDisabled =
-    props.sourceVariant === 'concurrent' || props.sourceVariant === 'wasm' || usingRemoteExecution;
+  const replDisabled = props.sourceVariant === 'concurrent' || usingRemoteExecution;
 
   const editorProps = {
     onChange: onChangeMethod,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12290,10 +12290,10 @@ sourcemap-codec@^1.4.4:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-sourceror@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/sourceror/-/sourceror-0.7.3.tgz#92010af8df81e7754fa8aa8d18da396258853a1d"
-  integrity sha512-s0q+QWOdLqFL8P2F5lM6PJkOidURMUXNoWmQIY17n+SUOJLh51eJ6Bwv63IjbhBwQ1QwMtfAcGbyjC44avqQ7g==
+sourceror@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/sourceror/-/sourceror-0.8.0.tgz#e4fc988de4fef4215d69404237c063f18a9b916c"
+  integrity sha512-vSdorpaYo0YMIIM/om7XGH9nGbpyRN5893xZE96aD+sVcbBta8jNRRcAZNShcsMrMPN6BCtjd5nSwfWqLG467Q==
   dependencies:
     acorn "^8.1.0"
     js-slang "^0.4.60"


### PR DESCRIPTION
### Description

Sourceror 0.8.0 now supports REPL.  This PR makes minor changes to cadet-frontend to integrate with Sourceror.

Most things you can do in the editor can now also be done in the REPL.  However:
- You have to run the editor once before you can use the REPL (if not, a descriptive error will be presented).
- You cannot write import declarations in the REPL.

Essentially, we save the linear memory and globals of the original WebAssembly instance after it has finished running, and when invoking the REPL we load the saved linear memory and globals into the new instance.  In order to ensure "compatibility" (i.e. the new instance can use the old memory and globals), we can't add additional imports, and the code from the REPL cannot use statically allocated memory (which is okay, but leads to slightly slower string constants and the lack of location information when the new code triggers a runtime error).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Open the playground and set the language to Source §1 WebAssembly, and play around with the REPL.

![image](https://user-images.githubusercontent.com/6948096/119489919-cac75980-bd8e-11eb-94fa-83f1c8ee4edf.png)

### Checklist

- [x] I have tested this code
