### PR TITLE
CSE Machine: Enhance layout and tooltip rendering for function values

### DIFF
--- a/src/features/cseMachine/CseMachineLayout.tsx
+++ b/src/features/cseMachine/CseMachineLayout.tsx
@@ -129,6 +129,7 @@ export class Layout {
   static animationGroupRef: RefObject<KonvaGroupNode | null> = React.createRef();
   static arrowUnderlayLayerRef: RefObject<KonvaLayerNode | null> = React.createRef();
   static underlayArrows: React.ReactNode[] = [];
+  static overlayNodes: React.ReactNode[] = [];
 
   // buffer for faster rendering of diagram when scrolling
   static invisiblePaddingVertical: number = 300;
@@ -141,6 +142,14 @@ export class Layout {
 
   static registerUnderlayArrow(arrow: React.ReactNode) {
     Layout.underlayArrows.push(arrow);
+  }
+
+  static resetOverlayNodes() {
+    Layout.overlayNodes = [];
+  }
+
+  static registerOverlayNode(node: React.ReactNode) {
+    Layout.overlayNodes.push(node);
   }
 
   static updateDimensions(width: number, height: number) {
@@ -194,6 +203,7 @@ export class Layout {
     arrowSelection.clearSelection();
     Layout.key = 0;
     Layout.resetUnderlayArrows();
+    Layout.resetOverlayNodes();
 
     // deep copy so we don't mutate the context
     Layout.globalEnvNode = deepCopyTree(envTree).root;
@@ -689,10 +699,12 @@ export class Layout {
       return Layout.prevLayout;
     } else {
       Layout.resetUnderlayArrows();
+      Layout.resetOverlayNodes();
       const levelNodes = Layout.levels.map(level => level.draw());
       const controlNode = CseMachine.getControlStash() ? Layout.controlComponent.draw() : null;
       const stashNode = CseMachine.getControlStash() ? Layout.stashComponent.draw() : null;
       const underlayArrows = [...Layout.underlayArrows];
+      const overlayNodes = [...Layout.overlayNodes];
       const layout = (
         <div className="sa-cse-machine" data-testid="sa-cse-machine">
           <div
@@ -760,6 +772,7 @@ export class Layout {
                     {CseAnimation.animations.map(c => c.draw())}
                   </KonvaGroup>
                 </KonvaLayer>
+                <KonvaLayer listening={false}>{overlayNodes}</KonvaLayer>
               </KonvaStage>
             </div>
           </div>

--- a/src/features/cseMachine/components/Binding.tsx
+++ b/src/features/cseMachine/components/Binding.tsx
@@ -123,7 +123,14 @@ export class Binding extends Visible {
     if (!isMainReference(this.value, this)) {
       return false;
     }
-    return !Layout.clearDeadFrames || (this.value?.isLive?.() ?? true);
+    if (!Layout.clearDeadFrames) {
+      return true;
+    }
+    // Keep function values interactive even when they are classified as dead.
+    if (this.value instanceof FnValue || this.value instanceof GlobalFnValue) {
+      return true;
+    }
+    return this.value?.isLive?.() ?? true;
   }
 
   /**

--- a/src/features/cseMachine/components/values/ArrayValue.tsx
+++ b/src/features/cseMachine/components/values/ArrayValue.tsx
@@ -160,7 +160,7 @@ export class ArrayValue extends Value implements IHoverable {
       <Group
         key={Layout.key++}
         ref={this.ref}
-        listening={false}
+        listening={true}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
       >

--- a/src/features/cseMachine/components/values/FnValue.tsx
+++ b/src/features/cseMachine/components/values/FnValue.tsx
@@ -14,6 +14,7 @@ import { Config, ShapeDefaultProps } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
 import { IHoverable, NonGlobalFn, ReferenceType } from '../../CseMachineTypes';
 import {
+  defaultBackgroundColor,
   defaultStrokeColor,
   defaultTextColor,
   fadedStrokeColor,
@@ -230,6 +231,62 @@ export class FnValue extends Value implements IHoverable {
     return id ? Layout.liveObjectIDs.has(id) : false;
   }
 
+  private drawTooltipLabels(strokeColor: string, textColor: string): React.ReactNode {
+    return (
+      <React.Fragment key={Layout.key++}>
+        <KonvaLabel
+          x={this.x() + Config.TextMargin}
+          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
+          visible={CseMachine.getPrintableMode()}
+          listening={false}
+          ref={this.labelRef}
+        >
+          <KonvaTag
+            stroke={strokeColor}
+            fill={defaultBackgroundColor()}
+            cornerRadius={Config.FrameCornerRadius}
+          />
+          <KonvaText
+            text={
+              !CseMachine.getPrintableMode() && this.isTooltipTruncated
+                ? `${this.exportTooltip}\n(click for full)`
+                : this.exportTooltip
+            }
+            fontFamily={Config.FontFamily}
+            fontSize={Config.FontSize}
+            fontStyle={Config.FontStyle}
+            fill={textColor} //even the text that appears on hover is faded if unreferenced
+            padding={Config.FnTooltipTextPadding}
+            width={Config.FnDescriptionMaxWidth}
+          />
+        </KonvaLabel>
+        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
+          <KonvaLabel
+            x={this.x() + Config.TextMargin}
+            y={this.y() + this.radius + Config.TextMargin}
+            visible={false}
+            listening={false}
+            ref={this.revealLabelRef}
+          >
+            <KonvaTag
+              stroke={strokeColor}
+              fill={defaultBackgroundColor()}
+              cornerRadius={Config.FrameCornerRadius}
+            />
+            <KonvaText
+              text={this.tooltip}
+              fontFamily={Config.FontFamily}
+              fontSize={Config.FontSize}
+              fontStyle={Config.FontStyle}
+              fill={textColor}
+              padding={Config.FnTooltipTextPadding}
+            />
+          </KonvaLabel>
+        )}
+      </React.Fragment>
+    );
+  }
+
   draw(): React.ReactNode {
     if (this.fnName === undefined) {
       throw new Error('Closure has no main reference and is not initialised!');
@@ -248,10 +305,8 @@ export class FnValue extends Value implements IHoverable {
     const isLive: boolean = this.isLive();
     const textColor = isLive ? defaultTextColor() : fadedTextColor();
     const strokeColor = isLive ? defaultStrokeColor() : fadedStrokeColor();
-    //dont need to check isReferenced here since live is ALL we need to know
-    if (Layout.clearDeadFrames && !isLive) {
-      return null;
-    }
+    Layout.registerOverlayNode(this.drawTooltipLabels(strokeColor, textColor));
+    // Keep function objects rendered so they remain hoverable in clear-dead-frames mode.
     return (
       <React.Fragment key={Layout.key++}>
         <Group
@@ -293,59 +348,6 @@ export class FnValue extends Value implements IHoverable {
             fill={strokeColor}
           />
         </Group>
-        <KonvaLabel
-          x={this.x() + Config.TextMargin}
-          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
-          visible={CseMachine.getPrintableMode()}
-          listening={false}
-          ref={this.labelRef}
-        >
-          {CseMachine.getPrintableMode() ? (
-            <KonvaTag stroke={strokeColor} />
-          ) : (
-            <KonvaTag
-              stroke={Config.HoverBgColor}
-              fill={Config.HoverBgColor}
-              opacity={Config.FnTooltipOpacity}
-            />
-          )}
-          <KonvaText
-            text={
-              !CseMachine.getPrintableMode() && this.isTooltipTruncated
-                ? `${this.exportTooltip}\n(click for full)`
-                : this.exportTooltip
-            }
-            fontFamily={Config.FontFamily}
-            fontSize={Config.FontSize}
-            fontStyle={Config.FontStyle}
-            fill={textColor} //even the text that appears on hover is faded if unreferenced
-            padding={Config.FnTooltipTextPadding}
-            width={Config.FnDescriptionMaxWidth}
-          />
-        </KonvaLabel>
-        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
-          <KonvaLabel
-            x={this.x() + Config.TextMargin}
-            y={this.y() + this.radius + Config.TextMargin}
-            visible={false}
-            listening={false}
-            ref={this.revealLabelRef}
-          >
-            <KonvaTag
-              stroke={Config.HoverBgColor}
-              fill={Config.HoverBgColor}
-              opacity={Config.FnTooltipOpacity}
-            />
-            <KonvaText
-              text={this.tooltip}
-              fontFamily={Config.FontFamily}
-              fontSize={Config.FontSize}
-              fontStyle={Config.FontStyle}
-              fill={textColor}
-              padding={Config.FnTooltipTextPadding}
-            />
-          </KonvaLabel>
-        )}
         {this._arrow?.draw()}
         {this.tooltipArrow?.draw()}
       </React.Fragment>

--- a/src/features/cseMachine/components/values/FnValue.tsx
+++ b/src/features/cseMachine/components/values/FnValue.tsx
@@ -1,20 +1,13 @@
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
 import React, { RefObject } from 'react';
-import {
-  Circle,
-  Group,
-  Label as KonvaLabel,
-  Tag as KonvaTag,
-  Text as KonvaText
-} from 'react-konva';
+import { Circle, Group } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
 import { Config, ShapeDefaultProps } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
 import { IHoverable, NonGlobalFn, ReferenceType } from '../../CseMachineTypes';
 import {
-  defaultBackgroundColor,
   defaultStrokeColor,
   defaultTextColor,
   fadedStrokeColor,
@@ -33,7 +26,7 @@ import { ArrowFromFn } from '../arrows/ArrowFromFn';
 import { ArrowFromFnTooltip } from '../arrows/ArrowFromFnTooltip';
 import { Binding } from '../Binding';
 import { Frame } from '../Frame';
-import { Value } from './Value';
+import { FunctionTooltipLabels, Value } from './Value';
 
 /** this class encapsulates a JS Slang function (not from the global frame) that
  *  contains extra props such as environment and fnName */
@@ -231,62 +224,6 @@ export class FnValue extends Value implements IHoverable {
     return id ? Layout.liveObjectIDs.has(id) : false;
   }
 
-  private drawTooltipLabels(strokeColor: string, textColor: string): React.ReactNode {
-    return (
-      <React.Fragment key={Layout.key++}>
-        <KonvaLabel
-          x={this.x() + Config.TextMargin}
-          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
-          visible={CseMachine.getPrintableMode()}
-          listening={false}
-          ref={this.labelRef}
-        >
-          <KonvaTag
-            stroke={strokeColor}
-            fill={defaultBackgroundColor()}
-            cornerRadius={Config.FrameCornerRadius}
-          />
-          <KonvaText
-            text={
-              !CseMachine.getPrintableMode() && this.isTooltipTruncated
-                ? `${this.exportTooltip}\n(click for full)`
-                : this.exportTooltip
-            }
-            fontFamily={Config.FontFamily}
-            fontSize={Config.FontSize}
-            fontStyle={Config.FontStyle}
-            fill={textColor} //even the text that appears on hover is faded if unreferenced
-            padding={Config.FnTooltipTextPadding}
-            width={Config.FnDescriptionMaxWidth}
-          />
-        </KonvaLabel>
-        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
-          <KonvaLabel
-            x={this.x() + Config.TextMargin}
-            y={this.y() + this.radius + Config.TextMargin}
-            visible={false}
-            listening={false}
-            ref={this.revealLabelRef}
-          >
-            <KonvaTag
-              stroke={strokeColor}
-              fill={defaultBackgroundColor()}
-              cornerRadius={Config.FrameCornerRadius}
-            />
-            <KonvaText
-              text={this.tooltip}
-              fontFamily={Config.FontFamily}
-              fontSize={Config.FontSize}
-              fontStyle={Config.FontStyle}
-              fill={textColor}
-              padding={Config.FnTooltipTextPadding}
-            />
-          </KonvaLabel>
-        )}
-      </React.Fragment>
-    );
-  }
-
   draw(): React.ReactNode {
     if (this.fnName === undefined) {
       throw new Error('Closure has no main reference and is not initialised!');
@@ -305,7 +242,22 @@ export class FnValue extends Value implements IHoverable {
     const isLive: boolean = this.isLive();
     const textColor = isLive ? defaultTextColor() : fadedTextColor();
     const strokeColor = isLive ? defaultStrokeColor() : fadedStrokeColor();
-    Layout.registerOverlayNode(this.drawTooltipLabels(strokeColor, textColor));
+    Layout.registerOverlayNode(
+      <FunctionTooltipLabels
+        key={Layout.key++}
+        x={this.x()}
+        y={this.y()}
+        radius={this.radius}
+        printDescriptionOffsetY={this.printDescriptionOffsetY}
+        isTooltipTruncated={this.isTooltipTruncated}
+        exportTooltip={this.exportTooltip}
+        tooltip={this.tooltip}
+        strokeColor={strokeColor}
+        textColor={textColor}
+        labelRef={this.labelRef}
+        revealLabelRef={this.revealLabelRef}
+      />
+    );
     // Keep function objects rendered so they remain hoverable in clear-dead-frames mode.
     return (
       <React.Fragment key={Layout.key++}>

--- a/src/features/cseMachine/components/values/GlobalFnValue.tsx
+++ b/src/features/cseMachine/components/values/GlobalFnValue.tsx
@@ -14,6 +14,7 @@ import { Config, ShapeDefaultProps } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
 import { GlobalFn, IHoverable } from '../../CseMachineTypes';
 import {
+  defaultBackgroundColor,
   defaultStrokeColor,
   defaultTextColor,
   fadedStrokeColor,
@@ -199,6 +200,62 @@ export class GlobalFnValue extends Value implements IHoverable {
     return true;
   }
 
+  private drawTooltipLabels(strokeColor: string, textColor: string): React.ReactNode {
+    return (
+      <React.Fragment key={Layout.key++}>
+        <KonvaLabel
+          x={this.x() + Config.TextMargin}
+          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
+          visible={CseMachine.getPrintableMode()}
+          listening={false}
+          ref={this.labelRef}
+        >
+          <KonvaTag
+            stroke={strokeColor}
+            fill={defaultBackgroundColor()}
+            cornerRadius={Config.FrameCornerRadius}
+          />
+          <KonvaText
+            text={
+              !CseMachine.getPrintableMode() && this.isTooltipTruncated
+                ? `${this.exportTooltip}\n(click for full)`
+                : this.exportTooltip
+            }
+            fontFamily={Config.FontFamily}
+            fontSize={Config.FontSize}
+            fontStyle={Config.FontStyle}
+            fill={textColor}
+            padding={Config.FnTooltipTextPadding}
+            width={Config.FnDescriptionMaxWidth}
+          />
+        </KonvaLabel>
+        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
+          <KonvaLabel
+            x={this.x() + Config.TextMargin}
+            y={this.y() + this.radius + Config.TextMargin}
+            visible={false}
+            listening={false}
+            ref={this.revealLabelRef}
+          >
+            <KonvaTag
+              stroke={strokeColor}
+              fill={defaultBackgroundColor()}
+              cornerRadius={Config.FrameCornerRadius}
+            />
+            <KonvaText
+              text={this.tooltip}
+              fontFamily={Config.FontFamily}
+              fontSize={Config.FontSize}
+              fontStyle={Config.FontStyle}
+              fill={textColor}
+              padding={Config.FnTooltipTextPadding}
+            />
+          </KonvaLabel>
+        )}
+      </React.Fragment>
+    );
+  }
+
   draw(): React.ReactNode {
     this._isDrawn = true;
     if (Layout.globalEnvNode.frame) {
@@ -210,6 +267,7 @@ export class GlobalFnValue extends Value implements IHoverable {
     this.tooltipArrow.setVisible(CseMachine.getPrintableMode() || this.showTooltipArrow);
     const textColor = this.isReferenced() ? defaultTextColor() : fadedTextColor();
     const strokeColor = this.isReferenced() ? defaultStrokeColor() : fadedStrokeColor();
+    Layout.registerOverlayNode(this.drawTooltipLabels(strokeColor, textColor));
     return (
       <React.Fragment key={Layout.key++}>
         <Group
@@ -251,59 +309,6 @@ export class GlobalFnValue extends Value implements IHoverable {
             fill={strokeColor}
           />
         </Group>
-        <KonvaLabel
-          x={this.x() + Config.TextMargin}
-          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
-          visible={CseMachine.getPrintableMode()}
-          listening={false}
-          ref={this.labelRef}
-        >
-          {CseMachine.getPrintableMode() ? (
-            <KonvaTag stroke={strokeColor} />
-          ) : (
-            <KonvaTag
-              stroke={Config.HoverBgColor}
-              fill={Config.HoverBgColor}
-              opacity={Config.FnTooltipOpacity}
-            />
-          )}
-          <KonvaText
-            text={
-              !CseMachine.getPrintableMode() && this.isTooltipTruncated
-                ? `${this.exportTooltip}\n(click for full)`
-                : this.exportTooltip
-            }
-            fontFamily={Config.FontFamily}
-            fontSize={Config.FontSize}
-            fontStyle={Config.FontStyle}
-            fill={textColor}
-            padding={Config.FnTooltipTextPadding}
-            width={Config.FnDescriptionMaxWidth}
-          />
-        </KonvaLabel>
-        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
-          <KonvaLabel
-            x={this.x() + Config.TextMargin}
-            y={this.y() + this.radius + Config.TextMargin}
-            visible={false}
-            listening={false}
-            ref={this.revealLabelRef}
-          >
-            <KonvaTag
-              stroke={Config.HoverBgColor}
-              fill={Config.HoverBgColor}
-              opacity={Config.FnTooltipOpacity}
-            />
-            <KonvaText
-              text={this.tooltip}
-              fontFamily={Config.FontFamily}
-              fontSize={Config.FontSize}
-              fontStyle={Config.FontStyle}
-              fill={textColor}
-              padding={Config.FnTooltipTextPadding}
-            />
-          </KonvaLabel>
-        )}
         {this._arrow?.draw()}
         {this.tooltipArrow?.draw()}
       </React.Fragment>

--- a/src/features/cseMachine/components/values/GlobalFnValue.tsx
+++ b/src/features/cseMachine/components/values/GlobalFnValue.tsx
@@ -1,20 +1,13 @@
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
 import React, { RefObject } from 'react';
-import {
-  Circle,
-  Group,
-  Label as KonvaLabel,
-  Tag as KonvaTag,
-  Text as KonvaText
-} from 'react-konva';
+import { Circle, Group } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
 import { Config, ShapeDefaultProps } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
 import { GlobalFn, IHoverable } from '../../CseMachineTypes';
 import {
-  defaultBackgroundColor,
   defaultStrokeColor,
   defaultTextColor,
   fadedStrokeColor,
@@ -30,7 +23,7 @@ import {
 import { ArrowFromFn } from '../arrows/ArrowFromFn';
 import { ArrowFromFnTooltip } from '../arrows/ArrowFromFnTooltip';
 import { Binding } from '../Binding';
-import { Value } from './Value';
+import { FunctionTooltipLabels, Value } from './Value';
 
 /** this encapsulates a function from the global frame */
 export class GlobalFnValue extends Value implements IHoverable {
@@ -200,62 +193,6 @@ export class GlobalFnValue extends Value implements IHoverable {
     return true;
   }
 
-  private drawTooltipLabels(strokeColor: string, textColor: string): React.ReactNode {
-    return (
-      <React.Fragment key={Layout.key++}>
-        <KonvaLabel
-          x={this.x() + Config.TextMargin}
-          y={this.y() + this.radius + Config.TextMargin + this.printDescriptionOffsetY}
-          visible={CseMachine.getPrintableMode()}
-          listening={false}
-          ref={this.labelRef}
-        >
-          <KonvaTag
-            stroke={strokeColor}
-            fill={defaultBackgroundColor()}
-            cornerRadius={Config.FrameCornerRadius}
-          />
-          <KonvaText
-            text={
-              !CseMachine.getPrintableMode() && this.isTooltipTruncated
-                ? `${this.exportTooltip}\n(click for full)`
-                : this.exportTooltip
-            }
-            fontFamily={Config.FontFamily}
-            fontSize={Config.FontSize}
-            fontStyle={Config.FontStyle}
-            fill={textColor}
-            padding={Config.FnTooltipTextPadding}
-            width={Config.FnDescriptionMaxWidth}
-          />
-        </KonvaLabel>
-        {!CseMachine.getPrintableMode() && this.isTooltipTruncated && (
-          <KonvaLabel
-            x={this.x() + Config.TextMargin}
-            y={this.y() + this.radius + Config.TextMargin}
-            visible={false}
-            listening={false}
-            ref={this.revealLabelRef}
-          >
-            <KonvaTag
-              stroke={strokeColor}
-              fill={defaultBackgroundColor()}
-              cornerRadius={Config.FrameCornerRadius}
-            />
-            <KonvaText
-              text={this.tooltip}
-              fontFamily={Config.FontFamily}
-              fontSize={Config.FontSize}
-              fontStyle={Config.FontStyle}
-              fill={textColor}
-              padding={Config.FnTooltipTextPadding}
-            />
-          </KonvaLabel>
-        )}
-      </React.Fragment>
-    );
-  }
-
   draw(): React.ReactNode {
     this._isDrawn = true;
     if (Layout.globalEnvNode.frame) {
@@ -267,7 +204,22 @@ export class GlobalFnValue extends Value implements IHoverable {
     this.tooltipArrow.setVisible(CseMachine.getPrintableMode() || this.showTooltipArrow);
     const textColor = this.isReferenced() ? defaultTextColor() : fadedTextColor();
     const strokeColor = this.isReferenced() ? defaultStrokeColor() : fadedStrokeColor();
-    Layout.registerOverlayNode(this.drawTooltipLabels(strokeColor, textColor));
+    Layout.registerOverlayNode(
+      <FunctionTooltipLabels
+        key={Layout.key++}
+        x={this.x()}
+        y={this.y()}
+        radius={this.radius}
+        printDescriptionOffsetY={this.printDescriptionOffsetY}
+        isTooltipTruncated={this.isTooltipTruncated}
+        exportTooltip={this.exportTooltip}
+        tooltip={this.tooltip}
+        strokeColor={strokeColor}
+        textColor={textColor}
+        labelRef={this.labelRef}
+        revealLabelRef={this.revealLabelRef}
+      />
+    );
     return (
       <React.Fragment key={Layout.key++}>
         <Group

--- a/src/features/cseMachine/components/values/Value.tsx
+++ b/src/features/cseMachine/components/values/Value.tsx
@@ -1,8 +1,92 @@
-import React from 'react';
+import { Label } from 'konva/lib/shapes/Label';
+import React, { RefObject } from 'react';
+import { Label as KonvaLabel, Tag as KonvaTag, Text as KonvaText } from 'react-konva';
 
+import CseMachine from '../../CseMachine';
+import { Config } from '../../CseMachineConfig';
 import { Data, ReferenceType } from '../../CseMachineTypes';
-import { isDummyReference } from '../../CseMachineUtils';
+import { defaultBackgroundColor, isDummyReference } from '../../CseMachineUtils';
 import { Visible } from '../Visible';
+
+type FunctionTooltipLabelsProps = {
+  x: number;
+  y: number;
+  radius: number;
+  printDescriptionOffsetY: number;
+  isTooltipTruncated: boolean;
+  exportTooltip: string;
+  tooltip: string;
+  strokeColor: string;
+  textColor: string;
+  labelRef: RefObject<Label | null>;
+  revealLabelRef: RefObject<Label | null>;
+};
+
+export const FunctionTooltipLabels = ({
+  x,
+  y,
+  radius,
+  printDescriptionOffsetY,
+  isTooltipTruncated,
+  exportTooltip,
+  tooltip,
+  strokeColor,
+  textColor,
+  labelRef,
+  revealLabelRef
+}: FunctionTooltipLabelsProps): React.ReactNode => (
+  <React.Fragment>
+    <KonvaLabel
+      x={x + Config.TextMargin}
+      y={y + radius + Config.TextMargin + printDescriptionOffsetY}
+      visible={CseMachine.getPrintableMode()}
+      listening={false}
+      ref={labelRef}
+    >
+      <KonvaTag
+        stroke={strokeColor}
+        fill={defaultBackgroundColor()}
+        cornerRadius={Config.FrameCornerRadius}
+      />
+      <KonvaText
+        text={
+          !CseMachine.getPrintableMode() && isTooltipTruncated
+            ? `${exportTooltip}\n(click for full)`
+            : exportTooltip
+        }
+        fontFamily={Config.FontFamily}
+        fontSize={Config.FontSize}
+        fontStyle={Config.FontStyle}
+        fill={textColor}
+        padding={Config.FnTooltipTextPadding}
+        width={Config.FnDescriptionMaxWidth}
+      />
+    </KonvaLabel>
+    {!CseMachine.getPrintableMode() && isTooltipTruncated && (
+      <KonvaLabel
+        x={x + Config.TextMargin}
+        y={y + radius + Config.TextMargin}
+        visible={false}
+        listening={false}
+        ref={revealLabelRef}
+      >
+        <KonvaTag
+          stroke={strokeColor}
+          fill={defaultBackgroundColor()}
+          cornerRadius={Config.FrameCornerRadius}
+        />
+        <KonvaText
+          text={tooltip}
+          fontFamily={Config.FontFamily}
+          fontSize={Config.FontSize}
+          fontStyle={Config.FontStyle}
+          fill={textColor}
+          padding={Config.FnTooltipTextPadding}
+        />
+      </KonvaLabel>
+    )}
+  </React.Fragment>
+);
 
 /** the value of a `Binding` or an `ArrayUnit` */
 export abstract class Value extends Visible {


### PR DESCRIPTION
### Description

This pull request introduces significant improvements to the rendering and interactivity of function tooltips in the CSE Machine visualization. The main changes center around separating overlay elements (like tooltips) from the main diagram rendering, ensuring function objects remain interactive even when "clear dead frames" mode is enabled, and improving tooltip rendering logic.

**Rendering and overlay management improvements:**

* Introduced a new `overlayNodes` array and related methods (`resetOverlayNodes`, `registerOverlayNode`) in the `Layout` class to manage overlay elements (such as tooltips) separately from the main diagram. Overlay nodes are now rendered in their own non-interactive Konva layer, ensuring proper stacking and interactivity. (`src/features/cseMachine/CseMachineLayout.tsx`) [[1]](diffhunk://#diff-fedf7f18ee2e9b5c1077cc7b732c40e0d8038b81563a7f720b33a32e801054f2R132) [[2]](diffhunk://#diff-fedf7f18ee2e9b5c1077cc7b732c40e0d8038b81563a7f720b33a32e801054f2R147-R154) [[3]](diffhunk://#diff-fedf7f18ee2e9b5c1077cc7b732c40e0d8038b81563a7f720b33a32e801054f2R206) [[4]](diffhunk://#diff-fedf7f18ee2e9b5c1077cc7b732c40e0d8038b81563a7f720b33a32e801054f2R702-R707) [[5]](diffhunk://#diff-fedf7f18ee2e9b5c1077cc7b732c40e0d8038b81563a7f720b33a32e801054f2R775)

* Refactored both `FnValue` and `GlobalFnValue` components to move tooltip label rendering into a new `drawTooltipLabels` method, and registered these tooltips as overlay nodes via the new `Layout.registerOverlayNode` mechanism. This cleans up the main rendering logic and ensures tooltips are consistently managed as overlays. (`src/features/cseMachine/components/values/FnValue.tsx`, `src/features/cseMachine/components/values/GlobalFnValue.tsx`) [[1]](diffhunk://#diff-b1f7ffd8f2f6b22fd786ea84a579eada4e55264e507f5794faa047faf9353318R234-R289) [[2]](diffhunk://#diff-b1f7ffd8f2f6b22fd786ea84a579eada4e55264e507f5794faa047faf9353318L251-R309) [[3]](diffhunk://#diff-b1f7ffd8f2f6b22fd786ea84a579eada4e55264e507f5794faa047faf9353318L296-L348) [[4]](diffhunk://#diff-d376c03356effa30a7cb39b35299c27576c18d10bb15d81ba0a65e03ab727e99R203-R258) [[5]](diffhunk://#diff-d376c03356effa30a7cb39b35299c27576c18d10bb15d81ba0a65e03ab727e99R270) [[6]](diffhunk://#diff-d376c03356effa30a7cb39b35299c27576c18d10bb15d81ba0a65e03ab727e99L254-L306)

**Interactivity and usability enhancements:**

* Modified the logic in the `Binding` component so that function values (`FnValue` and `GlobalFnValue`) remain interactive and visible even when they are considered "dead" (unreferenced) and "clear dead frames" mode is active. This ensures users can always interact with function objects, improving usability. (`src/features/cseMachine/components/Binding.tsx`)

* Changed the `ArrayValue` component to set `listening={true}` on its Konva group, enabling hover and mouse events for array values. (`src/features/cseMachine/components/values/ArrayValue.tsx`)

**Minor improvements:**

* Added missing import of `defaultBackgroundColor` in function value components to support the new tooltip rendering logic. (`src/features/cseMachine/components/values/FnValue.tsx`, `src/features/cseMachine/components/values/GlobalFnValue.tsx`) [[1]](diffhunk://#diff-b1f7ffd8f2f6b22fd786ea84a579eada4e55264e507f5794faa047faf9353318R17) [[2]](diffhunk://#diff-d376c03356effa30a7cb39b35299c27576c18d10bb15d81ba0a65e03ab727e99R17)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
