### PR TITLE
fix(GradingEditor): remove redundant isNewQuestion check to allow seamless browsing (#3037)

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -295,7 +295,7 @@ const GradingEditor: React.FC<Props> = props => {
   return (
     <div className="GradingEditor">
       <Prompt
-        when={!currentlySaving && (hasUnsavedChanges || isNewQuestion)}
+        when={!currentlySaving && hasUnsavedChanges}
         message={'You have unsaved changes. Are you sure you want to leave?'}
       />
 


### PR DESCRIPTION
### Description

This PR fixes a UX issue in the GradingEditor (related to #3037) where a "unsaved changes" warning would incorrectly appear when a tutor was simply browsing questions.

Problem: The previous logic included isNewQuestion in the Prompt's when condition. This caused the warning to trigger even if no grading data had been entered, as long as the question was being viewed for the first time.

Solution: Removed the isNewQuestion check from the Prompt component. Now, the warning only triggers if there are actual unsaved changes (hasUnsavedChanges), allowing tutors to browse through ungraded questions without unnecessary interruptions.

Fixes: #3037

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Open a submission in Source Academy that has not been graded yet.
2. Browse through different questions using the navigation (without entering any marks or feedback).
3. Expected Result: No "unsaved changes" prompt should appear.
4. Now, enter some marks for a question and try to switch to another question.
5. Expected Result: The prompt should appear, as there are now actual unsaved changes.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
