### PR TITLE
Update js-slang and expose __PROGRAM__ to program

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "classnames": "^2.3.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.16",
+    "js-slang": "^0.5.17",
     "konva": "^7.2.5",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8137,10 +8137,10 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-js-slang@^0.5.16:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.16.tgz#9e98dfc9259ec2f3e7b10ecad791a0cbd5a5e9a2"
-  integrity sha512-dj2Edgtx+CGHsKzTg4HkQW6Izw10t7T8jUnBLl8s17YqxskZGsjBl5G+G5iZZsCv4gvDLogQ9mHdXJCiC8XudQ==
+js-slang@^0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.17.tgz#84db70705e5d8d37d8d6a20e90e4c5a129c08323"
+  integrity sha512-ayjBduMERPaec5H09xucqA+5+irRxRK68b0UgM0j9ExgraFK+SZeiLShPQMgqiojhv+Rj7rzAs1Cxm7xlDDbrA==
   dependencies:
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
     "@types/estree" "0.0.50"


### PR DESCRIPTION
### Description

Bump js-slang to 0.5.17, and expose a symbol `__PROGRAM__` to the Source program containing the program source itself.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test

Test that `tokenize` works in Source §4. Test that `__PROGRAM__` has a value equal to the program source.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
