### PR TITLE
Changed hotkey for hulk mode

### DIFF
--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -292,7 +292,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   // Playground hotkeys
   const [isGreen, setIsGreen] = useState(false);
   const playgroundHotkeyBindings: HotkeyItem[] = useMemo(
-    () => [['alt+shift+h', () => setIsGreen(v => !v)]],
+    () => [['ctrl+alt+h', () => setIsGreen(v => !v)]],
     [setIsGreen]
   );
   useHotkeys(playgroundHotkeyBindings);


### PR DESCRIPTION
### Description

This PR includes a short one-liner change to the hotkey for hulk mode. The hotkey changed from alt+shift+h to ctrl+alt+h. 

Rationale: It was previously mentioned that hulk mode was not working for mac users due to a conflict with the special characters through the use of the option key. A suggested fix was to change the hotkey to ctrl+alt+h. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Pressing ctrl+alt+h activates hulk mode.

### Checklist

- [x] I have tested this code