### PR TITLE
Hotfix: Replace `@blueprintjs/datetime` with react-day-picker v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "re-resizable": "^6.9.9",
     "react": "^19.2.4",
     "react-ace": "^14.0.0",
+    "react-day-picker": "^9.14.0",
     "react-debounce-render": "^8.0.2",
     "react-dom": "^19.2.4",
     "react-drag-drop-files": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^6.0.0",
-    "@blueprintjs/datetime": "^6.0.0",
     "@blueprintjs/icons": "^6.0.0",
     "@blueprintjs/select": "^6.0.0",
     "@convergencelabs/ace-collab-ext": "^0.6.0",

--- a/src/commons/DateTimePickers/DateInput.tsx
+++ b/src/commons/DateTimePickers/DateInput.tsx
@@ -1,6 +1,6 @@
 import { Button, InputGroup, Popover } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import GradingFlex from '../grading/GradingFlex';
 import DatePicker from './DatePicker';
@@ -38,6 +38,14 @@ const DateInput: React.FC<DateInputProps> = ({
   void disableTimezoneSelect;
   const [inputValue, setInputValue] = useState(value ? formatDate(new Date(value)) : '');
   const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (value) {
+      setInputValue(formatDate(new Date(value)));
+    } else {
+      setInputValue('');
+    }
+  }, [value, formatDate]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;

--- a/src/commons/DateTimePickers/DateInput.tsx
+++ b/src/commons/DateTimePickers/DateInput.tsx
@@ -1,0 +1,110 @@
+import { Button, InputGroup, Popover } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { useState } from 'react';
+
+import GradingFlex from '../grading/GradingFlex';
+import DatePicker from './DatePicker';
+
+type DateInputProps = {
+  value?: string;
+  onChange: (date: string | null) => void;
+  onError?: () => void;
+  formatDate: (date: Date) => string;
+  parseDate: (str: string) => Date | false;
+  placeholder?: string;
+  minDate?: Date;
+  maxDate?: Date;
+  fill?: boolean;
+  closeOnSelection?: boolean;
+  timePrecision?: 'second' | 'minute' | 'hour';
+  disableTimezoneSelect?: boolean;
+};
+
+const DateInput: React.FC<DateInputProps> = ({
+  value,
+  onChange,
+  onError,
+  formatDate,
+  parseDate,
+  placeholder = 'MM/DD/YYYY',
+  minDate,
+  maxDate,
+  fill,
+  closeOnSelection,
+  timePrecision,
+  disableTimezoneSelect
+}) => {
+  void timePrecision;
+  void disableTimezoneSelect;
+  const [inputValue, setInputValue] = useState(value ? formatDate(new Date(value)) : '');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setInputValue(newValue);
+
+    const parsed = parseDate(newValue);
+    if (parsed !== false) {
+      onChange(parsed.toISOString());
+    }
+  };
+
+  const handleDateTimeChange = (datetime: Date | null) => {
+    if (datetime) {
+      const formatted = formatDate(datetime);
+      setInputValue(formatted);
+      onChange(datetime.toISOString());
+      if (closeOnSelection) {
+        setIsOpen(false);
+      }
+    }
+  };
+
+  const handleInputBlur = () => {
+    if (!inputValue) {
+      onChange(null);
+      return;
+    }
+
+    const parsed = parseDate(inputValue);
+    if (parsed === false && onError) {
+      onError();
+    }
+  };
+
+  const datePickerContent = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <DatePicker
+        value={value ? new Date(value) : undefined}
+        onChange={handleDateTimeChange}
+        minDate={minDate}
+        maxDate={maxDate}
+        showTimePicker
+        showActionsBar
+      />
+    </div>
+  );
+
+  return (
+    <GradingFlex alignItems="center" style={{ columnGap: '0.5rem' }}>
+      <InputGroup
+        value={inputValue}
+        onChange={handleInputChange}
+        onBlur={handleInputBlur}
+        placeholder={placeholder}
+        fill={fill}
+        style={{ flex: 1 }}
+      />
+      <Popover
+        isOpen={isOpen}
+        onInteraction={setIsOpen}
+        content={datePickerContent}
+        placement="bottom-start"
+      >
+        <Button icon={IconNames.CALENDAR} />
+      </Popover>
+    </GradingFlex>
+  );
+};
+
+export default DateInput;

