### PR TITLE
Fixed the issue described at #3574

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/updateInspector.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/updateInspector.ts
@@ -14,6 +14,10 @@ export function* updateInspector(workspaceLocation: WorkspaceLocation): SagaIter
       state.workspaces[workspaceLocation].lastDebuggerResult,
       state.workspaces[workspaceLocation].context.chapter
     ]);
+    if (!lastDebuggerResult) {
+      yield put(actions.setEditorHighlightedLines(workspaceLocation, 0, []));
+      return;
+    }
     if (chapter === Chapter.FULL_JAVA) {
       const controlItem = lastDebuggerResult.context.control.peek();
       let start = -1;


### PR DESCRIPTION
### Description

This PR fixes the issue raised at #3574 : **Running "true||false;" causes unexpected behaviour in CSE machine**
During the evaluation when the updateInspector method is called and when **short circuiting** happens, nodes[0] remains null. As soon as that happens, an error occurs and the visualisation crashes for the last final step causing the _literal_ to stay on the control instead of moving to the stash in the CSE UI.

Now, if it's null or whatever else, using the operator '?.' instead of '.', it boils down to **undefined** and if it is so, we assign -1 manually. Hence, the visualization happens as required!

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test
Run the following code to test how this minor one line change affects the working of short-circuiting expressions like true || false.
```javascript
true || false;
```
The above works as intended right now!

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
