### PR TITLE
Contributors list fix

### DIFF
--- a/src/pages/contributors/subcomponents/ContributorsGithubApi.ts
+++ b/src/pages/contributors/subcomponents/ContributorsGithubApi.ts
@@ -4,7 +4,7 @@ import {
   ReposInApi
 } from '../../../features/contributors/ContributorsTypes';
 
-const apiRepoDetails: string = 'https://api.github.com/orgs/source-academy/repos?per_page=100';
+const apiRepoDetails: string = 'https://api.github.com/orgs/source-academy/repos?per_page=59';
 const ignoreRepos: string[] = ['assessments', 'tools', 'source-academy2'];
 const ignoreContributors: string[] = [
   'dependabot[bot]',


### PR DESCRIPTION
### Description

Resolves https://github.com/source-academy/frontend/issues/3296 by using the `per_page` parameter set to 59.
As the GitHub REST API has a rate limit of 60 requests per hour, 1 request will be used to fetch all the repositories, and the other 59 requests will be used to get the contributors list per repository. Should the organisation have more than 59 repositories, another solution will need to be implemented.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How to test

Navigate to the Contributors page, it should show all repositories in the organisation now

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