--- a/src/commons/DateTimePickers/DatePicker.tsx
+++ b/src/commons/DateTimePickers/DatePicker.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, Divider, HTMLSelect } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Matcher } from 'react-day-picker';
 import {
   DayPicker,
@@ -36,26 +36,38 @@ const DatePicker: React.FC<DatePickerProps> = ({
   minDate,
   maxDate
 }) => {
-  const [selected, setSelected] = useState<Date | undefined>(value);
+  const [selectedDatetime, setSelectedDatetime] = useState<Date | undefined>(value);
 
-  const handleSelect = (date: Date | undefined) => {
-    setSelected(date);
-    if (date) {
-      onChange(date);
+  useEffect(() => {
+    setSelectedDatetime(value);
+  }, [value]);
+
+  const handleSelectDate = (date: Date | undefined) => {
+    if (selectedDatetime && date) {
+      const newDatetime = new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        selectedDatetime.getHours(),
+        selectedDatetime.getMinutes(),
+        selectedDatetime.getSeconds()
+      );
+      setSelectedDatetime(newDatetime);
+      onChange(newDatetime);
     }
   };
 
   const handleTimeChange = (time: Date) => {
-    if (selected) {
-      const newDate = new Date(
-        selected.getFullYear(),
-        selected.getMonth(),
-        selected.getDate(),
+    if (selectedDatetime) {
+      const newDatetime = new Date(
+        selectedDatetime.getFullYear(),
+        selectedDatetime.getMonth(),
+        selectedDatetime.getDate(),
         time.getHours(),
         time.getMinutes(),
         time.getSeconds()
       );
-      onChange(newDate);
+      onChange(newDatetime);
     }
   };
 
@@ -71,8 +83,8 @@ const DatePicker: React.FC<DatePickerProps> = ({
     <div className="bp6-datepicker">
       <DayPicker
         mode="single"
-        selected={selected}
-        onSelect={handleSelect}
+        selected={selectedDatetime}
+        onSelect={handleSelectDate}
         hidden={hidden.length > 0 ? hidden : undefined}
         startMonth={minDate ? new Date(minDate.getFullYear(), minDate.getMonth()) : undefined}
         endMonth={maxDate ? new Date(maxDate.getFullYear(), maxDate.getMonth()) : undefined}

--- a/src/commons/DateTimePickers/DatePicker.tsx
+++ b/src/commons/DateTimePickers/DatePicker.tsx
@@ -54,6 +54,9 @@ const DatePicker: React.FC<DatePickerProps> = ({
       );
       setSelectedDatetime(newDatetime);
       onChange(newDatetime);
+    } else {
+      setSelectedDatetime(date);
+      onChange(date || null);
     }
   };
 

--- a/src/commons/DateTimePickers/DatePicker.tsx
+++ b/src/commons/DateTimePickers/DatePicker.tsx
@@ -1,0 +1,146 @@
+import { Button, Classes, Divider, HTMLSelect } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import classNames from 'classnames';
+import React, { useState } from 'react';
+import type { Matcher } from 'react-day-picker';
+import {
+  DayPicker,
+  MonthCaption as DayPickerMonthCaption,
+  Nav as DayPickerNav
+} from 'react-day-picker';
+
+import GradingFlex from '../grading/GradingFlex';
+import TimePicker from './TimePicker';
+
+type DatePickerProps = {
+  value?: Date;
+  onChange: (date: Date | null) => void;
+  showActionsBar?: boolean;
+  highlightCurrentDay?: boolean;
+  showTimePicker?: boolean;
+  timePickerProps?: {
+    showArrowButtons?: boolean;
+  };
+  minDate?: Date;
+  maxDate?: Date;
+};
+
+const DatePicker: React.FC<DatePickerProps> = ({
+  value,
+  onChange,
+  // TODO: Unused for now
+  showActionsBar,
+  highlightCurrentDay,
+  showTimePicker,
+  timePickerProps,
+  minDate,
+  maxDate
+}) => {
+  const [selected, setSelected] = useState<Date | undefined>(value);
+
+  const handleSelect = (date: Date | undefined) => {
+    setSelected(date);
+    if (date) {
+      onChange(date);
+    }
+  };
+
+  const handleTimeChange = (time: Date) => {
+    if (selected) {
+      const newDate = new Date(
+        selected.getFullYear(),
+        selected.getMonth(),
+        selected.getDate(),
+        time.getHours(),
+        time.getMinutes(),
+        time.getSeconds()
+      );
+      onChange(newDate);
+    }
+  };
+
+  const hidden: Matcher[] = [];
+  if (minDate) {
+    hidden.push({ before: minDate });
+  }
+  if (maxDate) {
+    hidden.push({ after: maxDate });
+  }
+
+  return (
+    <div className="bp6-datepicker">
+      <DayPicker
+        mode="single"
+        selected={selected}
+        onSelect={handleSelect}
+        hidden={hidden.length > 0 ? hidden : undefined}
+        startMonth={minDate ? new Date(minDate.getFullYear(), minDate.getMonth()) : undefined}
+        endMonth={maxDate ? new Date(maxDate.getFullYear(), maxDate.getMonth()) : undefined}
+        showOutsideDays
+        captionLayout="dropdown"
+        components={{
+          Nav(props) {
+            return (
+              <GradingFlex justifyContent="center">
+                <DayPickerNav {...props} />
+              </GradingFlex>
+            );
+          },
+          DayButton({ day, modifiers, onClick }) {
+            return (
+              <Button
+                variant="minimal"
+                className={classNames(
+                  modifiers.selected && Classes.ACTIVE,
+                  (modifiers.selected || (highlightCurrentDay && modifiers.today)) &&
+                    Classes.INTENT_PRIMARY
+                )}
+                disabled={modifiers.outside}
+                onClick={onClick as any}
+              >
+                {day.date.getDate()}
+              </Button>
+            );
+          },
+          MonthCaption(props) {
+            return (
+              <>
+                <GradingFlex justifyContent="center">
+                  <DayPickerMonthCaption {...props} />
+                </GradingFlex>
+                <Divider />
+              </>
+            );
+          },
+          Dropdown(props) {
+            return <HTMLSelect minimal {...(props as any)} />;
+          },
+          NextMonthButton({ onClick }) {
+            return (
+              <Button icon={IconNames.CHEVRON_RIGHT} variant="minimal" onClick={onClick as any} />
+            );
+          },
+          PreviousMonthButton({ onClick }) {
+            return (
+              <Button icon={IconNames.CHEVRON_LEFT} variant="minimal" onClick={onClick as any} />
+            );
+          }
+        }}
+      />
+      {showTimePicker && (
+        <>
+          <Divider />
+          <GradingFlex justifyContent="center">
+            <TimePicker
+              value={value}
+              onChange={handleTimeChange}
+              showArrowButtons={timePickerProps?.showArrowButtons}
+            />
+          </GradingFlex>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default DatePicker;

--- a/src/commons/DateTimePickers/DatePicker.tsx
+++ b/src/commons/DateTimePickers/DatePicker.tsx
@@ -111,7 +111,8 @@ const DatePicker: React.FC<DatePickerProps> = ({
                     Classes.INTENT_PRIMARY
                 )}
                 disabled={modifiers.outside}
-                onClick={onClick as any}
+                // @ts-expect-error - mismatched types
+                onClick={onClick}
               >
                 {day.date.getDate()}
               </Button>
@@ -128,16 +129,19 @@ const DatePicker: React.FC<DatePickerProps> = ({
             );
           },
           Dropdown(props) {
-            return <HTMLSelect minimal {...(props as any)} />;
+            // @ts-expect-error - mismatched types
+            return <HTMLSelect minimal {...props} />;
           },
           NextMonthButton({ onClick }) {
             return (
-              <Button icon={IconNames.CHEVRON_RIGHT} variant="minimal" onClick={onClick as any} />
+              // @ts-expect-error - mismatched types
+              <Button icon={IconNames.CHEVRON_RIGHT} variant="minimal" onClick={onClick} />
             );
           },
           PreviousMonthButton({ onClick }) {
             return (
-              <Button icon={IconNames.CHEVRON_LEFT} variant="minimal" onClick={onClick as any} />
+              // @ts-expect-error - mismatched types
+              <Button icon={IconNames.CHEVRON_LEFT} variant="minimal" onClick={onClick} />
             );
           }
         }}

--- a/src/commons/DateTimePickers/TimePicker.tsx
+++ b/src/commons/DateTimePickers/TimePicker.tsx
@@ -1,0 +1,94 @@
+import { NumericInput } from '@blueprintjs/core';
+import React from 'react';
+
+type TimePickerProps = {
+  value?: Date;
+  onChange: (date: Date) => void;
+  showArrowButtons?: boolean;
+};
+
+const TimePicker: React.FC<TimePickerProps> = ({ value, onChange, showArrowButtons = false }) => {
+  const hours = value ? value.getHours() : 0;
+  const minutes = value ? value.getMinutes() : 0;
+  const seconds = value ? value.getSeconds() : 0;
+
+  const handleHoursChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const newHours = parseInt(e.target.value, 10);
+    const newDate = value ? new Date(value) : new Date();
+    newDate.setHours(newHours);
+    onChange(newDate);
+  };
+
+  const handleMinutesChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const newMinutes = parseInt(e.target.value, 10);
+    const newDate = value ? new Date(value) : new Date();
+    newDate.setMinutes(newMinutes);
+    onChange(newDate);
+  };
+
+  const handleSecondsChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const newSeconds = parseInt(e.target.value, 10);
+    const newDate = value ? new Date(value) : new Date();
+    newDate.setSeconds(newSeconds);
+    onChange(newDate);
+  };
+
+  const formatNumber = (n: number) => n.toString().padStart(2, '0');
+
+  const handleWheel = (
+    e: React.WheelEvent<HTMLInputElement>,
+    field: 'hours' | 'minutes' | 'seconds'
+  ) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -1 : 1;
+    const newDate = value ? new Date(value) : new Date();
+
+    if (field === 'hours') {
+      const newHours = (newDate.getHours() + delta + 24) % 24;
+      newDate.setHours(newHours);
+    } else if (field === 'minutes') {
+      const newMinutes = (newDate.getMinutes() + delta + 60) % 60;
+      newDate.setMinutes(newMinutes);
+    } else if (field === 'seconds') {
+      const newSeconds = (newDate.getSeconds() + delta + 60) % 60;
+      newDate.setSeconds(newSeconds);
+    }
+    onChange(newDate);
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+      <NumericInput
+        value={formatNumber(hours)}
+        onChange={handleHoursChange}
+        onWheel={e => handleWheel(e, 'hours')}
+        min={0}
+        max={23}
+        style={{ width: '50px', textAlign: 'center' }}
+        buttonPosition={showArrowButtons ? 'right' : 'none'}
+      />
+      <span>:</span>
+      <NumericInput
+        value={formatNumber(minutes)}
+        onChange={handleMinutesChange}
+        onWheel={e => handleWheel(e, 'minutes')}
+        min={0}
+        max={59}
+        style={{ width: '50px', textAlign: 'center' }}
+        buttonPosition={showArrowButtons ? 'right' : 'none'}
+      />
+      <span>:</span>
+      <NumericInput
+        value={formatNumber(seconds)}
+        onChange={handleSecondsChange}
+        onWheel={e => handleWheel(e, 'seconds')}
+        min={0}
+        max={59}
+        style={{ width: '50px', textAlign: 'center' }}
+        buttonPosition={showArrowButtons ? 'right' : 'none'}
+      />
+    </div>
+  );
+};
+
+export default TimePicker;

--- a/src/commons/DateTimePickers/index.ts
+++ b/src/commons/DateTimePickers/index.ts
@@ -1,0 +1,3 @@
+export { default as DatePicker } from './DatePicker';
+export { default as TimePicker } from './TimePicker';
+export { default as DateInput } from './DateInput';

--- a/src/commons/achievement/control/achievementEditor/EditableDate.tsx
+++ b/src/commons/achievement/control/achievementEditor/EditableDate.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import { DatePicker } from '@blueprintjs/datetime';
 import React, { useState } from 'react';
 import { prettifyDate } from 'src/commons/achievement/utils/DateHelper';
+import { DatePicker } from 'src/commons/DateTimePickers';
 
 type Props = {
   type: string;

--- a/src/commons/achievement/control/goalEditor/EditableDate.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableDate.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import { DatePicker } from '@blueprintjs/datetime';
 import React, { useState } from 'react';
 import { prettifyDate } from 'src/commons/achievement/utils/DateHelper';
+import { DatePicker } from 'src/commons/DateTimePickers';
 
 type Props = {
   type: string;

--- a/src/commons/achievement/control/goalEditor/EditableTime.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableTime.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import { TimePicker } from '@blueprintjs/datetime';
 import React, { useState } from 'react';
 import { prettifyTime } from 'src/commons/achievement/utils/DateHelper';
+import { TimePicker } from 'src/commons/DateTimePickers';
 
 type Props = {
   type: string;

--- a/src/pages/academy/gameSimulator/subcomponents/chapterPublisher/ChapterPublisherEditor.tsx
+++ b/src/pages/academy/gameSimulator/subcomponents/chapterPublisher/ChapterPublisherEditor.tsx
@@ -1,6 +1,6 @@
 import { Button, Classes, Intent, Switch } from '@blueprintjs/core';
-import { DatePicker } from '@blueprintjs/datetime';
 import { memo, useCallback, useEffect, useState } from 'react';
+import { DatePicker } from 'src/commons/DateTimePickers';
 import { getStandardDateTime } from 'src/commons/utils/DateHelper';
 import { useInput } from 'src/commons/utils/Hooks';
 import { SortableList, useSortableList } from 'src/commons/utils/SortableList';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
@@ -1,8 +1,8 @@
 import { Dialog, DialogBody, DialogFooter, Intent } from '@blueprintjs/core';
-import { DateInput } from '@blueprintjs/datetime';
 import { IconNames } from '@blueprintjs/icons';
 import dayjs from 'dayjs';
 import React, { useCallback, useState } from 'react';
+import { DateInput } from 'src/commons/DateTimePickers';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';
 import ControlButton from '../../../../commons/ControlButton';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,7 +2,6 @@
 
 @import '~normalize.css/normalize.css';
 @import '~@blueprintjs/core/lib/css/blueprint.css';
-@import '~@blueprintjs/datetime/lib/css/blueprint-datetime.css';
 @import '~@blueprintjs/select/lib/css/blueprint-select.css';
 @import '~flexboxgrid/dist/flexboxgrid.css';
 @import '~flexboxgrid-helpers/dist/flexboxgrid-helpers.min.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@date-fns/tz@npm:1.4.1"
+  checksum: 10c0/9033fdc4682fe3d4d147625ce04fa88a8792653594e2de8d5a438c8f3bfc0990ee28fe773f91cac6810b06d818b5b281ae0608752ba8337257d0279ded3f019a
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.6.3":
   version: 0.6.3
   resolution: "@discoveryjs/json-ext@npm:0.6.3"
@@ -3618,6 +3625,13 @@ __metadata:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
   checksum: 10c0/69a86cc52bf9915c74d70acd031e8f86080e95dcbcc84766af879b33345f2e38d8db8f8f01d5035d916e60af462e9c6838ca016a7a85e2d86ae6f32c92bf3044
+  languageName: node
+  linkType: hard
+
+"@tabby_ai/hijri-converter@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@tabby_ai/hijri-converter@npm:1.0.5"
+  checksum: 10c0/40044f463ff57855315c8925461942311460bb64e16706480dde98142f40bcd8e9925bb6fee401fd209397b5bb25368d1529c85b1e6c7e6216ea2085f6aaf61e
   languageName: node
   linkType: hard
 
@@ -5995,6 +6009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-jalali@npm:4.1.0-0":
+  version: 4.1.0-0
+  resolution: "date-fns-jalali@npm:4.1.0-0"
+  checksum: 10c0/f9ad98d9f7e8e5abe0d070dc806b0c8baded2b1208626c42e92cbd2605b5171f5714d6b79b20cc2666267d821699244c9d0b5e93274106cf57d6232da77596ed
+  languageName: node
+  linkType: hard
+
 "date-fns-tz@npm:^2.0.0":
   version: 2.0.1
   resolution: "date-fns-tz@npm:2.0.1"
@@ -6010,6 +6031,13 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.21.0"
   checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -7268,6 +7296,7 @@ __metadata:
     re-resizable: "npm:^6.9.9"
     react: "npm:^19.2.4"
     react-ace: "npm:^14.0.0"
+    react-day-picker: "npm:^9.14.0"
     react-debounce-render: "npm:^8.0.2"
     react-dom: "npm:^19.2.4"
     react-drag-drop-files: "npm:^3.0.0"
@@ -10929,6 +10958,20 @@ __metadata:
     date-fns: ^2.28.0 || ^3.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
+  languageName: node
+  linkType: hard
+
+"react-day-picker@npm:^9.14.0":
+  version: 9.14.0
+  resolution: "react-day-picker@npm:9.14.0"
+  dependencies:
+    "@date-fns/tz": "npm:^1.4.1"
+    "@tabby_ai/hijri-converter": "npm:1.0.5"
+    date-fns: "npm:^4.1.0"
+    date-fns-jalali: "npm:4.1.0-0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10c0/5d26b2e8e28fb504c2ec577bda2ea26709ccab07555aada0674bd72ae38963de6f5cab135d936bb2fef935f97f73c6510657b15b936766e53d5c65811d13289a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,7 +1298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -1385,30 +1385,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blueprintjs/datetime@npm:^6.0.0":
-  version: 6.0.24
-  resolution: "@blueprintjs/datetime@npm:6.0.24"
-  dependencies:
-    "@blueprintjs/core": "npm:^6.12.0"
-    "@blueprintjs/icons": "npm:^6.9.0"
-    "@blueprintjs/select": "npm:^6.1.9"
-    classnames: "npm:^2.3.1"
-    date-fns: "npm:^2.28.0"
-    date-fns-tz: "npm:^2.0.0"
-    react-day-picker: "npm:^8.10.0"
-    react-innertext: "npm:^1.1.5"
-    tslib: "npm:~2.6.2"
-  peerDependencies:
-    "@types/react": 18
-    react: 18
-    react-dom: 18
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/e83f53e54cceade39c098fd7a9be61ac66cd4e5a7218b25c1ce062932ac9502cc5b45ee8548ca284bea40c6f6e9d8f5ed8e54d60ec2117ad362ed26ff819140b
-  languageName: node
-  linkType: hard
-
 "@blueprintjs/icons@npm:^6.0.0, @blueprintjs/icons@npm:^6.9.0":
   version: 6.9.0
   resolution: "@blueprintjs/icons@npm:6.9.0"
@@ -1427,7 +1403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blueprintjs/select@npm:^6.0.0, @blueprintjs/select@npm:^6.1.9":
+"@blueprintjs/select@npm:^6.0.0":
   version: 6.1.9
   resolution: "@blueprintjs/select@npm:6.1.9"
   dependencies:
@@ -6016,24 +5992,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns-tz@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "date-fns-tz@npm:2.0.1"
-  peerDependencies:
-    date-fns: 2.x
-  checksum: 10c0/f860dda9e3d38bc99dc325c678cafb94b3a18c12b1fea0e2f4e451396ea6c4cacced683066c669a67ec380f64fdda83aa4c414a207029b647faa2b76b2a5c6e3
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.28.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.21.0"
-  checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
-  languageName: node
-  linkType: hard
-
 "date-fns@npm:^4.1.0":
   version: 4.1.0
   resolution: "date-fns@npm:4.1.0"
@@ -7193,7 +7151,6 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.24.1"
     "@babel/runtime": "npm:^7.24.5"
     "@blueprintjs/core": "npm:^6.0.0"
-    "@blueprintjs/datetime": "npm:^6.0.0"
     "@blueprintjs/icons": "npm:^6.0.0"
     "@blueprintjs/select": "npm:^6.0.0"
     "@convergencelabs/ace-collab-ext": "npm:^0.6.0"
@@ -10951,16 +10908,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-day-picker@npm:^8.10.0":
-  version: 8.10.0
-  resolution: "react-day-picker@npm:8.10.0"
-  peerDependencies:
-    date-fns: ^2.28.0 || ^3.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
-  languageName: node
-  linkType: hard
-
 "react-day-picker@npm:^9.14.0":
   version: 9.14.0
   resolution: "react-day-picker@npm:9.14.0"
@@ -11070,16 +11017,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/6bbaeccb919726a7f4fda1e547fa58936f1004e122b99234ac1a65d35077563864af7062c51ab9b8b0190be4cb384cd2ed7aeaa895d2785c1783c39cdae64ecd
-  languageName: node
-  linkType: hard
-
-"react-innertext@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "react-innertext@npm:1.1.5"
-  peerDependencies:
-    "@types/react": ">=0.0.0 <=99"
-    react: ">=0.0.0 <=99"
-  checksum: 10c0/45335918ac83334133a9fa0df4ce109e0d4a45d54b783a8eaec88811b36dd5c3bbb5d9a6af2da1eed518a6f325a6ffae4be7bd30878596e0ec1760b231a8e0ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The former depends on v8 which doesn't work in React 19. We create our own custom component for now with the same API to minimize downstream dependent changes.

Fixes crashes in pages that depend on it

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
