### PR TITLE
Fixed Redundant Draw in CseMachine.tsx

### DIFF
--- a/src/features/cseMachine/CseMachine.tsx
+++ b/src/features/cseMachine/CseMachine.tsx
@@ -450,7 +450,6 @@ export default class CseMachine {
         CseAnimation.updateAnimation();
         this.setVis(Layout.draw());
       }
-      this.setVis(Layout.draw());
       Layout.updateDimensions(Layout.visibleWidth, Layout.visibleHeight);
     }
   }


### PR DESCRIPTION
### Description

This pull request makes a small change to the `CseMachine` class to eliminate a redundant call to `Layout.draw()`. The call is now made only once, improving efficiency and avoiding unnecessary redraws.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
