### PR TITLE
Set minimum number of days to wait before creating update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
   "packageRules": [
     {
       "rangeStrategy": "update-lockfile",
-      "matchPackageNames": ["*"]
+      "matchPackageNames": ["*"],
+      "minimumReleaseAge": "5 days"
     }
   ],
   "enabledManagers": ["npm"]


### PR DESCRIPTION
### Description

This sets a minimum number of 5 days to wait after a new release of a dependency before creating the PR, so that we allow sufficient time for the package to stabilize and be mature enough to be updated (so as to avoid misconfiguration/bugs in the dependency update).

It is also good to have at least 3 days because NPM allows unpublishing of updates within 72 hours of release, and this helps to prevent broken packages in the rare case that it does happen.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

N/A

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
