### PR TITLE
Fix: resolve CSE Machine layout corruption when switching files in Folder Mode

### DIFF
--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -425,9 +425,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   const autorunButtonHandlers = useMemo(() => {
     return {
       handleEditorEval: () => {
-        if (updateCse) {
-          CseMachine.clearCachedLayouts();
-        }
+        CseMachine.clearCachedLayouts();
         // reset stepper before evaluation
         dispatch(WorkspaceActions.updateCurrentStep(-1, workspaceLocation));
         dispatch(WorkspaceActions.updateStepsTotal(0, workspaceLocation));
@@ -456,7 +454,6 @@ const Playground: React.FC<PlaygroundProps> = props => {
   }, [
     dispatch,
     workspaceLocation,
-    updateCse,
     playgroundSourceChapter,
     selectedTab,
     hasAnyBreakpoints,
@@ -505,7 +502,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         time: Date.now(),
         type: 'chapterSelect',
         data: chapter
-      };
+      };  
 
       pushLog(input);
 

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -502,7 +502,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         time: Date.now(),
         type: 'chapterSelect',
         data: chapter
-      };  
+      };
 
       pushLog(input);
 

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -221,7 +221,6 @@ const Playground: React.FC<PlaygroundProps> = props => {
     sharedbConnected,
     usingSubst,
     usingCse,
-    updateCse,
     isFolderModeEnabled,
     activeEditorTabIndex,
     context: { chapter: playgroundSourceChapter, variant: playgroundSourceVariant }


### PR DESCRIPTION

### Description

**Resolves:** #3796 

**Bug Context:**
A major visual bug occurs in the CSE Machine when users switch between different files in Folder Mode and evaluate them. The layouts from the old file and the new file overlap, corrupting the layout table until the page is fully reloaded.

This was caused by the `updateCse` boolean flag. In `handleEditorEval`, the layout caches were only being cleared if `updateCse === true`. However, simply switching active editor tabs does not trigger a code change event, meaning `updateCse` remains `false`. When the user pressed "Run" on the newly selected file, the `if (updateCse)` check bypassed `CseMachine.clearCachedLayouts()`, causing the new execution to draw using the old file's cached ghost coordinates.

**Changes Made:**
* **`Playground.tsx`**: Removed the `if (updateCse)` condition inside `handleEditorEval`. 
* `CseMachine.clearCachedLayouts()` now triggers on *every* evaluation. The tiny computational save of skipping a cache clear if the code hasn't changed is redundant and not worth the side effect of breaking Folder Mode.
* Removed `updateCse` from the `useMemo` dependency array for `autorunButtonHandlers` as it is no longer needed in that block.

**How to Test:**
1. Open the CSE Machine in Folder Mode.
2. Create two files with the code snippets from issue #3796 (`foo` and `add_stream`).
3. Run the first file.
4. Switch the active tab to the second file and hit Run.
5. The CSE Machine should now properly wipe the layout cache and render the new layout cleanly without any visual overlap.