### PR TITLE
Update most dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-responsive": "^8.2.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-simple-keyboard": "^2.5.186",
+    "react-simple-keyboard": "^3.1.36",
     "react-sortable-hoc": "^1.11.0",
     "react-textarea-autosize": "^8.3.2",
     "redux": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@craco/craco": "^6.1.2",
-    "@testing-library/react": "^11.2.6",
+    "@testing-library/react": "^11.2.7",
     "@types/acorn": "^4.0.5",
     "@types/common-tags": "^1.8.0",
     "@types/draft-js": "^0.11.2",
@@ -101,7 +101,7 @@
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.169",
     "@types/lz-string": "^1.3.34",
-    "@types/node": "*",
+    "@types/node": "^15.12.1",
     "@types/react": "^17.0.5",
     "@types/react-copy-to-clipboard": "^5.0.0",
     "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-simple-keyboard": "^2.5.186",
     "react-sortable-hoc": "^1.11.0",
     "react-textarea-autosize": "^8.3.2",
-    "redux": "~4.0",
+    "redux": "^4.1.0",
     "redux-mock-store": "^1.5.4",
     "redux-saga": "^1.1.3",
     "showdown": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-draggable": "^4.4.3",
     "react-dropzone": "^11.3.2",
     "react-hotkeys": "^2.0.0",
-    "react-konva": "^17.0.2-0",
+    "react-konva": "^17.0.2-4",
     "react-mde": "^11.5.0",
     "react-redux": "^7.2.4",
     "react-responsive": "^8.2.0",

--- a/src/pages/createStore.ts
+++ b/src/pages/createStore.ts
@@ -27,7 +27,7 @@ export function createStore(history: History) {
 
   const enhancers = composeEnhancers(applyMiddleware(...middleware));
 
-  const createdStore = _createStore(createRootReducer(history), initialStore, enhancers);
+  const createdStore = _createStore(createRootReducer(history), initialStore as any, enhancers);
   sagaMiddleware.run(MainSaga);
 
   createdStore.subscribe(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11242,10 +11242,10 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
 
-react-simple-keyboard@^2.5.186:
-  version "2.5.186"
-  resolved "https://registry.yarnpkg.com/react-simple-keyboard/-/react-simple-keyboard-2.5.186.tgz#93dca2ef0327469bfab6c8a65296a7376288de91"
-  integrity sha512-INNYqbIRlZlsLzf1vfW5O3gEhjfDowv0ya+Y79ZwBvFPIx05YTp4tdmv4Pqhas3UMGKG35eM//WyIqW4JrTYMA==
+react-simple-keyboard@^3.1.36:
+  version "3.1.36"
+  resolved "https://registry.yarnpkg.com/react-simple-keyboard/-/react-simple-keyboard-3.1.36.tgz#8257fd63021e533454b6fec226eb1bf3377addd5"
+  integrity sha512-kaxQ5QN7f78bnnW/+3flIIoXzeWfMxGe1PeLa7VCFb2Hk3tQOfkFcjRmMvAhE5MglFBU7Tq9Tm8UZYh784avyA==
 
 react-sortable-hoc@^1.11.0:
   version "1.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.5.tgz#665450911c6031af38f81db530f387ec04cd9a98"
+  integrity sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -11419,6 +11426,13 @@ redux-saga@^1.1.3:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
+  integrity sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11064,13 +11064,13 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-konva@^17.0.2-0:
-  version "17.0.2-0"
-  resolved "https://registry.yarnpkg.com/react-konva/-/react-konva-17.0.2-0.tgz#35b1cf1b0ff3ed63b7de16aa6c0744e496391374"
-  integrity sha512-zT//biPf2UqqE4OIaivY2NfnnYgsEscSFacO9sbiUVrhtaP9mV8YgKx48CA4XjlgvfjjZqAxY6JTTmjJlsVYPw==
+react-konva@^17.0.2-4:
+  version "17.0.2-4"
+  resolved "https://registry.yarnpkg.com/react-konva/-/react-konva-17.0.2-4.tgz#afd0968e1295b624bf2a7a154ba294e0d5be55cd"
+  integrity sha512-YvRVPT81y8sMQV1SY1/tIDetGxBK+7Rk86u4LmiyDBLLE17vD78F01b8EC3AuP3nI3hUaTblfBugUF35cm6Etg==
   dependencies:
-    react-reconciler "~0.26.1"
-    scheduler "^0.20.1"
+    react-reconciler "~0.26.2"
+    scheduler "^0.20.2"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -11103,7 +11103,7 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-reconciler@~0.26.1:
+react-reconciler@~0.26.2:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
   integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
@@ -11901,7 +11901,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.1, scheduler@^0.20.2:
+scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,10 +1970,10 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/react@^11.2.6":
-  version "11.2.6"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
-  integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
+"@testing-library/react@^11.2.7":
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
+  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
@@ -2221,6 +2221,11 @@
   version "14.14.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.45.tgz#ec2dfb5566ff814d061aef7e141575aedba245cf"
   integrity sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==
+
+"@types/node@^15.12.1":
+  version "15.12.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
+  integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
### Description

Updated most dependencies.

Not updated:
- husky: requires new configuration for pre-push hooks
- konva: huge version update that is breaking
- eslint: throws a `failed to load config "react-app" to extend from` locally
- @types/estree: needs to be upgraded together with version in js-slang