### PR TITLE
Remove unnecessary React import

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ const reactRestrictedImports = [
   'ComponentType',
   'JSX',
   'CSSProperties',
+  'ErrorInfo',
   'MouseEvent',
   'KeyboardEvent',
   'RefObject'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,16 @@ const restrictedImports = [
     name: 'react',
     importNames: [importName],
     message: `Use the fully qualified name React.${importName} instead of importing ${importName} directly.`
-  }))
+  })),
+  {
+    name: 'react-redux',
+    importNames: [
+      // TODO: Create typed hook for useDispatch
+      // "useDispatch",
+      'useSelector'
+    ],
+    message: 'Use the typed hook "useTypedSelector" instead.'
+  }
 ];
 
 export default tseslint.config(
@@ -58,22 +67,6 @@ export default tseslint.config(
       'react-hooks/refs': 'warn', // TODO: Fix and delete (default is error)
       'react-hooks/use-memo': 'warn', // TODO: Fix and delete (default is error)
       'no-empty': 'warn',
-      'no-restricted-imports': [
-        'error',
-        {
-          paths: [
-            {
-              name: 'react-redux',
-              importNames: [
-                // TODO: Create typed hook for useDispatch
-                // "useDispatch",
-                'useSelector'
-              ],
-              message: 'Use the typed hook "useTypedSelector" instead.'
-            }
-          ]
-        }
-      ],
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-duplicate-enum-values': 'off',
       '@typescript-eslint/no-empty-function': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,24 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import tseslint from 'typescript-eslint';
 
+const reactRestrictedImports = [
+  'FC',
+  'FunctionComponent',
+  'SFC',
+  'ReactNode',
+  'ReactElement',
+  'ComponentType',
+  'JSX'
+];
+
+const restrictedImports = [
+  ...reactRestrictedImports.map(importName => ({
+    name: 'react',
+    importNames: [importName],
+    message: `Use the fully qualified name React.${importName} instead of importing ${importName} directly.`
+  }))
+];
+
 export default tseslint.config(
   { ignores: ['eslint.config.mjs', '**/*.snap'] },
   eslint.configs.recommended,
@@ -77,6 +95,12 @@ export default tseslint.config(
         }
       ],
       'simple-import-sort/imports': 'error'
+    }
+  },
+  {
+    files: ['**/*.tsx', '**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', ...restrictedImports]
     }
   }
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,11 @@ const reactRestrictedImports = [
   'ReactNode',
   'ReactElement',
   'ComponentType',
-  'JSX'
+  'JSX',
+  'CSSProperties',
+  'MouseEvent',
+  'KeyboardEvent',
+  'RefObject'
 ];
 
 const restrictedImports = [

--- a/src/assets/PortSvg.tsx
+++ b/src/assets/PortSvg.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
   port: string;
 };

--- a/src/commons/ContentDisplay.tsx
+++ b/src/commons/ContentDisplay.tsx
@@ -1,9 +1,9 @@
 import { Card, Elevation } from '@blueprintjs/core';
-import React, { type JSX, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export type ContentDisplayProps = {
   fullWidth?: boolean;
-  display: JSX.Element;
+  display: React.ReactElement;
   loadContentDispatch?: () => void;
 };
 

--- a/src/commons/ControlButton.tsx
+++ b/src/commons/ControlButton.tsx
@@ -1,5 +1,4 @@
 import { AnchorButton, Button, Icon, IconName, Intent } from '@blueprintjs/core';
-import React from 'react';
 
 type ButtonOptions = {
   className: string;

--- a/src/commons/DateTimePickers/DatePicker.tsx
+++ b/src/commons/DateTimePickers/DatePicker.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, Divider, HTMLSelect } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Matcher } from 'react-day-picker';
 import {
   DayPicker,

--- a/src/commons/DateTimePickers/TimePicker.tsx
+++ b/src/commons/DateTimePickers/TimePicker.tsx
@@ -1,5 +1,4 @@
 import { NumericInput } from '@blueprintjs/core';
-import React from 'react';
 
 type TimePickerProps = {
   value?: Date;

--- a/src/commons/DateTimePickers/index.ts
+++ b/src/commons/DateTimePickers/index.ts
@@ -1,3 +1,3 @@
+export { default as DateInput } from './DateInput';
 export { default as DatePicker } from './DatePicker';
 export { default as TimePicker } from './TimePicker';
-export { default as DateInput } from './DateInput';

--- a/src/commons/Markdown.tsx
+++ b/src/commons/Markdown.tsx
@@ -1,6 +1,7 @@
 import { Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
+import { memo } from 'react';
 import { Converter } from 'showdown';
 
 type Props = {
@@ -34,4 +35,4 @@ const Markdown: React.FC<Props> = props => {
   );
 };
 
-export default React.memo(Markdown);
+export default memo(Markdown);

--- a/src/commons/Markdown.tsx
+++ b/src/commons/Markdown.tsx
@@ -1,7 +1,6 @@
 import { Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
-import React from 'react';
 import { Converter } from 'showdown';
 
 type Props = {

--- a/src/commons/ReactRouterPrompt.tsx
+++ b/src/commons/ReactRouterPrompt.tsx
@@ -7,7 +7,7 @@
  *
  * See: https://github.com/remix-run/react-router/issues/8139#issuecomment-1382428200
  */
-import React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useBeforeUnload, useBlocker } from 'react-router';
 
 // You can abstract `useBlocker` to use the browser's `window.confirm` dialog to
@@ -26,13 +26,10 @@ function usePrompt(
   { beforeUnload }: { beforeUnload?: boolean } = {}
 ) {
   const blocker = useBlocker(
-    React.useCallback(
-      () => (typeof message === 'string' ? !window.confirm(message) : false),
-      [message]
-    )
+    useCallback(() => (typeof message === 'string' ? !window.confirm(message) : false), [message])
   );
-  const prevState = React.useRef(blocker.state);
-  React.useEffect(() => {
+  const prevState = useRef(blocker.state);
+  useEffect(() => {
     if (blocker.state === 'blocked') {
       blocker.reset();
     }
@@ -40,7 +37,7 @@ function usePrompt(
   }, [blocker]);
 
   useBeforeUnload(
-    React.useCallback(
+    useCallback(
       event => {
         if (beforeUnload && typeof message === 'string') {
           event.preventDefault();

--- a/src/commons/WorkspaceSettingsContext.tsx
+++ b/src/commons/WorkspaceSettingsContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createContext, type Dispatch, type SetStateAction } from 'react';
 
 export enum EditorBinding {
   NONE = '',
@@ -19,6 +19,6 @@ export const defaultWorkspaceSettings: WorkspaceSettings = {
  *
  * The local storage state is initialized in Application.tsx via the useLocalStorageState hook.
  */
-export const WorkspaceSettingsContext = React.createContext<
-  [WorkspaceSettings, React.Dispatch<React.SetStateAction<WorkspaceSettings>>] | null
+export const WorkspaceSettingsContext = createContext<
+  [WorkspaceSettings, Dispatch<SetStateAction<WorkspaceSettings>>] | null
 >(null);

--- a/src/commons/achievement/AchievementCard.tsx
+++ b/src/commons/achievement/AchievementCard.tsx
@@ -1,6 +1,6 @@
 import { Icon, Intent, ProgressBar } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext, handleGlow } from 'src/features/achievement/AchievementConstants';
 
 import { AchievementStatus } from '../../features/achievement/AchievementTypes';

--- a/src/commons/achievement/AchievementCommentCard.tsx
+++ b/src/commons/achievement/AchievementCommentCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import classes from 'src/styles/AchievementCommentCard.module.scss';
 

--- a/src/commons/achievement/AchievementFilter.tsx
+++ b/src/commons/achievement/AchievementFilter.tsx
@@ -1,5 +1,4 @@
 import { Icon, IconName } from '@blueprintjs/core';
-import React from 'react';
 
 import { getFilterColor } from '../../features/achievement/AchievementConstants';
 import { FilterStatus } from '../../features/achievement/AchievementTypes';

--- a/src/commons/achievement/AchievementManualEditor.tsx
+++ b/src/commons/achievement/AchievementManualEditor.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, MenuItem, NumericInput } from '@blueprintjs/core';
 import { ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 import {
   AchievementGoal,

--- a/src/commons/achievement/AchievementOverview.tsx
+++ b/src/commons/achievement/AchievementOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { AchievementUser } from 'src/features/achievement/AchievementTypes';
 

--- a/src/commons/achievement/AchievementTask.tsx
+++ b/src/commons/achievement/AchievementTask.tsx
@@ -1,5 +1,5 @@
 import { Collapse } from '@blueprintjs/core';
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 
 import {
   AchievementContext,

--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {

--- a/src/commons/achievement/card/AchievementDeadline.tsx
+++ b/src/commons/achievement/card/AchievementDeadline.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { DeadlineColors } from '../../../features/achievement/AchievementConstants';
 import { isExpired, prettifyDeadline, timeFromExpired } from '../utils/DateHelper';

--- a/src/commons/achievement/card/AchievementXp.tsx
+++ b/src/commons/achievement/card/AchievementXp.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 const stringifyXp = (xp: number, isBonus: boolean) => {
   return (isBonus ? 'Total ' : '') + xp + ' XP';

--- a/src/commons/achievement/control/AchievementEditor.tsx
+++ b/src/commons/achievement/control/AchievementEditor.tsx
@@ -1,10 +1,10 @@
-import React, { type JSX, useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 
 import AchievementAdder from './achievementEditor/AchievementAdder';
 import EditableCard from './achievementEditor/EditableCard';
 
-let editableCards: JSX.Element[] = [];
+let editableCards: React.ReactElement[] = [];
 
 type Props = {
   requestPublish: () => void;

--- a/src/commons/achievement/control/AchievementPreview.tsx
+++ b/src/commons/achievement/control/AchievementPreview.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext, useReducer, useState } from 'react';
+import { useContext, useReducer, useState } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 import { FilterStatus } from 'src/features/achievement/AchievementTypes';
 import { generateAchievementTasks } from 'src/pages/achievement/subcomponents/AchievementDashboard';

--- a/src/commons/achievement/control/GoalEditor.tsx
+++ b/src/commons/achievement/control/GoalEditor.tsx
@@ -1,10 +1,10 @@
-import React, { type JSX, useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 
 import EditableGoal from './goalEditor/EditableGoal';
 import GoalAdder from './goalEditor/GoalAdder';
 
-let editableGoals: JSX.Element[] = [];
+let editableGoals: React.ReactElement[] = [];
 
 type Props = {
   requestPublish: () => void;

--- a/src/commons/achievement/control/achievementEditor/AchievementAdder.tsx
+++ b/src/commons/achievement/control/achievementEditor/AchievementAdder.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 
 import { achievementTemplate } from './AchievementTemplate';

--- a/src/commons/achievement/control/achievementEditor/AchievementSettings.tsx
+++ b/src/commons/achievement/control/achievementEditor/AchievementSettings.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Dialog, EditableText, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AchievementItem } from 'src/features/achievement/AchievementTypes';
 
 import EditableGoalUuids from './achievementSettings/EditableGoalUuids';

--- a/src/commons/achievement/control/achievementEditor/AchievementUuidCopier.tsx
+++ b/src/commons/achievement/control/achievementEditor/AchievementUuidCopier.tsx
@@ -1,6 +1,5 @@
 import { Button, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { showSuccessMessage } from 'src/commons/utils/notifications/NotificationsHelper';
 
 type Props = {

--- a/src/commons/achievement/control/achievementEditor/EditableCard.tsx
+++ b/src/commons/achievement/control/achievementEditor/EditableCard.tsx
@@ -1,7 +1,7 @@
 import { EditableText, NumericInput, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { cloneDeep } from 'lodash';
-import React, { useContext, useMemo, useReducer, useState } from 'react';
+import { useContext, useMemo, useReducer, useState } from 'react';
 
 import { AchievementContext } from '../../../../features/achievement/AchievementConstants';
 import {

--- a/src/commons/achievement/control/achievementEditor/EditableDate.tsx
+++ b/src/commons/achievement/control/achievementEditor/EditableDate.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { prettifyDate } from 'src/commons/achievement/utils/DateHelper';
 import { DatePicker } from 'src/commons/DateTimePickers';
 

--- a/src/commons/achievement/control/achievementEditor/EditableView.tsx
+++ b/src/commons/achievement/control/achievementEditor/EditableView.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, EditableText, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AchievementView } from 'src/features/achievement/AchievementTypes';
 
 type Props = {

--- a/src/commons/achievement/control/achievementEditor/achievementSettings/EditableGoalUuids.tsx
+++ b/src/commons/achievement/control/achievementEditor/achievementSettings/EditableGoalUuids.tsx
@@ -1,7 +1,7 @@
 import { MenuItem } from '@blueprintjs/core';
 import { ItemPredicate, ItemRenderer, MultiSelect } from '@blueprintjs/select';
 import { without } from 'lodash';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 import { AchievementGoal } from 'src/features/achievement/AchievementTypes';
 

--- a/src/commons/achievement/control/achievementEditor/achievementSettings/EditablePosition.tsx
+++ b/src/commons/achievement/control/achievementEditor/achievementSettings/EditablePosition.tsx
@@ -1,6 +1,6 @@
 import { Button, MenuItem } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 
 type Props = {

--- a/src/commons/achievement/control/achievementEditor/achievementSettings/EditablePrerequisiteUuids.tsx
+++ b/src/commons/achievement/control/achievementEditor/achievementSettings/EditablePrerequisiteUuids.tsx
@@ -1,7 +1,7 @@
 import { MenuItem } from '@blueprintjs/core';
 import { ItemPredicate, ItemRenderer, MultiSelect } from '@blueprintjs/select';
 import { without } from 'lodash';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 import { AchievementItem } from 'src/features/achievement/AchievementTypes';
 

--- a/src/commons/achievement/control/common/ItemDeleter.tsx
+++ b/src/commons/achievement/control/common/ItemDeleter.tsx
@@ -1,6 +1,5 @@
 import { Button, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { showSimpleConfirmDialog } from 'src/commons/utils/DialogHelper';
 
 type Props = {

--- a/src/commons/achievement/control/common/ItemSaver.tsx
+++ b/src/commons/achievement/control/common/ItemSaver.tsx
@@ -1,6 +1,5 @@
 import { Button, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import {
   showSuccessMessage,
   showWarningMessage

--- a/src/commons/achievement/control/goalEditor/EditableDate.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableDate.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { prettifyDate } from 'src/commons/achievement/utils/DateHelper';
 import { DatePicker } from 'src/commons/DateTimePickers';
 

--- a/src/commons/achievement/control/goalEditor/EditableGoal.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableGoal.tsx
@@ -1,6 +1,6 @@
 import { EditableText } from '@blueprintjs/core';
 import { cloneDeep } from 'lodash';
-import React, { useContext, useMemo, useReducer, useState } from 'react';
+import { useContext, useMemo, useReducer, useState } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 import { GoalDefinition, GoalMeta } from 'src/features/achievement/AchievementTypes';
 

--- a/src/commons/achievement/control/goalEditor/EditableMeta.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableMeta.tsx
@@ -1,6 +1,5 @@
 import { Button, MenuItem, Tooltip } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React from 'react';
 import {
   AssessmentMeta,
   BinaryMeta,

--- a/src/commons/achievement/control/goalEditor/EditableTime.tsx
+++ b/src/commons/achievement/control/goalEditor/EditableTime.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog, Tooltip } from '@blueprintjs/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { prettifyTime } from 'src/commons/achievement/utils/DateHelper';
 import { TimePicker } from 'src/commons/DateTimePickers';
 

--- a/src/commons/achievement/control/goalEditor/GoalAdder.tsx
+++ b/src/commons/achievement/control/goalEditor/GoalAdder.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { AchievementContext } from 'src/features/achievement/AchievementConstants';
 
 import { goalDefinitionTemplate } from './GoalTemplate';

--- a/src/commons/achievement/control/goalEditor/metaDetails/EditableAssessmentMeta.tsx
+++ b/src/commons/achievement/control/goalEditor/metaDetails/EditableAssessmentMeta.tsx
@@ -1,5 +1,4 @@
 import { NumericInput, Tooltip } from '@blueprintjs/core';
-import React from 'react';
 import { AssessmentMeta, GoalMeta } from 'src/features/achievement/AchievementTypes';
 
 type Props = {

--- a/src/commons/achievement/control/goalEditor/metaDetails/EditableBinaryMeta.tsx
+++ b/src/commons/achievement/control/goalEditor/metaDetails/EditableBinaryMeta.tsx
@@ -1,7 +1,6 @@
 import { Button, EditableText, MenuItem, NumericInput, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React from 'react';
 import { BinaryMeta, GoalMeta } from 'src/features/achievement/AchievementTypes';
 import { AND, BooleanExpression, OR } from 'src/features/achievement/ExpressionTypes';
 

--- a/src/commons/achievement/control/goalEditor/metaDetails/EditableEventMeta.tsx
+++ b/src/commons/achievement/control/goalEditor/metaDetails/EditableEventMeta.tsx
@@ -1,7 +1,6 @@
 import { Button, MenuItem, NumericInput, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React from 'react';
 import { EventMeta, EventType, GoalMeta } from 'src/features/achievement/AchievementTypes';
 
 import EditableDate from '../EditableDate';

--- a/src/commons/achievement/control/goalEditor/metaDetails/EditableManualMeta.tsx
+++ b/src/commons/achievement/control/goalEditor/metaDetails/EditableManualMeta.tsx
@@ -1,6 +1,5 @@
 import { NumericInput, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { GoalMeta, ManualMeta } from 'src/features/achievement/AchievementTypes';
 
 type Props = {

--- a/src/commons/achievement/overview/AchievementLevel.tsx
+++ b/src/commons/achievement/overview/AchievementLevel.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@blueprintjs/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { xpPerLevel } from '../../../features/achievement/AchievementConstants';
 import Constants from '../../utils/Constants';

--- a/src/commons/achievement/overview/AchievementMilestone.tsx
+++ b/src/commons/achievement/overview/AchievementMilestone.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Constants from '../../utils/Constants';
 
 type Props = {

--- a/src/commons/achievement/view/AchievementViewCompletion.tsx
+++ b/src/commons/achievement/view/AchievementViewCompletion.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
   awardedXp: number;
   completionText: string;

--- a/src/commons/achievement/view/AchievementViewGoal.tsx
+++ b/src/commons/achievement/view/AchievementViewGoal.tsx
@@ -1,5 +1,4 @@
 import { ProgressBar } from '@blueprintjs/core';
-import React from 'react';
 
 import { AchievementGoal } from '../../../features/achievement/AchievementTypes';
 

--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { Outlet } from 'react-router';
 import Messages, {
@@ -22,7 +22,7 @@ const Application: React.FC = () => {
   // Used in the mobile/PWA experience (e.g. separate handling of orientation changes on Andriod & iOS due to unique browser behaviours)
   const isMobile = /iPhone|iPad|Android/.test(navigator.userAgent);
   const isPWA = window.matchMedia('(display-mode: standalone)').matches; // Checks if user is accessing from the PWA
-  const browserDimensions = React.useRef({ height: 0, width: 0 });
+  const browserDimensions = useRef({ height: 0, width: 0 });
 
   const [workspaceSettings, setWorkspaceSettings] = useLocalStorageState(
     Constants.workspaceSettingsLocalStorageKey,
@@ -31,7 +31,7 @@ const Application: React.FC = () => {
 
   // Effect to fetch the latest user info and course configurations from the backend on refresh,
   // if the user was previously logged in
-  React.useEffect(() => {
+  useEffect(() => {
     if (isLoggedIn) {
       dispatch(SessionActions.fetchUserAndCourse());
     }
@@ -48,7 +48,7 @@ const Application: React.FC = () => {
    * does not update the application height when the Android keyboard triggers the resize event. IOS
    * devices are not affected.
    */
-  React.useEffect(() => {
+  useEffect(() => {
     const orientationChangeHandler = () => {
       if (
         !(
@@ -78,7 +78,7 @@ const Application: React.FC = () => {
   }, [isPWA, isMobile]);
 
   // Effect to handle messages from VS Code
-  React.useEffect(() => {
+  useEffect(() => {
     if (!window.confirm) {
       // Polyfill confirm() to instead show as VS Code notification
       // TODO: Pass text as a new Message to the webview

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -25,7 +25,7 @@ import type {
 import type { RouterState } from './types/CommonsTypes';
 import { ExternalLibraryName } from './types/ExternalTypes';
 import type { SessionState } from './types/SessionTypes';
-import type { VscodeState as VscodeState } from './types/VscodeTypes';
+import type { VscodeState } from './types/VscodeTypes';
 
 export type OverallState = {
   readonly router: RouterState;

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -13,7 +13,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { sortBy } from 'lodash';
-import React, { type JSX, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Navigate, useLoaderData, useParams } from 'react-router';
 import { numberRegExp } from 'src/features/academy/AcademyTypes';
@@ -144,7 +144,7 @@ const Assessment: React.FC = () => {
   }
 
   // Otherwise, render a list of assOwnProps
-  let display: JSX.Element;
+  let display: React.ReactElement;
   if (assessmentOverviews === undefined) {
     display = <NonIdealState description="Fetching assessment..." icon={<Spinner />} />;
   } else if (assessmentOverviews.length === 0) {

--- a/src/commons/assessment/AssessmentOverviewCard.tsx
+++ b/src/commons/assessment/AssessmentOverviewCard.tsx
@@ -1,7 +1,6 @@
 import { Card, Elevation, H4, H6, Icon, Intent, Position, Text, Tooltip } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { JSX } from 'react';
 import classes from 'src/styles/Academy.module.scss';
 
 import defaultCoverImage from '../../assets/default_cover_image.jpg';
@@ -19,7 +18,7 @@ type AssessmentOverviewCardProps = {
   /** Will only render the attempt button if true, regardless of attempt status. */
   renderAttemptButton: boolean;
   renderGradingTooltip: boolean;
-  makeSubmissionButton: (overview: AssessmentOverview) => JSX.Element;
+  makeSubmissionButton: (overview: AssessmentOverview) => React.ReactElement;
 };
 
 /** A card to display `AssessmentOverview`s. */
@@ -105,7 +104,7 @@ const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
 type AssessmentOverviewCardTitleProps = {
   overview: AssessmentOverview;
   renderProgressStatus: boolean;
-  makeSubmissionButton: (overview: AssessmentOverview) => JSX.Element;
+  makeSubmissionButton: (overview: AssessmentOverview) => React.ReactElement;
 };
 
 const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = ({

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -14,7 +14,7 @@ import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import { isEqual } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import { showSimpleConfirmDialog } from 'src/commons/utils/DialogHelper';

--- a/src/commons/assessmentWorkspace/AssessmentWorkspaceGradingResult.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspaceGradingResult.tsx
@@ -1,5 +1,4 @@
 import { Divider, HTMLTable, Text } from '@blueprintjs/core';
-import React from 'react';
 
 import Markdown from '../Markdown';
 import { getPrettyDate } from '../utils/DateHelper';

--- a/src/commons/controlBar/AceDiffViewer.tsx
+++ b/src/commons/controlBar/AceDiffViewer.tsx
@@ -5,7 +5,7 @@ import 'ace-diff/styles.css';
 
 import * as ace from 'ace-builds';
 import AceDiff from 'ace-diff';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 // Disable ace web workers globally (only needs to run once per module load)
 (ace.config as any).set('useWorker', false);

--- a/src/commons/controlBar/ControlBar.tsx
+++ b/src/commons/controlBar/ControlBar.tsx
@@ -1,11 +1,10 @@
 import { Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { type JSX } from 'react';
 
 export type ControlBarProps = {
-  editorButtons: Array<JSX.Element | null>;
-  flowButtons?: Array<JSX.Element | null>;
-  editingWorkspaceButtons?: Array<JSX.Element | null>;
+  editorButtons: Array<React.ReactElement | null>;
+  flowButtons?: Array<React.ReactElement | null>;
+  editingWorkspaceButtons?: Array<React.ReactElement | null>;
 };
 
 const ControlBar: React.FC<ControlBarProps> = props => {

--- a/src/commons/controlBar/ControlBarAutorunButtons.tsx
+++ b/src/commons/controlBar/ControlBarAutorunButtons.tsx
@@ -1,6 +1,5 @@
 import { Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { flagConductorEnable } from '../../features/conductor/flagConductorEnable';
 import ControlButton from '../ControlButton';

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -3,7 +3,6 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
 import { IEvaluatorDefinition } from '@sourceacademy/language-directory/dist/types';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import { flagConductorEnable } from '../../features/conductor/flagConductorEnable';

--- a/src/commons/controlBar/ControlBarClearButton.tsx
+++ b/src/commons/controlBar/ControlBarClearButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarCloseButton.tsx
+++ b/src/commons/controlBar/ControlBarCloseButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarEvalButton.tsx
+++ b/src/commons/controlBar/ControlBarEvalButton.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { flagConductorEnable } from '../../features/conductor/flagConductorEnable';
 import ControlButton from '../ControlButton';

--- a/src/commons/controlBar/ControlBarExecutionTime.tsx
+++ b/src/commons/controlBar/ControlBarExecutionTime.tsx
@@ -1,6 +1,5 @@
 import { NumericInput, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 type ControlBarExecutionTimeProps = DispatchProps & StateProps;
 

--- a/src/commons/controlBar/ControlBarGoogleDriveButtons.tsx
+++ b/src/commons/controlBar/ControlBarGoogleDriveButtons.tsx
@@ -1,6 +1,5 @@
 import { ButtonGroup, Classes, Intent, Popover, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { PersistenceFile, PersistenceState } from '../../features/persistence/PersistenceTypes';
 import ControlButton from '../ControlButton';

--- a/src/commons/controlBar/ControlBarNextButton.tsx
+++ b/src/commons/controlBar/ControlBarNextButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 import { ControlBarReturnToAcademyButton } from './ControlBarReturnToAcademyButton';

--- a/src/commons/controlBar/ControlBarPreviousButton.tsx
+++ b/src/commons/controlBar/ControlBarPreviousButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarQuestionViewButton.tsx
+++ b/src/commons/controlBar/ControlBarQuestionViewButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ControlButton from '../ControlButton';
 
 /**

--- a/src/commons/controlBar/ControlBarResetButton.tsx
+++ b/src/commons/controlBar/ControlBarResetButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarReturnToAcademyButton.tsx
+++ b/src/commons/controlBar/ControlBarReturnToAcademyButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarRunButton.tsx
+++ b/src/commons/controlBar/ControlBarRunButton.tsx
@@ -1,6 +1,5 @@
 import { Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarSaveButton.tsx
+++ b/src/commons/controlBar/ControlBarSaveButton.tsx
@@ -1,6 +1,5 @@
 import { Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarSaveStatusIndicator.tsx
+++ b/src/commons/controlBar/ControlBarSaveStatusIndicator.tsx
@@ -1,6 +1,5 @@
 import { Intent, type MaybeElement, Spinner, SpinnerSize, Tag } from '@blueprintjs/core';
 import { type IconName, IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import type { SaveStatus } from '../workspace/WorkspaceTypes';
 

--- a/src/commons/controlBar/ControlBarSessionButton.tsx
+++ b/src/commons/controlBar/ControlBarSessionButton.tsx
@@ -1,6 +1,6 @@
 import { Classes, Colors, Divider, FormGroup, Popover, Text, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import CopyToClipboard from 'src/commons/utils/CopyToClipboard';
 

--- a/src/commons/controlBar/ControlBarShareButton.tsx
+++ b/src/commons/controlBar/ControlBarShareButton.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { createRef, PureComponent, type RefObject } from 'react';
+import { createRef, PureComponent } from 'react';
 import CopyToClipboard from 'src/commons/utils/CopyToClipboard';
 
 import ControlButton from '../ControlButton';
@@ -35,7 +35,7 @@ type State = {
 };
 
 export class ControlBarShareButton extends PureComponent<ControlBarShareButtonProps, State> {
-  private shareInputElem: RefObject<HTMLInputElement | null>;
+  private shareInputElem: React.RefObject<HTMLInputElement | null>;
 
   constructor(props: ControlBarShareButtonProps) {
     super(props);

--- a/src/commons/controlBar/ControlBarShareButton.tsx
+++ b/src/commons/controlBar/ControlBarShareButton.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
+import { createRef, PureComponent, type RefObject } from 'react';
 import CopyToClipboard from 'src/commons/utils/CopyToClipboard';
 
 import ControlButton from '../ControlButton';
@@ -34,15 +34,15 @@ type State = {
   isLoading: boolean;
 };
 
-export class ControlBarShareButton extends React.PureComponent<ControlBarShareButtonProps, State> {
-  private shareInputElem: React.RefObject<HTMLInputElement | null>;
+export class ControlBarShareButton extends PureComponent<ControlBarShareButtonProps, State> {
+  private shareInputElem: RefObject<HTMLInputElement | null>;
 
   constructor(props: ControlBarShareButtonProps) {
     super(props);
     this.selectShareInputText = this.selectShareInputText.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.toggleButton = this.toggleButton.bind(this);
-    this.shareInputElem = React.createRef();
+    this.shareInputElem = createRef();
     this.state = { keyword: '', isLoading: false };
   }
 

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -1,6 +1,5 @@
 import { NumericInput, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 type ControlBarStepLimitProps = DispatchProps & StateProps;
 

--- a/src/commons/controlBar/ControlBarSubmit.tsx
+++ b/src/commons/controlBar/ControlBarSubmit.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarToggleEditModeButton.tsx
+++ b/src/commons/controlBar/ControlBarToggleEditModeButton.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
+++ b/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
@@ -1,6 +1,5 @@
 import { Colors, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/ControlBarVersionHistoryButton.tsx
+++ b/src/commons/controlBar/ControlBarVersionHistoryButton.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import ControlButton from '../ControlButton';
 

--- a/src/commons/controlBar/LegacyControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/LegacyControlBarChapterSelect.tsx
@@ -2,7 +2,6 @@ import { Button, Menu, MenuItem, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React from 'react';
 
 import {
   fullJSLanguage,

--- a/src/commons/controlBar/VersionHistoryPanel.tsx
+++ b/src/commons/controlBar/VersionHistoryPanel.tsx
@@ -10,7 +10,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import styles from '../../styles/VersionHistoryPanel.module.scss';
 import type { CodeVersion, CodeVersionMetadata } from '../workspace/WorkspaceTypes';

--- a/src/commons/controlBar/github/ControlBarGitHubButtons.tsx
+++ b/src/commons/controlBar/github/ControlBarGitHubButtons.tsx
@@ -1,7 +1,6 @@
 import { ButtonGroup, Classes, Intent, Popover, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Octokit } from '@octokit/rest';
-import React from 'react';
 import { useResponsive } from 'src/commons/utils/Hooks';
 
 import { GitHubSaveInfo } from '../../../features/github/GitHubTypes';

--- a/src/commons/delay/Delay.tsx
+++ b/src/commons/delay/Delay.tsx
@@ -1,7 +1,7 @@
-import { type JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type Props = {
-  children: JSX.Element;
+  children: React.ReactElement;
   waitInMsBeforeRender: number;
 };
 

--- a/src/commons/delay/Delay.tsx
+++ b/src/commons/delay/Delay.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX } from 'react';
+import { type JSX, useEffect, useState } from 'react';
 
 type Props = {
   children: JSX.Element;
@@ -9,9 +9,9 @@ type Props = {
  * Delays the rendering of child components by a set time.
  */
 const Delay: React.FC<Props> = ({ children, waitInMsBeforeRender }) => {
-  const [isRendered, setIsRendered] = React.useState(false);
+  const [isRendered, setIsRendered] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const timeoutId = setTimeout(() => setIsRendered(true), waitInMsBeforeRender);
     return () => clearTimeout(timeoutId);
   }, [waitInMsBeforeRender]);

--- a/src/commons/dialogs/ConfirmDialog.tsx
+++ b/src/commons/dialogs/ConfirmDialog.tsx
@@ -10,7 +10,6 @@ import {
   Intent
 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
 import classes from 'src/styles/ConfirmDialog.module.scss';
 
 export interface ConfirmDialogProps<T> {

--- a/src/commons/dialogs/PromptDialog.tsx
+++ b/src/commons/dialogs/PromptDialog.tsx
@@ -1,5 +1,5 @@
 import { InputGroup, Intent } from '@blueprintjs/core';
-import React from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ConfirmDialog, ConfirmDialogProps } from './ConfirmDialog';
 
@@ -18,11 +18,11 @@ export function PromptDialog<T>(
   props: PromptDialogProps<T>
 ): React.ReactElement<PromptDialogProps<T>> {
   const { enterResponse, validationFunction } = props;
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const [isValid, setIsValid] = React.useState(
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isValid, setIsValid] = useState(
     !validationFunction || validationFunction(props.defaultValue || '')
   );
-  React.useEffect(() => {
+  useEffect(() => {
     if (!inputRef.current) {
       return;
     }

--- a/src/commons/dropdown/Dropdown.tsx
+++ b/src/commons/dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 

--- a/src/commons/dropdown/DropdownAbout.tsx
+++ b/src/commons/dropdown/DropdownAbout.tsx
@@ -1,6 +1,5 @@
 import { Dialog, DialogBody } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { Links } from '../utils/Constants';
 

--- a/src/commons/dropdown/DropdownCourses.tsx
+++ b/src/commons/dropdown/DropdownCourses.tsx
@@ -1,6 +1,5 @@
 import { Dialog, DialogBody, HTMLSelect } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { useNavigate } from 'react-router';
 
 import { Role } from '../application/ApplicationTypes';

--- a/src/commons/dropdown/DropdownCreateCourse.tsx
+++ b/src/commons/dropdown/DropdownCreateCourse.tsx
@@ -14,7 +14,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AcademyActions from 'src/features/academy/AcademyActions';
 
@@ -32,7 +32,7 @@ type Props = {
 const DropdownCreateCourse = (props => {
   const dispatch = useDispatch();
 
-  const [courseConfig, setCourseConfig] = React.useState<UpdateCourseConfiguration>({
+  const [courseConfig, setCourseConfig] = useState<UpdateCourseConfiguration>({
     courseName: '',
     courseShortName: '',
     viewable: true,
@@ -47,7 +47,7 @@ const DropdownCreateCourse = (props => {
   });
 
   const [courseHelpTextSelectedTab, setCourseHelpTextSelectedTab] =
-    React.useState<CourseHelpTextEditorTab>(CourseHelpTextEditorTab.WRITE);
+    useState<CourseHelpTextEditorTab>(CourseHelpTextEditorTab.WRITE);
 
   const sourceChapterOptions = [
     { value: Chapter.SOURCE_1 },
@@ -76,7 +76,7 @@ const DropdownCreateCourse = (props => {
     props.onClose();
   };
 
-  const onChangeTabs = React.useCallback(
+  const onChangeTabs = useCallback(
     (
       newTabId: CourseHelpTextEditorTab,
       prevTabId: CourseHelpTextEditorTab,

--- a/src/commons/dropdown/DropdownHelp.tsx
+++ b/src/commons/dropdown/DropdownHelp.tsx
@@ -1,6 +1,5 @@
 import { Dialog, DialogBody } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import Markdown from '../Markdown';
 import { Links } from '../utils/Constants';

--- a/src/commons/dropdown/DropdownSettings.tsx
+++ b/src/commons/dropdown/DropdownSettings.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 
 import { EditorBinding, WorkspaceSettingsContext } from '../WorkspaceSettingsContext';

--- a/src/commons/editingOverviewCard/EditingOverviewCard.tsx
+++ b/src/commons/editingOverviewCard/EditingOverviewCard.tsx
@@ -15,7 +15,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { NavLink } from 'react-router';
 import Textarea from 'react-textarea-autosize';
 

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -11,7 +11,7 @@ import {
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentAutograderTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentAutograderTab.tsx
@@ -1,6 +1,5 @@
 import { Card, Elevation, H6 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import {
   Assessment,

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentDeploymentTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentDeploymentTab.tsx
@@ -2,7 +2,6 @@ import { Button, Classes, Divider, MenuItem, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React from 'react';
 
 import { SALanguage, sourceLanguages, styliseSublanguage } from '../application/ApplicationTypes';
 import {
@@ -65,7 +64,7 @@ const DeploymentTab: React.FC<DeploymentTabProps> = props => {
     );
 
     const symbolsFragment = (
-      <React.Fragment>
+      <>
         External Library:
         <br />
         {externalSelect(deployment.external.name, handleExternalSelect)}
@@ -76,18 +75,18 @@ const DeploymentTab: React.FC<DeploymentTabProps> = props => {
           <tbody>{symbols}</tbody>
         </table>
         <ControlButton label="New Symbol" icon={IconNames.PLUS} onClick={handleNewSymbol} />
-      </React.Fragment>
+      </>
     );
 
     const globalsFragment = (
-      <React.Fragment>
+      <>
         <div>Globals:</div>
         <br />
         <table style={{ width: '100%', borderSpacing: '5px' }}>
           <tbody>{globals}</tbody>
         </table>
         <ControlButton label="New Global" icon={IconNames.PLUS} onClick={handleNewGlobal} />
-      </React.Fragment>
+      </>
     );
 
     return (

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentGradingTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentGradingTab.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Assessment } from '../assessment/AssessmentTypes';
 import { limitNumberRange } from './EditingWorkspaceSideContentHelper';
 import TextAreaContent from './EditingWorkspaceSideContentTextAreaContent';

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentManageQuestionTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentManageQuestionTab.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, DialogBody, DialogFooter, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { Assessment, mcqTemplate, programmingTemplate } from '../assessment/AssessmentTypes';

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentMcqQuestionTemplateTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentMcqQuestionTemplateTab.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 
 import { Assessment, IMCQQuestion } from '../assessment/AssessmentTypes';
 import ControlButton from '../ControlButton';

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentProgrammingQuestionTemplateTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentProgrammingQuestionTemplateTab.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Classes, Divider, IconName, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import AceEditor from 'react-ace';
 
 import { Assessment } from '../assessment/AssessmentTypes';

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentTextAreaContent.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentTextAreaContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Textarea from 'react-textarea-autosize';
 
 import { Assessment } from '../assessment/AssessmentTypes';

--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -22,25 +22,25 @@ import { Card } from '@blueprintjs/core';
 import * as AceBuilds from 'ace-builds';
 import { Ace, require as acequire, createEditSession } from 'ace-builds';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import AceEditor, { IAceEditorProps, IEditorProps } from 'react-ace';
 import { IAceEditor } from 'react-ace/lib/types';
 import { SALanguage } from '../application/ApplicationTypes';
-import { EditorBinding } from '../WorkspaceSettingsContext';
 import { getModeString, selectMode } from '../utils/AceHelper';
 import { objectEntries } from '../utils/TypeHelper';
+import { EditorBinding } from '../WorkspaceSettingsContext';
 import { KeyFunction, keyBindings } from './EditorHotkeys';
 import { AceMouseEvent, HighlightedLines, Position } from './EditorTypes';
 
 // =============== Hooks ===============
 // TODO: Should further refactor into EditorBase + different variants.
 // Ideally, hooks should be specified by the parent component instead.
+import type { SharedbAceUser } from '@sourceacademy/sharedb-ace/types';
+import { ExternalLibraryName } from '../application/types/ExternalTypes';
 import useHighlighting from './UseHighlighting';
 import useNavigation from './UseNavigation';
 import useRefactor from './UseRefactor';
 import useShareAce from './UseShareAce';
-import type { SharedbAceUser } from '@sourceacademy/sharedb-ace/types';
-import { ExternalLibraryName } from '../application/types/ExternalTypes';
 
 export type EditorKeyBindingHandlers = { [name in KeyFunction]?: () => void };
 export type EditorHook = (
@@ -345,13 +345,13 @@ const moveCursor = (editor: AceEditor['editor'], position: Position) => {
   editor.renderer.scrollCursorIntoView(position, 0.5);
 };
 
-const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
-  const reactAceRef: React.MutableRefObject<AceEditor | null> = React.useRef(null);
-  const [filePath, setFilePath] = React.useState<string | undefined>(undefined);
+const EditorBase = memo((props: EditorProps & LocalStateProps) => {
+  const reactAceRef: React.MutableRefObject<AceEditor | null> = useRef(null);
+  const [filePath, setFilePath] = useState<string | undefined>(undefined);
 
   // Refs for things that technically shouldn't change... but just in case.
-  const handleEditorUpdateBreakpointsRef = React.useRef(props.handleEditorUpdateBreakpoints);
-  const handlePromptAutocompleteRef = React.useRef(props.handlePromptAutocomplete);
+  const handleEditorUpdateBreakpointsRef = useRef(props.handleEditorUpdateBreakpoints);
+  const handlePromptAutocompleteRef = useRef(props.handlePromptAutocomplete);
 
   const editor = reactAceRef.current?.editor;
   // Set edit session history when switching to another editor tab.
@@ -374,12 +374,12 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     handleEditorUpdateBreakpointsRef.current = props.handleEditorUpdateBreakpoints;
     handlePromptAutocompleteRef.current = props.handlePromptAutocomplete;
   }, [props.handleEditorUpdateBreakpoints, props.handlePromptAutocomplete]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (editor === undefined) {
       return;
     }
@@ -387,7 +387,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   }, [editor, props.breakpoints]);
 
   // Handles input into AceEditor causing app to scroll to the top on iOS Safari
-  React.useEffect(() => {
+  useEffect(() => {
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent);
     if (isIOS) {
       document.body.style.position = 'fixed';
@@ -416,7 +416,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   // unconditionally.
   selectMode(sourceChapter, sourceVariant, externalLibraryName);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (editor === undefined) {
       return;
     }
@@ -446,7 +446,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     }
   }, [editor, props.sourceChapter, props.editorTabIndex]);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (editor === undefined) {
       return;
     }
@@ -462,7 +462,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     isEditorAutorun,
     handleEditorEval
   } = props;
-  const handleEditorEvalRef = React.useRef(handleEditorEval);
+  const handleEditorEvalRef = useRef(handleEditorEval);
   handleEditorEvalRef.current = handleEditorEval;
 
   const keyHandlers: EditorKeyBindingHandlers = {
@@ -476,7 +476,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     editorProps: {
       $blockScrolling: Infinity
     },
-    markers: React.useMemo(() => getMarkers(props.highlightedLines), [props.highlightedLines]),
+    markers: useMemo(() => getMarkers(props.highlightedLines), [props.highlightedLines]),
     fontSize: 17,
     height: '100%',
     highlightActiveLine: false,
@@ -494,7 +494,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
 
   // Hooks must not change after an editor is instantiated, so to prevent that
   // we store the original value and always use that only
-  const [hooks] = React.useState(props.hooks);
+  const [hooks] = useState(props.hooks);
   if (hooks) {
     // Note: the following is extremely non-standard use of hooks
     // DO NOT refactor this into any form where the hook is called from a lambda
@@ -505,7 +505,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
 
   const { onChange } = aceEditorProps;
 
-  aceEditorProps.onChange = React.useCallback(
+  aceEditorProps.onChange = useCallback(
     (newCode: string, delta: Ace.Delta) => {
       if (!reactAceRef.current) {
         return;
@@ -645,7 +645,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   };
 
   // Remove the overlay div when the editor is unmounted
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       const div = document.getElementById('overlay');
       if (div) {
@@ -668,7 +668,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
 const hooks = [useHighlighting, useNavigation, useShareAce, useRefactor];
 
 const Editor: React.FC<EditorProps> = (props: EditorProps) => {
-  const [sessions, setSessions] = React.useState<Record<string, Ace.EditSession>>({});
+  const [sessions, setSessions] = useState<Record<string, Ace.EditSession>>({});
 
   // Create new edit session.
   const defaultMode = acequire('ace/mode/javascript').Mode();

--- a/src/commons/editor/EditorContainer.tsx
+++ b/src/commons/editor/EditorContainer.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import { useContext } from 'react';
 
 import { EditorTabState } from '../workspace/WorkspaceTypes';
 import { WorkspaceSettingsContext } from '../WorkspaceSettingsContext';
@@ -40,7 +40,7 @@ const createNormalEditorTab =
   };
 
 const EditorContainer: React.FC<EditorContainerProps> = (props: EditorContainerProps) => {
-  const [workspaceSettings] = React.useContext(WorkspaceSettingsContext)!;
+  const [workspaceSettings] = useContext(WorkspaceSettingsContext)!;
   const {
     baseFilePath,
     isFolderModeEnabled,

--- a/src/commons/editor/UseHighlighting.tsx
+++ b/src/commons/editor/UseHighlighting.tsx
@@ -1,15 +1,15 @@
 import { Ace, Range as AceRange } from 'ace-builds';
 import { createContext, getAllOccurrencesInScope, getScope } from 'js-slang';
-import React from 'react';
+import { useCallback, useRef } from 'react';
 
 import { EditorHook } from './Editor';
 
 const useHighlighting: EditorHook = (inProps, outProps, keyBindings, reactAceRef) => {
-  const propsRef = React.useRef(inProps);
+  const propsRef = useRef(inProps);
   propsRef.current = inProps;
-  const markerIdsRef = React.useRef<Array<number>>([]);
+  const markerIdsRef = useRef<Array<number>>([]);
 
-  const handleVariableHighlighting = React.useCallback(() => {
+  const handleVariableHighlighting = useCallback(() => {
     // using Ace Editor's way of highlighting as seen here: https://github.com/ajaxorg/ace/blob/master/lib/ace/editor.js#L497
     // We use async blocks so we don't block the browser during editing
 
@@ -43,7 +43,7 @@ const useHighlighting: EditorHook = (inProps, outProps, keyBindings, reactAceRef
     }, 10);
   }, [reactAceRef]);
 
-  const handleHighlightScope = React.useCallback(() => {
+  const handleHighlightScope = useCallback(() => {
     if (!reactAceRef.current) {
       return;
     }
@@ -77,14 +77,14 @@ const useHighlighting: EditorHook = (inProps, outProps, keyBindings, reactAceRef
   }, [reactAceRef]);
 
   const { onChange: prevOnChange, onCursorChange: prevOnCursorChange } = outProps;
-  outProps.onChange = React.useCallback(
+  outProps.onChange = useCallback(
     (value: string, event?: any) => {
       handleVariableHighlighting();
       prevOnChange?.(value, event);
     },
     [handleVariableHighlighting, prevOnChange]
   );
-  outProps.onCursorChange = React.useCallback(
+  outProps.onCursorChange = useCallback(
     (value: any, event?: any) => {
       handleVariableHighlighting();
       prevOnCursorChange?.(value, event);

--- a/src/commons/editor/UseNavigation.tsx
+++ b/src/commons/editor/UseNavigation.tsx
@@ -1,6 +1,6 @@
 import { createContext, hasDeclaration } from 'js-slang';
 import { Variant } from 'js-slang/dist/langs';
-import React from 'react';
+import { useCallback, useRef } from 'react';
 
 import { Documentation } from '../documentation/Documentation';
 import { Links } from '../utils/Constants';
@@ -14,10 +14,10 @@ import { EditorHook } from './Editor';
 // reactAceRef is the underlying reactAce instance for hooking.
 
 const useNavigation: EditorHook = (inProps, outProps, keyBindings, reactAceRef) => {
-  const propsRef = React.useRef(inProps);
+  const propsRef = useRef(inProps);
   propsRef.current = inProps;
 
-  const handleNavigate = React.useCallback(() => {
+  const handleNavigate = useCallback(() => {
     const editor = reactAceRef.current!.editor;
     const pos = editor.selection.getCursor();
     const token = editor.session.getTokenAt(pos.row, pos.column);

--- a/src/commons/editor/UseRefactor.tsx
+++ b/src/commons/editor/UseRefactor.tsx
@@ -1,6 +1,6 @@
 import { Range } from 'ace-builds';
 import { createContext, getAllOccurrencesInScope } from 'js-slang';
-import React from 'react';
+import { useCallback } from 'react';
 
 import { EditorHook } from './Editor';
 
@@ -14,7 +14,7 @@ import { EditorHook } from './Editor';
 const useRefactor: EditorHook = (inProps, outProps, keyBindings, reactAceRef) => {
   const { sourceChapter } = inProps;
 
-  const refactor = React.useCallback(() => {
+  const refactor = useCallback(() => {
     const editor = reactAceRef.current!.editor;
     if (!editor) {
       return;

--- a/src/commons/editor/UseShareAce.tsx
+++ b/src/commons/editor/UseShareAce.tsx
@@ -9,7 +9,7 @@ import * as Sentry from '@sentry/react';
 import sharedbAce from '@sourceacademy/sharedb-ace';
 import type SharedbAceBinding from '@sourceacademy/sharedb-ace/binding';
 import { CollabEditingAccess } from '@sourceacademy/sharedb-ace/types';
-import React from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { getLanguageConfig } from '../application/ApplicationTypes';
@@ -32,14 +32,14 @@ const color = getColor();
 const useShareAce: EditorHook = (inProps, outProps, keyBindings, reactAceRef) => {
   // use a ref to refer to any other props so that we run the effect below
   // *only* when the editorSessionId or sessionDetails changes
-  const propsRef = React.useRef(inProps);
+  const propsRef = useRef(inProps);
   propsRef.current = inProps;
 
   const { editorSessionId, sessionDetails } = inProps;
   const { name, userId } = useSession();
   const dispatch = useDispatch();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!editorSessionId || !sessionDetails) {
       return;
     }

--- a/src/commons/editor/tabs/EditorTab.tsx
+++ b/src/commons/editor/tabs/EditorTab.tsx
@@ -1,7 +1,6 @@
 import { Card, Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React from 'react';
 
 type Props = {
   filePath: string;

--- a/src/commons/editor/tabs/EditorTabContainer.tsx
+++ b/src/commons/editor/tabs/EditorTabContainer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import EditorTab from './EditorTab';
 import { getShortestUniqueFilePaths } from './utils';
 

--- a/src/commons/fileSystemView/FileSystemView.tsx
+++ b/src/commons/fileSystemView/FileSystemView.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import path from 'path';
-import React from 'react';
+import { useState } from 'react';
 import classes from 'src/styles/FileSystemView.module.scss';
 
 import { showSimpleErrorDialog } from '../utils/DialogHelper';
@@ -20,9 +20,9 @@ type Props = {
 const FileSystemView: React.FC<Props> = ({ workspaceLocation, basePath }) => {
   const fileSystem = useTypedSelector(state => state.fileSystem.inBrowserFileSystem);
 
-  const [isAddingNewFile, setIsAddingNewFile] = React.useState(false);
-  const [isAddingNewDirectory, setIsAddingNewDirectory] = React.useState(false);
-  const [fileSystemViewListKey, setFileSystemViewListKey] = React.useState(0);
+  const [isAddingNewFile, setIsAddingNewFile] = useState(false);
+  const [isAddingNewDirectory, setIsAddingNewDirectory] = useState(false);
+  const [fileSystemViewListKey, setFileSystemViewListKey] = useState(0);
 
   const handleCreateNewFile = () => setIsAddingNewFile(true);
   const handleCreateNewDirectory = () => setIsAddingNewDirectory(true);

--- a/src/commons/fileSystemView/FileSystemViewContextMenu.tsx
+++ b/src/commons/fileSystemView/FileSystemViewContextMenu.tsx
@@ -1,7 +1,7 @@
 import { Classes } from '@blueprintjs/core';
 import { ControlledMenu, MenuItem, useMenuState } from '@szhsin/react-menu';
 import classNames from 'classnames';
-import React, { type JSX } from 'react';
+import { type JSX, useState } from 'react';
 import classes from 'src/styles/ContextMenu.module.scss';
 
 type Props = {
@@ -24,7 +24,7 @@ const FileSystemViewContextMenu: React.FC<Props> = ({
   remove
 }) => {
   const [menuProps, toggleMenu] = useMenuState();
-  const [anchorPoint, setAnchorPoint] = React.useState({ x: 0, y: 0 });
+  const [anchorPoint, setAnchorPoint] = useState({ x: 0, y: 0 });
 
   const onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();

--- a/src/commons/fileSystemView/FileSystemViewContextMenu.tsx
+++ b/src/commons/fileSystemView/FileSystemViewContextMenu.tsx
@@ -1,11 +1,11 @@
 import { Classes } from '@blueprintjs/core';
 import { ControlledMenu, MenuItem, useMenuState } from '@szhsin/react-menu';
 import classNames from 'classnames';
-import { type JSX, useState } from 'react';
+import { useState } from 'react';
 import classes from 'src/styles/ContextMenu.module.scss';
 
 type Props = {
-  children?: JSX.Element;
+  children?: React.ReactElement;
   className?: string;
   createNewFile?: () => void;
   createNewDirectory?: () => void;

--- a/src/commons/fileSystemView/FileSystemViewDirectoryNode.tsx
+++ b/src/commons/fileSystemView/FileSystemViewDirectoryNode.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { FSModule } from 'browserfs/dist/node/core/FS';
 import path from 'path';
-import React from 'react';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classes from 'src/styles/FileSystemView.module.scss';
 
@@ -35,11 +35,11 @@ const FileSystemViewDirectoryNode: React.FC<Props> = ({
 }) => {
   const fullPath = path.join(basePath, directoryName);
 
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const [isEditing, setIsEditing] = React.useState(false);
-  const [isAddingNewFile, setIsAddingNewFile] = React.useState(false);
-  const [isAddingNewDirectory, setIsAddingNewDirectory] = React.useState(false);
-  const [fileSystemViewListKey, setFileSystemViewListKey] = React.useState(0);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isAddingNewFile, setIsAddingNewFile] = useState(false);
+  const [isAddingNewDirectory, setIsAddingNewDirectory] = useState(false);
+  const [fileSystemViewListKey, setFileSystemViewListKey] = useState(0);
   const dispatch = useDispatch();
 
   const toggleIsExpanded = () => {

--- a/src/commons/fileSystemView/FileSystemViewFileName.tsx
+++ b/src/commons/fileSystemView/FileSystemViewFileName.tsx
@@ -1,6 +1,6 @@
 import { FSModule } from 'browserfs/dist/node/core/FS';
 import path from 'path';
-import React from 'react';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classes from 'src/styles/FileSystemView.module.scss';
 
@@ -29,7 +29,7 @@ const FileSystemViewFileName: React.FC<Props> = ({
   setIsEditing,
   refreshDirectory
 }) => {
-  const [editedFileName, setEditedFileName] = React.useState(fileName);
+  const [editedFileName, setEditedFileName] = useState(fileName);
   const dispatch = useDispatch();
 
   const handleInputOnChange = (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/commons/fileSystemView/FileSystemViewFileNode.tsx
+++ b/src/commons/fileSystemView/FileSystemViewFileNode.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { FSModule } from 'browserfs/dist/node/core/FS';
 import path from 'path';
-import React from 'react';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classes from 'src/styles/FileSystemView.module.scss';
 
@@ -30,7 +30,7 @@ const FileSystemViewFileNode: React.FC<Props> = ({
   indentationLevel,
   refreshDirectory
 }) => {
-  const [isEditing, setIsEditing] = React.useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const dispatch = useDispatch();
 
   const fullPath = path.join(basePath, fileName);

--- a/src/commons/fileSystemView/FileSystemViewIndentationPadding.tsx
+++ b/src/commons/fileSystemView/FileSystemViewIndentationPadding.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
   indentationLevel: number;
 };

--- a/src/commons/fileSystemView/FileSystemViewList.tsx
+++ b/src/commons/fileSystemView/FileSystemViewList.tsx
@@ -1,7 +1,7 @@
 import { Spinner, SpinnerSize } from '@blueprintjs/core';
 import { FSModule } from 'browserfs/dist/node/core/FS';
 import path from 'path';
-import React from 'react';
+import { useEffect, useState } from 'react';
 import classes from 'src/styles/FileSystemView.module.scss';
 
 import Delay from '../delay/Delay';
@@ -22,8 +22,8 @@ const FileSystemViewList: React.FC<Props> = ({
   basePath,
   indentationLevel
 }) => {
-  const [dirNames, setDirNames] = React.useState<string[] | undefined>(undefined);
-  const [fileNames, setFileNames] = React.useState<string[] | undefined>(undefined);
+  const [dirNames, setDirNames] = useState<string[] | undefined>(undefined);
+  const [fileNames, setFileNames] = useState<string[] | undefined>(undefined);
 
   const readDirectory = () => {
     fileSystem.readdir(basePath, async (err, fileNames) => {
@@ -65,7 +65,7 @@ const FileSystemViewList: React.FC<Props> = ({
     });
   };
 
-  React.useEffect(readDirectory, [fileSystem, basePath]);
+  useEffect(readDirectory, [fileSystem, basePath]);
 
   if (!fileNames || !dirNames) {
     return (

--- a/src/commons/fileSystemView/FileSystemViewPlaceholderNode.tsx
+++ b/src/commons/fileSystemView/FileSystemViewPlaceholderNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import classes from 'src/styles/FileSystemView.module.scss';
 
 type Props = {
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const FileSystemViewPlaceholderNode: React.FC<Props> = ({ processFileName, removePlaceholder }) => {
-  const [fileName, setFileName] = React.useState('');
+  const [fileName, setFileName] = useState('');
 
   const handleInputOnChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setFileName(e.target.value);

--- a/src/commons/gitHubOverlay/FileExplorerDialog.tsx
+++ b/src/commons/gitHubOverlay/FileExplorerDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Octokit } from '@octokit/rest';
 import { GetResponseTypeFromEndpointMethod } from '@octokit/types';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   checkIfFileCanBeOpened,

--- a/src/commons/gitHubOverlay/RepositoryDialog.tsx
+++ b/src/commons/gitHubOverlay/RepositoryDialog.tsx
@@ -10,7 +10,7 @@ import {
   RadioGroup
 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { showWarningMessage } from '../utils/notifications/NotificationsHelper';
 

--- a/src/commons/grading/GradingFlex.tsx
+++ b/src/commons/grading/GradingFlex.tsx
@@ -1,5 +1,4 @@
 import { Property } from 'csstype';
-import React from 'react';
 
 const defaultStyles: React.CSSProperties = {
   display: 'flex'

--- a/src/commons/grading/GradingText.tsx
+++ b/src/commons/grading/GradingText.tsx
@@ -1,6 +1,5 @@
 import { Classes, Text } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
 
 const defaultStyles: React.CSSProperties = {
   width: 'max-content',

--- a/src/commons/hotkeys/HotKeys.tsx
+++ b/src/commons/hotkeys/HotKeys.tsx
@@ -1,5 +1,5 @@
 import { getHotkeyHandler, HotkeyItem } from '@mantine/hooks';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 type HotKeysProps = {
   bindings: HotkeyItem[];

--- a/src/commons/mcqChooser/McqChooser.tsx
+++ b/src/commons/mcqChooser/McqChooser.tsx
@@ -1,5 +1,4 @@
 import { Button, Card, Intent } from '@blueprintjs/core';
-import React from 'react';
 
 import { IMCQQuestion } from '../assessment/AssessmentTypes';
 import Markdown from '../Markdown';

--- a/src/commons/missionCreator/MissionCreator.tsx
+++ b/src/commons/missionCreator/MissionCreator.tsx
@@ -1,6 +1,6 @@
 import { FileInput } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { parseString } from 'xml2js';
 

--- a/src/commons/mobileWorkspace/DraggableRepl.tsx
+++ b/src/commons/mobileWorkspace/DraggableRepl.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useRef } from 'react';
 import Draggable, { DraggableEventHandler } from 'react-draggable';
 
 import Repl, { ReplProps } from '../repl/Repl';
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const DraggableRepl: React.FC<Props> = props => {
-  const nodeRef = React.useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLDivElement>(null);
 
   return (
     <Draggable

--- a/src/commons/mobileWorkspace/MobileKeyboard.tsx
+++ b/src/commons/mobileWorkspace/MobileKeyboard.tsx
@@ -1,5 +1,5 @@
 import { Ace } from 'ace-builds';
-import React from 'react';
+import { useRef, useState } from 'react';
 import Draggable, { DraggableEvent, DraggableEventHandler } from 'react-draggable';
 import Keyboard from 'react-simple-keyboard';
 
@@ -8,13 +8,13 @@ type Props = {
 };
 
 const MobileKeyboard: React.FC<Props> = props => {
-  const nodeRef = React.useRef<HTMLDivElement>(null);
-  const [isKeyboardShown, setIsKeyboardShown] = React.useState(false);
-  const [buttonContent, setButtonContent] = React.useState('ᐸ');
-  const [keyboardPosition, setKeyboardPosition] = React.useState({ x: 0, y: 0 });
-  const [targetKeyboardInput, setTargetKeyboardInput] = React.useState<Ace.Editor | null>(null);
-  const [lastKeyPressed, setLastKeyPressed] = React.useState<string>('');
-  const [touchStartInfo, setTouchStartInfo] = React.useState({ x: 0, y: 0, time: 0 });
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const [isKeyboardShown, setIsKeyboardShown] = useState(false);
+  const [buttonContent, setButtonContent] = useState('ᐸ');
+  const [keyboardPosition, setKeyboardPosition] = useState({ x: 0, y: 0 });
+  const [targetKeyboardInput, setTargetKeyboardInput] = useState<Ace.Editor | null>(null);
+  const [lastKeyPressed, setLastKeyPressed] = useState<string>('');
+  const [touchStartInfo, setTouchStartInfo] = useState({ x: 0, y: 0, time: 0 });
 
   const onDrag: DraggableEventHandler = (
     e: DraggableEvent,

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -2,7 +2,7 @@ import { FocusStyleManager } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useMediaQuery } from '@mantine/hooks';
 import { Ace } from 'ace-builds';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { DraggableEvent } from 'react-draggable';
 
 import ControlBar from '../controlBar/ControlBar';

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -75,7 +75,7 @@ const MobileSideContent: React.FC<MobileSideContentProps> = ({
         ? {
             ...tab.body,
             props: {
-              ...tab.body.props,
+              ...(tab.body.props as any),
               workspaceLocation
             }
           }

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -1,6 +1,6 @@
 import { Classes, Icon, Tab, Tabs, Tooltip } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { type JSX } from 'react';
+import { type JSX, memo } from 'react';
 import { SideContentProps } from 'src/commons/sideContent/SideContent';
 import { generateIconId } from 'src/commons/sideContent/SideContentHelper';
 import SideContentProvider from 'src/commons/sideContent/SideContentProvider';
@@ -122,4 +122,4 @@ const MobileSideContent: React.FC<MobileSideContentProps> = ({
   );
 };
 
-export default React.memo(MobileSideContent, propsAreEqual);
+export default memo(MobileSideContent, propsAreEqual);

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -1,6 +1,6 @@
 import { Classes, Icon, Tab, Tabs, Tooltip } from '@blueprintjs/core';
 import classNames from 'classnames';
-import { type JSX, memo } from 'react';
+import { memo } from 'react';
 import { SideContentProps } from 'src/commons/sideContent/SideContent';
 import { generateIconId } from 'src/commons/sideContent/SideContentHelper';
 import SideContentProvider from 'src/commons/sideContent/SideContentProvider';
@@ -26,7 +26,7 @@ type MobileControlBarProps = {
 const renderTab = (tab: SideContentTab, isIOS: boolean) => {
   const iconSize = 20;
   const tabId = tab.id === undefined ? tab.label : tab.id;
-  const tabTitle: JSX.Element = (
+  const tabTitle: React.ReactElement = (
     <Tooltip
       content={tab.label}
       onOpening={() => {
@@ -71,7 +71,7 @@ const MobileSideContent: React.FC<MobileSideContentProps> = ({
     const renderPanel = (tab: SideContentTab, workspaceLocation?: SideContentLocation) => {
       if (!tab.body) return;
 
-      const tabBody: JSX.Element = workspaceLocation
+      const tabBody: React.ReactElement = workspaceLocation
         ? {
             ...tab.body,
             props: {

--- a/src/commons/navigationBar/NavigationBar.tsx
+++ b/src/commons/navigationBar/NavigationBar.tsx
@@ -14,7 +14,7 @@ import {
 } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Translation } from 'react-i18next';
 import { type Location, NavLink, Route, useLocation } from 'react-router';
 import { i18nDefaultLangKeys } from 'src/i18n/i18next';

--- a/src/commons/navigationBar/subcomponents/AcademyNavigationBar.tsx
+++ b/src/commons/navigationBar/subcomponents/AcademyNavigationBar.tsx
@@ -1,6 +1,6 @@
 import { Alignment, Navbar, NavbarGroup } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { AssessmentType } from 'src/commons/assessment/AssessmentTypes';
 import { useSession } from 'src/commons/utils/Hooks';
 import { assessmentTypeLink } from 'src/commons/utils/ParamParseHelper';

--- a/src/commons/navigationBar/subcomponents/SicpNavigationBar.tsx
+++ b/src/commons/navigationBar/subcomponents/SicpNavigationBar.tsx
@@ -14,7 +14,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Omnibar } from '@blueprintjs/select';
-import React from 'react';
+import { useMemo, useState } from 'react';
 import Latex from 'react-latex-next';
 import { useNavigate, useParams } from 'react-router';
 import ControlButton from 'src/commons/ControlButton';
@@ -28,7 +28,7 @@ type IndexSearchResult = { text: string; order: string; id: string; hasSubindex:
 
 const SicpNavigationBar: React.FC = () => {
   // this section responsible for the travel and table of content
-  const [isTocOpen, setIsTocOpen] = React.useState(false);
+  const [isTocOpen, setIsTocOpen] = useState(false);
   const { section } = useParams<{ section: string }>();
   const navigate = useNavigate();
   const prev = getPrev(section!);
@@ -214,7 +214,7 @@ const SicpNavigationBar: React.FC = () => {
   }
 
   // fetch search catalog only once
-  const rewritedSearchData: SearchData = React.useMemo(fetchSearchData, []);
+  const rewritedSearchData: SearchData = useMemo(fetchSearchData, []);
 
   const focusResult = (result: string, query: string): React.ReactNode => {
     result = result.replaceAll('\n', ' ').toLowerCase();
@@ -305,11 +305,11 @@ const SicpNavigationBar: React.FC = () => {
     );
   };
 
-  const [isOmnibarOpen, setIsOmnibarOpen] = React.useState(false);
-  const [omnibarMode, setOmnibarMode] = React.useState<'text' | 'index' | 'submenu'>('text');
-  const [previousMode, setPreviousMode] = React.useState<'text' | 'index' | null>(null);
-  const [query, setQuery] = React.useState('');
-  const [searchResults, setSearchResults] = React.useState<string[]>([]);
+  const [isOmnibarOpen, setIsOmnibarOpen] = useState(false);
+  const [omnibarMode, setOmnibarMode] = useState<'text' | 'index' | 'submenu'>('text');
+  const [previousMode, setPreviousMode] = useState<'text' | 'index' | null>(null);
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<string[]>([]);
 
   const initTextSearch = () => {
     setOmnibarMode('text');

--- a/src/commons/notificationBadge/NotificationBadge.tsx
+++ b/src/commons/notificationBadge/NotificationBadge.tsx
@@ -1,5 +1,4 @@
 import { Intent, Popover, PopoverInteractionKind, Position, Tag } from '@blueprintjs/core';
-import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import SessionActions from '../application/actions/SessionActions';

--- a/src/commons/profile/Profile.tsx
+++ b/src/commons/profile/Profile.tsx
@@ -1,6 +1,6 @@
 import { Drawer, DrawerSize, NonIdealState, Spinner } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
-import React, { type JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import SessionActions from '../application/actions/SessionActions';
@@ -53,7 +53,7 @@ const Profile = (props => {
   }, [assessmentOverviews, isLoggedIn, isEnrolledInACourse]);
 
   // Render
-  let content: JSX.Element;
+  let content: React.ReactElement;
 
   if (!isLoaded) {
     content = <NonIdealState description="Loading..." icon={<Spinner />} />;

--- a/src/commons/profile/ProfileCard.tsx
+++ b/src/commons/profile/ProfileCard.tsx
@@ -1,6 +1,5 @@
 import { Callout, ProgressBar } from '@blueprintjs/core';
 import { IconName } from '@blueprintjs/icons';
-import React from 'react';
 import { NavLink } from 'react-router';
 
 import { AssessmentOverview, AssessmentType } from '../assessment/AssessmentTypes';

--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { parseError } from 'js-slang';
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import { stringify } from 'js-slang/dist/utils/stringify';
-import React, { type JSX } from 'react';
+import { type JSX, useMemo } from 'react';
 
 import type { InterpreterOutput, ResultOutput } from '../application/ApplicationTypes';
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
@@ -66,7 +66,7 @@ const Repl: React.FC<ReplProps> = props => {
 const ResultOutputDisplay: React.FC<{ output: ResultOutput }> = ({
   output: { value, consoleLogs }
 }) => {
-  const stringified = React.useMemo(() => stringify(value), [value]);
+  const stringified = useMemo(() => stringify(value), [value]);
   if (consoleLogs.length === 0) {
     return (
       <Card>

--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { parseError } from 'js-slang';
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import { stringify } from 'js-slang/dist/utils/stringify';
-import { type JSX, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import type { InterpreterOutput, ResultOutput } from '../application/ApplicationTypes';
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
@@ -36,7 +36,7 @@ type DispatchProps = {
 };
 
 type OwnProps = {
-  replButtons: Array<JSX.Element | null>;
+  replButtons: Array<React.ReactElement | null>;
 };
 
 const Repl: React.FC<ReplProps> = props => {

--- a/src/commons/repl/ReplInput.tsx
+++ b/src/commons/repl/ReplInput.tsx
@@ -2,7 +2,7 @@ import { Classes } from '@blueprintjs/core';
 import { Ace } from 'ace-builds';
 import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import { type JSX, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import AceEditor from 'react-ace';
 import ReactAce from 'react-ace/lib/ace';
 
@@ -31,7 +31,7 @@ type StateProps = {
 };
 
 type OwnProps = {
-  replButtons: Array<JSX.Element | null>;
+  replButtons: Array<React.ReactElement | null>;
 };
 
 export const ReplInput: React.FC<ReplInputProps> = props => {

--- a/src/commons/repl/ReplInput.tsx
+++ b/src/commons/repl/ReplInput.tsx
@@ -2,7 +2,7 @@ import { Classes } from '@blueprintjs/core';
 import { Ace } from 'ace-builds';
 import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React, { type JSX } from 'react';
+import { type JSX, useEffect, useRef } from 'react';
 import AceEditor from 'react-ace';
 import ReactAce from 'react-ace/lib/ace';
 
@@ -37,8 +37,8 @@ type OwnProps = {
 export const ReplInput: React.FC<ReplInputProps> = props => {
   const { onFocus, onBlur } = props;
 
-  const replInput = React.useRef<ReactAce>(null);
-  const replInputBottom = React.useRef<HTMLDivElement>(null);
+  const replInput = useRef<ReactAce>(null);
+  const replInputBottom = useRef<HTMLDivElement>(null);
 
   const { isDesktopBreakpoint } = useResponsive();
 
@@ -55,7 +55,7 @@ export const ReplInput: React.FC<ReplInputProps> = props => {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!replInput.current) {
       return;
     }
@@ -68,7 +68,7 @@ export const ReplInput: React.FC<ReplInputProps> = props => {
     }
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!replInputBottom.current || props.disableScrolling) {
       return;
     }

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -1,6 +1,6 @@
 import { Card, Icon, IconName } from '@blueprintjs/core';
 import classNames from 'classnames';
-import { type JSX, useState } from 'react';
+import { useState } from 'react';
 
 import { SideContentType } from '../sideContent/SideContentTypes';
 
@@ -13,7 +13,7 @@ import { SideContentType } from '../sideContent/SideContentTypes';
  */
 export type SideBarTab = {
   label: string;
-  body: JSX.Element;
+  body: React.ReactElement;
   iconName: IconName;
   id?: SideContentType;
 };

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -1,6 +1,6 @@
 import { Card, Icon, IconName } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { type JSX } from 'react';
+import { type JSX, useState } from 'react';
 
 import { SideContentType } from '../sideContent/SideContentTypes';
 
@@ -26,7 +26,7 @@ type Props = {
 };
 
 const SideBar: React.FC<Props> = ({ tabs, isExpanded, expandSideBar, collapseSideBar }) => {
-  const [selectedTabIndex, setSelectedTabIndex] = React.useState(0);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   const handleTabSelection = (tabIndex: number) => {
     if (selectedTabIndex === tabIndex) {

--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -1,5 +1,4 @@
 import { Card, Icon, Tab, TabProps, Tabs, Tooltip } from '@blueprintjs/core';
-import type { JSX } from 'react';
 
 import { assertType } from '../utils/TypeHelper';
 import { generateTabAlert, getTabId } from './SideContentHelper';
@@ -51,18 +50,18 @@ const renderTab = (
     return <Tab key={tabId} {...tabProps} />;
   }
 
-  const tabBody: JSX.Element = workspaceLocation
+  const tabBody: React.ReactElement = workspaceLocation
     ? {
         ...tab.body,
         props: {
-          ...tab.body.props,
+          ...(tab.body.props as any),
           workspaceLocation,
           editorWidth,
           sideContentHeight
         }
       }
     : tab.body;
-  const tabPanel: JSX.Element = <div className="side-content-text">{tabBody}</div>;
+  const tabPanel: React.ReactElement = <div className="side-content-text">{tabBody}</div>;
 
   return <Tab key={tabId} {...tabProps} panel={tabPanel} />;
 };

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -5,7 +5,10 @@ import * as jsslang from 'js-slang';
 import * as jsslangDist from 'js-slang/dist';
 import lodash from 'lodash';
 import phaser from 'phaser';
-import React, { useCallback } from 'react';
+// We need it to inject modules into the context
+// eslint-disable-next-line no-restricted-imports
+import * as React from 'react';
+import { useCallback } from 'react';
 import JSXRuntime from 'react/jsx-runtime';
 import ace from 'react-ace';
 import ReactDOM from 'react-dom';

--- a/src/commons/sideContent/SideContentProvider.tsx
+++ b/src/commons/sideContent/SideContentProvider.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { useSideContent } from './SideContentHelper';
 import type {
@@ -19,7 +19,7 @@ type SideContentProviderProps = {
     changeTabsCallback: ChangeTabsCallback;
     height?: number;
     selectedTab?: SideContentType;
-  }) => JSX.Element;
+  }) => React.ReactElement;
 
   /**
    * Providing this prop changes the side content provider to uncontrolled mode. The user is

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -1,5 +1,4 @@
 import { IconName } from '@blueprintjs/core';
-import type { JSX } from 'react';
 
 import { DebuggerContext, WorkspaceLocation } from '../workspace/WorkspaceTypes';
 
@@ -58,7 +57,7 @@ export enum SideContentType {
 export type SideContentTab = {
   label: string;
   iconName: IconName;
-  body: JSX.Element | null;
+  body: React.ReactElement | null;
   id?: SideContentType;
   disabled?: boolean;
 };
@@ -80,7 +79,7 @@ export type SideContentTab = {
 export type ModuleSideContent = {
   label: string;
   iconName: IconName;
-  body: (props: any) => JSX.Element;
+  body: (props: any) => React.ReactElement;
   toSpawn?: (context: DebuggerContext) => boolean;
 };
 

--- a/src/commons/sideContent/content/SideContentCanvasOutput.tsx
+++ b/src/commons/sideContent/content/SideContentCanvasOutput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 type Props = {
   canvas: HTMLCanvasElement;

--- a/src/commons/sideContent/content/SideContentContestLeaderboard.tsx
+++ b/src/commons/sideContent/content/SideContentContestLeaderboard.tsx
@@ -1,6 +1,6 @@
 import { Button, Collapse, Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ContestEntry } from '../../assessment/AssessmentTypes';

--- a/src/commons/sideContent/content/SideContentContestVoting.tsx
+++ b/src/commons/sideContent/content/SideContentContestVoting.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Classes, Collapse, Elevation, Icon, Pre, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ContestEntry } from '../../assessment/AssessmentTypes';

--- a/src/commons/sideContent/content/SideContentContestVotingContainer.tsx
+++ b/src/commons/sideContent/content/SideContentContestVotingContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { showWarningMessage } from 'src/commons/utils/notifications/NotificationsHelper';
 
 import { ContestEntry } from '../../assessment/AssessmentTypes';

--- a/src/commons/sideContent/content/SideContentCseMachine.tsx
+++ b/src/commons/sideContent/content/SideContentCseMachine.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames';
 import { t } from 'i18next';
 import { Chapter } from 'js-slang/dist/langs';
 import { debounce } from 'lodash';
-import React from 'react';
+import { Component } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import HotKeys from 'src/commons/hotkeys/HotKeys';
@@ -88,7 +88,7 @@ type DispatchProps = {
   handleAlertSideContent: () => void;
 };
 
-class SideContentCseMachineBase extends React.Component<CseMachineProps, State> {
+class SideContentCseMachineBase extends Component<CseMachineProps, State> {
   constructor(props: CseMachineProps) {
     super(props);
     this.state = {

--- a/src/commons/sideContent/content/SideContentDataVisualizer.tsx
+++ b/src/commons/sideContent/content/SideContentDataVisualizer.tsx
@@ -1,12 +1,19 @@
-import { AnchorButton, Button, ButtonGroup, Card, Checkbox, Classes } from '@blueprintjs/core';
-import { Tooltip } from '@blueprintjs/core';
-import { Icon } from '@blueprintjs/core';
+import {
+  AnchorButton,
+  Button,
+  ButtonGroup,
+  Card,
+  Checkbox,
+  Classes,
+  Icon,
+  Tooltip
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { HotkeyItem } from '@mantine/hooks';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import classNames from 'classnames';
 import { t } from 'i18next';
-import React from 'react';
+import { Component } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { connect, MapDispatchToProps } from 'react-redux';
 import HotKeys from 'src/commons/hotkeys/HotKeys';
@@ -36,7 +43,7 @@ type DispatchProps = {
  * data_data function in Source. It adds a listener to the DataVisualizer singleton
  * which updates the steps list via setState whenever new steps are added.
  */
-class SideContentDataVisualizerBase extends React.Component<OwnProps & DispatchProps, State> {
+class SideContentDataVisualizerBase extends Component<OwnProps & DispatchProps, State> {
   constructor(props: any) {
     super(props);
     this.state = { steps: [], currentStep: 0 };

--- a/src/commons/sideContent/content/SideContentFaceapiDisplay.tsx
+++ b/src/commons/sideContent/content/SideContentFaceapiDisplay.tsx
@@ -1,6 +1,5 @@
 import { Button, Divider } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 const SideContentFaceapiDisplay: React.FC = () => {

--- a/src/commons/sideContent/content/SideContentHtmlDisplay.tsx
+++ b/src/commons/sideContent/content/SideContentHtmlDisplay.tsx
@@ -1,7 +1,7 @@
 import { IconNames } from '@blueprintjs/icons';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { t } from 'i18next';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { ResultOutput } from 'src/commons/application/ApplicationTypes';

--- a/src/commons/sideContent/content/SideContentLeaderboardCard.tsx
+++ b/src/commons/sideContent/content/SideContentLeaderboardCard.tsx
@@ -1,6 +1,5 @@
 import { Card, Classes, Elevation, Pre } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
 
 import { ContestEntry } from '../../assessment/AssessmentTypes';
 

--- a/src/commons/sideContent/content/SideContentResultCard.tsx
+++ b/src/commons/sideContent/content/SideContentResultCard.tsx
@@ -1,7 +1,6 @@
 import { Card, Elevation, Pre } from '@blueprintjs/core';
 import classNames from 'classnames';
 import type { TFunction } from 'i18next';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AutogradingError, AutogradingResult } from '../../assessment/AssessmentTypes';

--- a/src/commons/sideContent/content/SideContentSessionManagement.tsx
+++ b/src/commons/sideContent/content/SideContentSessionManagement.tsx
@@ -2,7 +2,7 @@ import { Classes, HTMLTable, Icon, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { CollabEditingAccess, type SharedbAceUser } from '@sourceacademy/sharedb-ace/types';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import {

--- a/src/commons/sideContent/content/SideContentSubstVisualizer.tsx
+++ b/src/commons/sideContent/content/SideContentSubstVisualizer.tsx
@@ -37,7 +37,7 @@ import {
   StepperVariableDeclaration,
   StepperVariableDeclarator
 } from 'js-slang/dist/tracer/nodes/Statement/VariableDeclaration';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 

--- a/src/commons/sideContent/content/SideContentTestcaseCard.tsx
+++ b/src/commons/sideContent/content/SideContentTestcaseCard.tsx
@@ -2,7 +2,7 @@ import { Card, Classes, Elevation, Pre } from '@blueprintjs/core';
 import classNames from 'classnames';
 import { parseError } from 'js-slang';
 import { stringify } from 'js-slang/dist/utils/stringify';
-import React from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Testcase, TestcaseTypes } from '../../assessment/AssessmentTypes';
 import { WorkspaceLocation } from '../../workspace/WorkspaceTypes';
@@ -25,7 +25,7 @@ type OwnProps = {
 const SideContentTestcaseCard: React.FC<SideContentTestcaseCardProps> = props => {
   const { index, testcase, handleTestcaseEval } = props;
 
-  const extraClasses = React.useMemo(() => {
+  const extraClasses = useMemo(() => {
     const isEvaluated = testcase.result !== undefined || testcase.errors;
     const isEqual = stringify(testcase.result) === testcase.answer;
 
@@ -37,7 +37,7 @@ const SideContentTestcaseCard: React.FC<SideContentTestcaseCardProps> = props =>
     };
   }, [testcase]);
 
-  const handleRunTestcase = React.useCallback(() => {
+  const handleRunTestcase = useCallback(() => {
     handleTestcaseEval(index);
   }, [index, handleTestcaseEval]);
 

--- a/src/commons/sideContent/content/SideContentToneMatrix.tsx
+++ b/src/commons/sideContent/content/SideContentToneMatrix.tsx
@@ -1,6 +1,6 @@
 import { Button, Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 const SideContentToneMatrix: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -38,4 +38,4 @@ const SideContentToneMatrix: React.FC = () => {
   );
 };
 
-export default React.memo(SideContentToneMatrix, () => true);
+export default memo(SideContentToneMatrix, () => true);

--- a/src/commons/sideContent/content/SideContentUpload.tsx
+++ b/src/commons/sideContent/content/SideContentUpload.tsx
@@ -1,7 +1,7 @@
 import { FileInput } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { t } from 'i18next';
-import React, { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { SideContentTab, SideContentType } from '../SideContentTypes';
@@ -31,7 +31,7 @@ type Props = {
  */
 const SideContentUpload: React.FC<Props> = ({ onUpload }) => {
   const { t } = useTranslation('sideContent', { keyPrefix: 'upload' });
-  const [count, setCount] = React.useState(0);
+  const [count, setCount] = useState(0);
 
   const handleFileUpload: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     e => {

--- a/src/commons/sideContent/content/githubAssessments/SideContentEditableTestcaseCard.tsx
+++ b/src/commons/sideContent/content/githubAssessments/SideContentEditableTestcaseCard.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { parseError } from 'js-slang';
 import { stringify } from 'js-slang/dist/utils/stringify';
-import React from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Testcase, TestcaseTypes } from '../../../assessment/AssessmentTypes';
 
@@ -30,7 +30,7 @@ const SideContentEditableTestcaseCard: React.FC<SideContentEditableTestcaseCardP
   deleteTestcase
 }) => {
   // TODO (Refactor): testcase type seems unused in GitHub Assessments
-  const extraClasses = React.useMemo(() => {
+  const extraClasses = useMemo(() => {
     const isEvaluated = testcase.result !== undefined || testcase.errors;
     const isEqual = stringify(testcase.result) === testcase.answer;
 
@@ -41,7 +41,7 @@ const SideContentEditableTestcaseCard: React.FC<SideContentEditableTestcaseCardP
     };
   }, [testcase]);
 
-  const handleRunTestcase = React.useCallback(() => {
+  const handleRunTestcase = useCallback(() => {
     handleTestcaseEval(index);
   }, [index, handleTestcaseEval]);
 
@@ -59,7 +59,7 @@ const SideContentEditableTestcaseCard: React.FC<SideContentEditableTestcaseCardP
     />
   );
 
-  const answer = React.useMemo(() => {
+  const answer = useMemo(() => {
     let answer = 'No Answer';
     if (testcase.errors) {
       answer = parseError(testcase.errors);

--- a/src/commons/sideContent/content/githubAssessments/SideContentMarkdownEditor.tsx
+++ b/src/commons/sideContent/content/githubAssessments/SideContentMarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import { TextArea } from '@blueprintjs/core';
-import React, { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Markdown from '../../../Markdown';
 
@@ -10,9 +10,9 @@ type Props = {
 };
 
 const SideContentMarkdownEditor: React.FC<Props> = ({ allowEdits, content, setContent }) => {
-  const [editorModeOn, setEditorModeOn] = React.useState(false);
+  const [editorModeOn, setEditorModeOn] = useState(false);
 
-  const node = React.useRef<HTMLDivElement>(null);
+  const node = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClick(event: any) {

--- a/src/commons/sideContent/content/githubAssessments/SideContentTaskEditor.tsx
+++ b/src/commons/sideContent/content/githubAssessments/SideContentTaskEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback } from 'react';
 
 import SideContentMarkdownEditor from './SideContentMarkdownEditor';
 
@@ -21,7 +21,7 @@ const SideContentTaskEditor: React.FC<Props> = props => {
     ? 'Welcome to Mission Mode! This is where the Task Briefing for each question will appear!'
     : taskDescriptions[taskIndex];
 
-  const taskBriefingSetter = React.useCallback(
+  const taskBriefingSetter = useCallback(
     (newDescription: string) => {
       if (indexOutOfRange) {
         return;

--- a/src/commons/sideContent/content/remoteExecution/DeviceMenuItemButtons.tsx
+++ b/src/commons/sideContent/content/remoteExecution/DeviceMenuItemButtons.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@blueprintjs/core';
-import React from 'react';
 
 type Props = {
   text?: React.ReactNode;

--- a/src/commons/sideContent/content/remoteExecution/SideContentRemoteExecution.tsx
+++ b/src/commons/sideContent/content/remoteExecution/SideContentRemoteExecution.tsx
@@ -8,7 +8,7 @@ import {
   Spinner
 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { SetStateAction, useCallback } from 'react';
+import { SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { NavLink } from 'react-router';
 import BrickSvg from 'src/assets/BrickSvg';
@@ -68,10 +68,10 @@ const motorPorts = ['portA', 'portB', 'portC', 'portD'] as const;
 const sensorPorts = ['port1', 'port2', 'port3', 'port4'] as const;
 
 const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = props => {
-  const [dialogState, setDialogState] = React.useState<Device | true | undefined>(
+  const [dialogState, setDialogState] = useState<Device | true | undefined>(
     props.secretParams ? true : undefined
   );
-  const [secretParams, setSecretParams] = React.useState(props.secretParams);
+  const [secretParams, setSecretParams] = useState(props.secretParams);
 
   const isLoggedIn = useTypedSelector(state => !!state.session.accessToken && !!state.session.role);
   const devices = useTypedSelector(state => state.session.remoteExecutionDevices);
@@ -80,7 +80,7 @@ const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = pr
 
   const isConnected = currentSession?.connection.status === 'CONNECTED';
 
-  React.useEffect(() => {
+  useEffect(() => {
     // this is not supposed to happen - the destructor below should disconnect
     // once the user navigates away from the workspace
     if (currentSession && currentSession.workspace !== props.workspace) {
@@ -93,13 +93,13 @@ const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = pr
     }
   }, [currentSession, dispatch, props.workspace]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!devices && isLoggedIn) {
       dispatch(actions.remoteExecFetchDevices());
     }
   }, [dispatch, devices, isLoggedIn]);
 
-  React.useEffect(
+  useEffect(
     () => () => {
       // note the double () => - this function is a destructor
       dispatch(actions.remoteExecDisconnect());

--- a/src/commons/utils/DialogHelper.tsx
+++ b/src/commons/utils/DialogHelper.tsx
@@ -1,5 +1,5 @@
 import { type IconName, Intent } from '@blueprintjs/core';
-import { createElement, createRef, PureComponent, type ReactNode } from 'react';
+import { createElement, createRef, PureComponent } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ConfirmDialog, ConfirmDialogProps } from '../dialogs/ConfirmDialog';
@@ -86,7 +86,7 @@ export function showConfirmDialog<T>(
 export interface SimpleConfirmDialogProps {
   icon?: IconName;
   title?: string;
-  contents?: ReactNode;
+  contents?: React.ReactNode;
   positiveLabel?: string;
   positiveIntent?: Intent;
   negativeLabel?: string;
@@ -114,7 +114,7 @@ export function showSimpleConfirmDialog(props: SimpleConfirmDialogProps): Promis
 
 export interface SimpleErrorDialogProps {
   title?: string;
-  contents?: ReactNode;
+  contents?: React.ReactNode;
   label?: string;
   props?: Partial<ConfirmDialogProps<boolean>>;
 }
@@ -139,7 +139,7 @@ export function showSimpleErrorDialog(props: SimpleErrorDialogProps): Promise<bo
 
 export function showSimplePromptDialog(props: {
   title?: string;
-  contents?: ReactNode;
+  contents?: React.ReactNode;
   positiveLabel?: string;
   negativeLabel?: string;
   props?: Partial<PromptDialogProps<boolean>>;

--- a/src/commons/utils/DialogHelper.tsx
+++ b/src/commons/utils/DialogHelper.tsx
@@ -1,5 +1,5 @@
-import { IconName, Intent } from '@blueprintjs/core';
-import React from 'react';
+import { type IconName, Intent } from '@blueprintjs/core';
+import { createElement, createRef, PureComponent, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ConfirmDialog, ConfirmDialogProps } from '../dialogs/ConfirmDialog';
@@ -10,11 +10,11 @@ import { PropsType } from './TypeHelper';
 // https://github.com/palantir/blueprint/blob/develop/packages/core/src/components/toast/toaster.tsx
 
 interface DialogHelperState {
-  dialog: ReturnType<typeof React.createElement> | null;
+  dialog: ReturnType<typeof createElement> | null;
   dialogOnClose: (() => void) | null;
 }
 
-class DialogHelper extends React.PureComponent<{}, DialogHelperState> {
+class DialogHelper extends PureComponent<{}, DialogHelperState> {
   public state: DialogHelperState = {
     dialog: null,
     dialogOnClose: null
@@ -31,7 +31,7 @@ class DialogHelper extends React.PureComponent<{}, DialogHelperState> {
     document.body.appendChild(containerElement);
     const root = createRoot(containerElement);
 
-    const dialogRef = React.createRef<DialogHelper>();
+    const dialogRef = createRef<DialogHelper>();
     root.render(<DialogHelper ref={dialogRef} />);
     return dialogRef;
   }
@@ -86,7 +86,7 @@ export function showConfirmDialog<T>(
 export interface SimpleConfirmDialogProps {
   icon?: IconName;
   title?: string;
-  contents?: React.ReactNode;
+  contents?: ReactNode;
   positiveLabel?: string;
   positiveIntent?: Intent;
   negativeLabel?: string;
@@ -114,7 +114,7 @@ export function showSimpleConfirmDialog(props: SimpleConfirmDialogProps): Promis
 
 export interface SimpleErrorDialogProps {
   title?: string;
-  contents?: React.ReactNode;
+  contents?: ReactNode;
   label?: string;
   props?: Partial<ConfirmDialogProps<boolean>>;
 }
@@ -139,7 +139,7 @@ export function showSimpleErrorDialog(props: SimpleErrorDialogProps): Promise<bo
 
 export function showSimplePromptDialog(props: {
   title?: string;
-  contents?: React.ReactNode;
+  contents?: ReactNode;
   positiveLabel?: string;
   negativeLabel?: string;
   props?: Partial<PromptDialogProps<boolean>>;

--- a/src/commons/utils/FormHelper.ts
+++ b/src/commons/utils/FormHelper.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 /* export interface FieldOptions {
   validationFunction?: (value: string | undefined) => boolean;
@@ -7,10 +7,10 @@ import React from 'react';
 export function useField<T extends HTMLInputElement | HTMLSelectElement>(
   validationFunction?: (value: string | undefined) => boolean
 ) {
-  const ref = React.useRef<T | null>(null);
-  const [isValid, setIsValid] = React.useState(true);
+  const ref = useRef<T | null>(null);
+  const [isValid, setIsValid] = useState(true);
 
-  const validate = React.useCallback(() => {
+  const validate = useCallback(() => {
     const newIsValid = !validationFunction || validationFunction(ref.current?.value);
     if (isValid !== newIsValid) {
       setIsValid(newIsValid);
@@ -18,7 +18,7 @@ export function useField<T extends HTMLInputElement | HTMLSelectElement>(
     return newIsValid;
   }, [isValid, validationFunction]);
 
-  const onChange = React.useCallback(() => void validate(), [validate]);
+  const onChange = useCallback(() => void validate(), [validate]);
 
   return { ref, isValid, setIsValid, validate, onChange };
 }

--- a/src/commons/utils/Hooks.ts
+++ b/src/commons/utils/Hooks.ts
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@mantine/hooks';
-import { RefObject, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { TypedUseSelectorHook, useSelector } from 'react-redux';
 
@@ -80,7 +80,7 @@ export const useTypedSelector: TypedUseSelectorHook<OverallState> = useSelector;
  */
 
 export const useDimensions = (
-  ref: RefObject<HTMLElement | null>
+  ref: React.RefObject<HTMLElement | null>
 ): [width: number, height: number] => {
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);

--- a/src/commons/utils/Hooks.ts
+++ b/src/commons/utils/Hooks.ts
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@mantine/hooks';
-import React, { RefObject } from 'react';
+import { RefObject, useEffect, useMemo, useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { TypedUseSelectorHook, useSelector } from 'react-redux';
 
@@ -15,9 +15,9 @@ import { readLocalStorage, setLocalStorage } from './LocalStorageHelper';
  * @param defaultValue T
  */
 export function useRequest<T>(requestFn: () => Promise<T>, defaultValue: T) {
-  const [value, setValue] = React.useState<T>(defaultValue);
+  const [value, setValue] = useState<T>(defaultValue);
 
-  React.useEffect(() => {
+  useEffect(() => {
     (async () => {
       const fetchedValue = await requestFn();
       setValue(fetchedValue);
@@ -36,7 +36,7 @@ export function useRequest<T>(requestFn: () => Promise<T>, defaultValue: T) {
  * @param defaultValue default value of input field
  */
 export function useInput<T>(defaultValue: T) {
-  const [value, setValue] = React.useState<T>(defaultValue);
+  const [value, setValue] = useState<T>(defaultValue);
 
   return {
     value,
@@ -51,7 +51,7 @@ export function useInput<T>(defaultValue: T) {
 }
 
 /**
- * This hook usage is similar to React.useState, the only difference
+ * This hook usage is similar to useState, the only difference
  * being that the state is also written to local storage at the specified key on state updates.
  *
  * When calling this hook, the value will take on the stored value in local storage (if any).
@@ -61,9 +61,9 @@ export function useLocalStorageState<T>(
   key: string,
   defaultValue: T
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [value, setValue] = React.useState<T>(readLocalStorage(key, defaultValue));
+  const [value, setValue] = useState<T>(readLocalStorage(key, defaultValue));
 
-  React.useEffect(() => {
+  useEffect(() => {
     setLocalStorage(key, value);
   }, [key, value]);
 
@@ -82,10 +82,10 @@ export const useTypedSelector: TypedUseSelectorHook<OverallState> = useSelector;
 export const useDimensions = (
   ref: RefObject<HTMLElement | null>
 ): [width: number, height: number] => {
-  const [width, setWidth] = React.useState(0);
-  const [height, setHeight] = React.useState(0);
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
 
-  const resizeObserver = React.useMemo(
+  const resizeObserver = useMemo(
     () =>
       new ResizeObserver((entries: ResizeObserverEntry[], observer: ResizeObserver) => {
         if (entries.length !== 1) {
@@ -100,7 +100,7 @@ export const useDimensions = (
     []
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const htmlElement = ref.current;
     if (htmlElement === null) {
       return;

--- a/src/commons/utils/SortableList.tsx
+++ b/src/commons/utils/SortableList.tsx
@@ -16,13 +16,13 @@ import {
   verticalListSortingStrategy
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import React from 'react';
+import { memo, useCallback, useState } from 'react';
 
 type SortableItemProps = {
   id: string;
 };
 
-const SortableItem = React.memo(({ id }: SortableItemProps) => {
+const SortableItem = memo(({ id }: SortableItemProps) => {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
 
   const style = {
@@ -42,7 +42,7 @@ type SortableListProps = {
   onSortEnd: (event: DragEndEvent) => void;
 };
 
-export const SortableList = React.memo(({ items, onSortEnd }: SortableListProps) => {
+export const SortableList = memo(({ items, onSortEnd }: SortableListProps) => {
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -62,9 +62,9 @@ export const SortableList = React.memo(({ items, onSortEnd }: SortableListProps)
 });
 
 export const useSortableList = () => {
-  const [items, setItems] = React.useState<string[]>([]);
+  const [items, setItems] = useState<string[]>([]);
 
-  const onSortEnd = React.useCallback((event: DragEndEvent) => {
+  const onSortEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
 
     if (over && active.id !== over.id) {

--- a/src/commons/utils/StoriesHelper.ts
+++ b/src/commons/utils/StoriesHelper.ts
@@ -6,7 +6,6 @@ import {
   Options as MdastToHastConverterOptions,
   toHast
 } from 'mdast-util-to-hast';
-import React from 'react';
 import * as runtime from 'react/jsx-runtime';
 import { IEditorProps } from 'react-ace';
 import rehypeReact from 'rehype-react';

--- a/src/commons/utils/TestUtils.ts
+++ b/src/commons/utils/TestUtils.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React, { act } from 'react';
+import { act } from 'react';
 
 export const renderTree = async (element: React.ReactElement) => {
   const app = render(element);

--- a/src/commons/utils/notifications/NotificationsHelper.ts
+++ b/src/commons/utils/notifications/NotificationsHelper.ts
@@ -1,10 +1,9 @@
 import { Intent, ToastProps } from '@blueprintjs/core';
-import type { JSX } from 'react';
 
 import { notification } from './createNotification';
 
 export const showSuccessMessage = (
-  message: string | JSX.Element,
+  message: string | React.ReactElement,
   timeout: number = 2000,
   key?: string
 ) =>
@@ -18,7 +17,7 @@ export const showSuccessMessage = (
   );
 
 export const showWarningMessage = (
-  message: string | JSX.Element,
+  message: string | React.ReactElement,
   timeout: number = 2000,
   key?: string
 ) =>
@@ -32,7 +31,7 @@ export const showWarningMessage = (
   );
 
 export const showDangerMessage = (
-  message: string | JSX.Element,
+  message: string | React.ReactElement,
   timeout: number = 2000,
   key?: string
 ) =>

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { useFullscreenElement } from '@mantine/hooks';
 import { Enable, NumberSize, Resizable, ResizableProps, ResizeCallback } from 're-resizable';
 import { Direction } from 're-resizable/lib/resizer';
-import React, { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import ControlBar, { ControlBarProps } from '../controlBar/ControlBar';
 import EditorContainer, { EditorContainerProps } from '../editor/EditorContainer';
@@ -196,8 +196,8 @@ const Workspace: React.FC<WorkspaceProps> = props => {
     fullscreen: isFullscreen
   } = useFullscreenElement<HTMLDivElement>();
 
-  const fullscreenContainerRef = React.useRef<HTMLDivElement | null>(null);
-  const setFullscreenRefs = React.useCallback(
+  const fullscreenContainerRef = useRef<HTMLDivElement | null>(null);
+  const setFullscreenRefs = useCallback(
     (node: HTMLDivElement | null) => {
       fullscreenContainerRef.current = node;
       fullscreenRef(node);

--- a/src/features/achievement/AchievementConstants.ts
+++ b/src/features/achievement/AchievementConstants.ts
@@ -1,10 +1,10 @@
-import React from 'react';
+import { createContext } from 'react';
 
 import AchievementInferencer from '../../commons/achievement/utils/AchievementInferencer';
 import { Links } from '../../commons/utils/Constants';
 import { FilterStatus } from './AchievementTypes';
 
-export const AchievementContext = React.createContext(new AchievementInferencer([], []));
+export const AchievementContext = createContext(new AchievementInferencer([], []));
 
 export enum DeadlineColors {
   RED = '#f00',

--- a/src/features/cseMachine/CseMachine.tsx
+++ b/src/features/cseMachine/CseMachine.tsx
@@ -1,7 +1,6 @@
 import { Context } from 'js-slang';
 import { Control, Stash } from 'js-slang/dist/cse-machine/interpreter';
 import { parse } from 'js-slang/dist/parser/parser';
-import React from 'react';
 
 import { arrowSelection } from './components/arrows/ArrowSelection';
 import { CseAnimation } from './CseMachineAnimation';

--- a/src/features/cseMachine/CseMachineAnimation.tsx
+++ b/src/features/cseMachine/CseMachineAnimation.tsx
@@ -2,7 +2,7 @@ import { AppInstr, ArrLitInstr, AssmtInstr, InstrType } from 'js-slang/dist/cse-
 import { Node } from 'js-slang/dist/types';
 import { Layer } from 'konva/lib/Layer';
 import { Easings } from 'konva/lib/Tween';
-import React from 'react';
+import { createRef } from 'react';
 
 import { ArrayAccessAnimation } from './animationComponents/ArrayAccessAnimation';
 import { ArrayAssignmentAnimation } from './animationComponents/ArrayAssignmentAnimation';
@@ -38,7 +38,7 @@ export class CseAnimation {
   private static currentFrame: Frame;
   private static previousFrame: Frame;
 
-  static layerRef = React.createRef<Layer>();
+  static layerRef = createRef<Layer>();
   static getLayer(): Layer | null {
     return this.layerRef.current;
   }

--- a/src/features/cseMachine/CseMachineLayout.tsx
+++ b/src/features/cseMachine/CseMachineLayout.tsx
@@ -6,7 +6,7 @@ import { Group as KonvaGroupNode } from 'konva/lib/Group';
 import { Layer as KonvaLayerNode } from 'konva/lib/Layer';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Stage } from 'konva/lib/Stage';
-import React, { RefObject } from 'react';
+import { createRef } from 'react';
 import {
   Group as KonvaGroup,
   Layer as KonvaLayer,
@@ -124,17 +124,17 @@ export class Layout {
   static currentStackTruncDark: React.ReactNode;
   static currentStackLight: React.ReactNode;
   static currentStackTruncLight: React.ReactNode;
-  static stageRef: RefObject<Stage | null> = React.createRef();
-  static contentGroupRef: RefObject<KonvaGroupNode | null> = React.createRef();
-  static animationGroupRef: RefObject<KonvaGroupNode | null> = React.createRef();
-  static arrowUnderlayLayerRef: RefObject<KonvaLayerNode | null> = React.createRef();
+  static stageRef: React.RefObject<Stage | null> = createRef();
+  static contentGroupRef: React.RefObject<KonvaGroupNode | null> = createRef();
+  static animationGroupRef: React.RefObject<KonvaGroupNode | null> = createRef();
+  static arrowUnderlayLayerRef: React.RefObject<KonvaLayerNode | null> = createRef();
   static underlayArrows: React.ReactNode[] = [];
   static overlayNodes: React.ReactNode[] = [];
 
   // buffer for faster rendering of diagram when scrolling
   static invisiblePaddingVertical: number = 300;
   static invisiblePaddingHorizontal: number = 300;
-  static scrollContainerRef: RefObject<HTMLDivElement | null> = React.createRef();
+  static scrollContainerRef: React.RefObject<HTMLDivElement | null> = createRef();
 
   static resetUnderlayArrows() {
     Layout.underlayArrows = [];

--- a/src/features/cseMachine/CseMachineTypes.ts
+++ b/src/features/cseMachine/CseMachineTypes.ts
@@ -5,7 +5,6 @@ import {
 import JsSlangClosure from 'js-slang/dist/cse-machine/closure';
 import { Environment } from 'js-slang/dist/types';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React from 'react';
 
 import { ArrayUnit } from './components/ArrayUnit';
 import { Binding } from './components/Binding';

--- a/src/features/cseMachine/__tests__/CseMachineAnimation.test.tsx
+++ b/src/features/cseMachine/__tests__/CseMachineAnimation.test.tsx
@@ -1,5 +1,4 @@
 import Konva from 'konva';
-import { RefObject } from 'react';
 import * as ReactKonva from 'react-konva';
 
 import { AnimatableTo, AnimationConfig } from '../animationComponents/base/Animatable';
@@ -76,7 +75,7 @@ async function testAnimationComponent<
   // node and assign it to the RefObject's `current` property
   expect(konvaNodeMap[nodeType]).toBeDefined();
   const node = Reflect.construct(konvaNodeMap[nodeType], [nodeProps]) as Konva.Shape;
-  (component.ref as Writable<RefObject<any>>).current = node;
+  (component.ref as Writable<React.RefObject<any>>).current = node;
   mockLayer.add(node);
 
   const timings = args.deltas.map(d => d * CseAnimation.defaultDuration);

--- a/src/features/cseMachine/animationComponents/ArrayAccessAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ArrayAccessAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ArrayUnit } from '../components/ArrayUnit';

--- a/src/features/cseMachine/animationComponents/ArrayAssignmentAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ArrayAssignmentAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ArrayUnit } from '../components/ArrayUnit';

--- a/src/features/cseMachine/animationComponents/ArraySpreadAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ArraySpreadAnimation.tsx
@@ -1,5 +1,4 @@
 //import { Easings } from 'konva/lib/Tween';
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/AssignmentAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/AssignmentAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { Binding } from '../components/Binding';

--- a/src/features/cseMachine/animationComponents/BinaryOperationAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/BinaryOperationAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/BranchAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/BranchAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/ClearDeadFramesAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ClearDeadFramesAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ArrayNullUnit } from '../components/ArrayNullUnit';

--- a/src/features/cseMachine/animationComponents/ControlExpansionAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ControlExpansionAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/ControlToStashAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/ControlToStashAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/EnvironmentAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/EnvironmentAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { Frame } from '../components/Frame';

--- a/src/features/cseMachine/animationComponents/FrameCreationAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/FrameCreationAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { GenericArrow } from '../components/arrows/GenericArrow';

--- a/src/features/cseMachine/animationComponents/FunctionApplicationAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/FunctionApplicationAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/InstructionApplicationAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/InstructionApplicationAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/LookupAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/LookupAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { Binding } from '../components/Binding';

--- a/src/features/cseMachine/animationComponents/PopAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/PopAnimation.tsx
@@ -1,5 +1,4 @@
 import { Easings } from 'konva/lib/Tween';
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/UnaryOperationAnimation.tsx
+++ b/src/features/cseMachine/animationComponents/UnaryOperationAnimation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { ControlItemComponent } from '../components/ControlItemComponent';

--- a/src/features/cseMachine/animationComponents/base/AnimationComponents.tsx
+++ b/src/features/cseMachine/animationComponents/base/AnimationComponents.tsx
@@ -1,6 +1,5 @@
 import Konva from 'konva';
 import { AnimationFn } from 'konva/lib/types';
-import React from 'react';
 import { Arrow, Circle, KonvaNodeComponent, Line, Path, Rect, Text } from 'react-konva';
 
 import { CseAnimation } from '../../CseMachineAnimation';

--- a/src/features/cseMachine/components/ArrayEmptyUnit.tsx
+++ b/src/features/cseMachine/components/ArrayEmptyUnit.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Rect } from 'react-konva';
 
 import { ShapeDefaultProps } from '../CseMachineConfig';

--- a/src/features/cseMachine/components/ArrayNullUnit.tsx
+++ b/src/features/cseMachine/components/ArrayNullUnit.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Line as KonvaLine } from 'react-konva';
 
 import { Config, ShapeDefaultProps } from '../CseMachineConfig';

--- a/src/features/cseMachine/components/ArrayUnit.tsx
+++ b/src/features/cseMachine/components/ArrayUnit.tsx
@@ -1,5 +1,4 @@
 import { Text, TextConfig } from 'konva/lib/shapes/Text';
-import React from 'react';
 import { Text as KonvaText } from 'react-konva';
 
 import CseMachine from '../CseMachine';

--- a/src/features/cseMachine/components/ArrayUnit.tsx
+++ b/src/features/cseMachine/components/ArrayUnit.tsx
@@ -1,4 +1,5 @@
 import { Text, TextConfig } from 'konva/lib/shapes/Text';
+import { createRef, Fragment } from 'react';
 import { Text as KonvaText } from 'react-konva';
 
 import CseMachine from '../CseMachine';
@@ -32,7 +33,7 @@ export class ArrayUnit extends Visible {
   readonly isLastUnit: boolean;
   /** arrow that is drawn from the array unit to the value */
   arrow?: GenericArrow<ArrayUnit, Value>;
-  readonly indexRef = React.createRef<Text>();
+  readonly indexRef = createRef<Text>();
 
   constructor(
     /** index of this unit in its parent */
@@ -118,7 +119,7 @@ export class ArrayUnit extends Visible {
         : fadedStrokeColor();
 
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <RoundedRect
           key={Layout.key++}
           x={this.x()}
@@ -144,7 +145,7 @@ export class ArrayUnit extends Visible {
         />
         {this.value.draw()}
         {this.arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/Binding.tsx
+++ b/src/features/cseMachine/components/Binding.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 
 import CseMachine from '../CseMachine';
 import { Config } from '../CseMachineConfig';
@@ -174,13 +174,13 @@ export class Binding extends Visible {
     }
 
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         {this.isDummyBinding
           ? null // omit the key since value is anonymous
           : this.key.draw()}
         {this.arrow?.draw()}
         {shouldRenderReferencedValue ? this.value.draw() : null}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/ControlItemComponent.tsx
+++ b/src/features/cseMachine/components/ControlItemComponent.tsx
@@ -1,5 +1,5 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React from 'react';
+import { createRef, Fragment, type RefObject } from 'react';
 import { Label, Tag, Text } from 'react-konva';
 
 import CseMachine from '../CseMachine';
@@ -25,7 +25,7 @@ import { Visible } from './Visible';
 export class ControlItemComponent extends Visible implements IHoverable {
   /** text to display */
   readonly text: string;
-  readonly tooltipRef: React.RefObject<any>;
+  readonly tooltipRef: RefObject<any>;
   readonly arrow?: ArrowFromControlItemComponent;
 
   constructor(
@@ -47,7 +47,7 @@ export class ControlItemComponent extends Visible implements IHoverable {
       ControlStashConfig.ControlMaxTextWidth,
       ControlStashConfig.ControlMaxTextHeight
     );
-    this.tooltipRef = React.createRef();
+    this.tooltipRef = createRef();
     this.highlightOnHover = highlightOnHover;
     this.unhighlightOnHover = unhighlightOnHover;
     this._x = ControlStashConfig.ControlPosX;
@@ -120,7 +120,7 @@ export class ControlItemComponent extends Visible implements IHoverable {
       cornerRadius: ControlStashConfig.ControlItemCornerRadius
     };
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <Label
           ref={this.ref}
           x={this.x()}
@@ -158,7 +158,7 @@ export class ControlItemComponent extends Visible implements IHoverable {
           />
         </Label>
         {this.arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/ControlItemComponent.tsx
+++ b/src/features/cseMachine/components/ControlItemComponent.tsx
@@ -1,5 +1,5 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import { createRef, Fragment, type RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Label, Tag, Text } from 'react-konva';
 
 import CseMachine from '../CseMachine';
@@ -25,7 +25,7 @@ import { Visible } from './Visible';
 export class ControlItemComponent extends Visible implements IHoverable {
   /** text to display */
   readonly text: string;
-  readonly tooltipRef: RefObject<any>;
+  readonly tooltipRef: React.RefObject<any>;
   readonly arrow?: ArrowFromControlItemComponent;
 
   constructor(

--- a/src/features/cseMachine/components/ControlStack.tsx
+++ b/src/features/cseMachine/components/ControlStack.tsx
@@ -1,10 +1,8 @@
 import { Control } from 'js-slang/dist/cse-machine/interpreter';
 import { ControlItem, Instr } from 'js-slang/dist/cse-machine/types';
 import { Chapter } from 'js-slang/dist/langs';
-import { StatementSequence } from 'js-slang/dist/types';
-import { Node } from 'js-slang/dist/types';
+import { Node, StatementSequence } from 'js-slang/dist/types';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React from 'react';
 import { Label, Tag, Text } from 'react-konva';
 
 import CseMachine from '../CseMachine';

--- a/src/features/cseMachine/components/Frame.tsx
+++ b/src/features/cseMachine/components/Frame.tsx
@@ -1,5 +1,5 @@
 import { Rect as KonvaRect } from 'konva/lib/shapes/Rect';
-import React from 'react';
+import { createRef } from 'react';
 import { Group, Rect } from 'react-konva';
 
 import CseMachine from '../CseMachine';
@@ -60,7 +60,7 @@ export class Frame extends Visible implements IHoverable {
   readonly bindings: Binding[] = [];
   /** name of this frame to display */
   private _name!: Text; // removed readonly to allow reassignment for fixed layout
-  private readonly rectRef = React.createRef<KonvaRect | null>();
+  private readonly rectRef = createRef<KonvaRect | null>();
   /** the level in which this frame resides */
   readonly level: Level | undefined;
   /** environment associated with this frame */

--- a/src/features/cseMachine/components/Level.tsx
+++ b/src/features/cseMachine/components/Level.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group, Rect } from 'react-konva';
 
 import CseMachine from '../CseMachine';

--- a/src/features/cseMachine/components/StashItemComponent.tsx
+++ b/src/features/cseMachine/components/StashItemComponent.tsx
@@ -1,5 +1,5 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Label, Tag, Text } from 'react-konva';
 
 import { FnValue } from '../components/values/FnValue';
@@ -35,7 +35,7 @@ export class StashItemComponent extends Visible implements IHoverable {
   readonly text: string;
   /** text to display on hover */
   readonly tooltip: string;
-  readonly tooltipRef: RefObject<any>;
+  readonly tooltipRef: React.RefObject<any>;
   readonly arrow?: ArrowFromStashItemComponent;
 
   constructor(
@@ -68,7 +68,7 @@ export class StashItemComponent extends Visible implements IHoverable {
       ControlStashConfig.StashMaxTextHeight
     ).replace(/[\r\n]/gm, ' ');
     this.tooltip = valToStashRep(value);
-    this.tooltipRef = React.createRef();
+    this.tooltipRef = createRef();
     this._width =
       ControlStashConfig.StashItemTextPadding * 2 +
       getTextWidth(
@@ -134,7 +134,7 @@ export class StashItemComponent extends Visible implements IHoverable {
       cornerRadius: ControlStashConfig.StashItemCornerRadius
     };
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <Label
           ref={this.ref}
           x={this.x()}
@@ -166,7 +166,7 @@ export class StashItemComponent extends Visible implements IHoverable {
           />
         </Label>
         {this.arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/StashStack.tsx
+++ b/src/features/cseMachine/components/StashStack.tsx
@@ -1,7 +1,6 @@
 import { Stash } from 'js-slang/dist/cse-machine/interpreter';
 import { Chapter } from 'js-slang/dist/langs';
 import { Value } from 'js-slang/dist/types';
-import React from 'react';
 
 import CseMachine from '../CseMachine';
 import { ControlStashConfig } from '../CseMachineControlStashConfig';

--- a/src/features/cseMachine/components/Text.tsx
+++ b/src/features/cseMachine/components/Text.tsx
@@ -1,6 +1,6 @@
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
-import React from 'react';
+import { createRef, Fragment } from 'react';
 import { Label as KonvaLabel, Tag as KonvaTag, Text as KonvaText } from 'react-konva';
 
 import CseMachine from '../CseMachine';
@@ -52,7 +52,7 @@ export class Text extends Visible implements IHoverable {
   readonly fullStr: string; // full string representation of data
 
   readonly options: TextOptions = defaultOptions;
-  readonly labelRef: React.RefObject<Label | null> = React.createRef();
+  readonly labelRef: React.RefObject<Label | null> = createRef();
 
   constructor(
     readonly data: Data,
@@ -152,7 +152,7 @@ export class Text extends Visible implements IHoverable {
       visible: !this.options.hidden
     };
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <KonvaLabel
           x={this.x()}
           y={this.y()}
@@ -182,7 +182,7 @@ export class Text extends Visible implements IHoverable {
           />
           <KonvaText {...ShapeDefaultProps} key={Layout.key++} text={this.fullStr} {...props} />
         </KonvaLabel>
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/Visible.tsx
+++ b/src/features/cseMachine/components/Visible.tsx
@@ -1,6 +1,5 @@
 import Konva from 'konva';
-import React from 'react';
-import { RefObject } from 'react';
+import { createRef, type RefObject } from 'react';
 
 import { IVisible } from '../CseMachineTypes';
 
@@ -44,7 +43,7 @@ export abstract class Visible implements IVisible {
       }
     });
   }
-  public ref: RefObject<any> = React.createRef();
+  public ref: RefObject<any> = createRef();
   protected get tag() {
     return this.ref.current?.getChildren?.()[0];
   }

--- a/src/features/cseMachine/components/Visible.tsx
+++ b/src/features/cseMachine/components/Visible.tsx
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import { createRef, type RefObject } from 'react';
+import { createRef } from 'react';
 
 import { IVisible } from '../CseMachineTypes';
 
@@ -43,7 +43,7 @@ export abstract class Visible implements IVisible {
       }
     });
   }
-  public ref: RefObject<any> = createRef();
+  public ref: React.RefObject<any> = createRef();
   protected get tag() {
     return this.ref.current?.getChildren?.()[0];
   }

--- a/src/features/cseMachine/components/arrows/Arrow.tsx
+++ b/src/features/cseMachine/components/arrows/Arrow.tsx
@@ -1,5 +1,4 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
 
 import { ArrayUnit } from '../ArrayUnit';
 import { ControlItemComponent } from '../ControlItemComponent';
@@ -26,7 +25,7 @@ export abstract class Arrow {
   abstract onClick(e: KonvaEventObject<MouseEvent>): void;
   abstract source: Visible;
   abstract target: Visible | undefined;
-  abstract ref: RefObject<any>;
+  abstract ref: React.RefObject<any>;
   abstract x(): number;
   abstract y(): number;
   abstract height(): number;

--- a/src/features/cseMachine/components/arrows/ArrowFromFnTooltip.tsx
+++ b/src/features/cseMachine/components/arrows/ArrowFromFnTooltip.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react';
-
 import { Config } from '../../CseMachineConfig';
 import { StepsArray } from '../../CseMachineTypes';
 import { FnValue } from '../values/FnValue';
@@ -32,7 +30,7 @@ class FnLeftCircleAnchor extends Visible {
     return Config.FnInnerRadius * 2;
   }
 
-  draw(): ReactNode {
+  draw(): React.ReactNode {
     return null;
   }
 }
@@ -65,7 +63,7 @@ class FnTooltipAnchor extends Visible {
     return this.rect().height;
   }
 
-  draw(): ReactNode {
+  draw(): React.ReactNode {
     return null;
   }
 }

--- a/src/features/cseMachine/components/arrows/GenericArrow.tsx
+++ b/src/features/cseMachine/components/arrows/GenericArrow.tsx
@@ -1,6 +1,6 @@
 import Konva from 'konva';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef } from 'react';
 import { Arrow as KonvaArrow, Group as KonvaGroup, Path as KonvaPath } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
@@ -23,10 +23,10 @@ export class GenericArrow<Source extends IVisible, Target extends IVisible>
   target: Target | undefined;
   faded: boolean = false;
   protected _visible: boolean = true;
-  private pathRef: RefObject<Konva.Path | null> = React.createRef();
-  private sourceSegmentPathRef: RefObject<Konva.Path | null> = React.createRef();
-  private sourceSegmentGroupRef: RefObject<Konva.Group | null> = React.createRef();
-  private arrowHeadRef: RefObject<Konva.Arrow | null> = React.createRef();
+  private pathRef: React.RefObject<Konva.Path | null> = createRef();
+  private sourceSegmentPathRef: React.RefObject<Konva.Path | null> = createRef();
+  private sourceSegmentGroupRef: React.RefObject<Konva.Group | null> = createRef();
+  private arrowHeadRef: React.RefObject<Konva.Arrow | null> = createRef();
 
   // Check if this arrow is selected
   protected isSelected(): boolean {

--- a/src/features/cseMachine/components/shapes/RoundedRect.tsx
+++ b/src/features/cseMachine/components/shapes/RoundedRect.tsx
@@ -1,5 +1,4 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
 import { Shape } from 'react-konva';
 
 import { ShapeDefaultProps } from '../../CseMachineConfig';
@@ -15,7 +14,7 @@ interface Props {
   listening?: boolean;
   fillEnabled: boolean;
   hitStrokeWidth: number;
-  forwardRef: RefObject<any>;
+  forwardRef: React.RefObject<any>;
   onMouseEnter?: ({ currentTarget }: KonvaEventObject<MouseEvent>) => void;
   onMouseLeave?: ({ currentTarget }: KonvaEventObject<MouseEvent>) => void;
   onClick?: ({ currentTarget }: KonvaEventObject<MouseEvent>) => void;

--- a/src/features/cseMachine/components/values/ArrayValue.tsx
+++ b/src/features/cseMachine/components/values/ArrayValue.tsx
@@ -1,5 +1,4 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React from 'react';
 import { Group } from 'react-konva';
 
 import CseMachine from '../../CseMachine';

--- a/src/features/cseMachine/components/values/ContValue.tsx
+++ b/src/features/cseMachine/components/values/ContValue.tsx
@@ -2,7 +2,7 @@ import { Control, Stash } from 'js-slang/dist/cse-machine/interpreter';
 import { Environment } from 'js-slang/dist/types';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import {
   Circle,
   Group,
@@ -37,7 +37,7 @@ import { Value } from './Value';
 export class ContValue extends Value implements IHoverable {
   readonly radius: number = Config.FnRadius;
   readonly innerRadius: number = Config.FnInnerRadius;
-  readonly labelRef: RefObject<Label | null> = React.createRef();
+  readonly labelRef: React.RefObject<Label | null> = createRef();
 
   readonly tooltip: string = 'continuation';
   readonly tooltipWidth: number = getTextWidth(this.tooltip);
@@ -150,7 +150,7 @@ export class ContValue extends Value implements IHoverable {
     //dont need to check isReferenced here since live is ALL we need to know
 
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <Group onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave} ref={this.ref}>
           <Rect
             {...ShapeDefaultProps}
@@ -212,7 +212,7 @@ export class ContValue extends Value implements IHoverable {
           />
         </KonvaLabel>
         {this._arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/values/FnValue.tsx
+++ b/src/features/cseMachine/components/values/FnValue.tsx
@@ -1,6 +1,6 @@
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Circle, Group } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
@@ -50,8 +50,8 @@ export class FnValue extends Value implements IHoverable {
 
   /** width of the closure circles + label */
   readonly totalWidth: number;
-  readonly labelRef: RefObject<Label | null> = React.createRef();
-  readonly revealLabelRef: RefObject<Label | null> = React.createRef();
+  readonly labelRef: React.RefObject<Label | null> = createRef();
+  readonly revealLabelRef: React.RefObject<Label | null> = createRef();
 
   centerX: number;
   enclosingFrame?: Frame;
@@ -260,7 +260,7 @@ export class FnValue extends Value implements IHoverable {
     );
     // Keep function objects rendered so they remain hoverable in clear-dead-frames mode.
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <Group
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
@@ -302,7 +302,7 @@ export class FnValue extends Value implements IHoverable {
         </Group>
         {this._arrow?.draw()}
         {this.tooltipArrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/values/GlobalFnValue.tsx
+++ b/src/features/cseMachine/components/values/GlobalFnValue.tsx
@@ -1,6 +1,6 @@
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Label } from 'konva/lib/shapes/Label';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Circle, Group } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
@@ -42,8 +42,8 @@ export class GlobalFnValue extends Value implements IHoverable {
   readonly printDescriptionOffsetY: number;
   readonly printDescriptionBottomGap: number;
   readonly totalWidth: number;
-  readonly labelRef: RefObject<Label | null> = React.createRef();
-  readonly revealLabelRef: RefObject<Label | null> = React.createRef();
+  readonly labelRef: React.RefObject<Label | null> = createRef();
+  readonly revealLabelRef: React.RefObject<Label | null> = createRef();
 
   centerX: number;
   private isExpandedDescription: boolean = false;
@@ -224,7 +224,7 @@ export class GlobalFnValue extends Value implements IHoverable {
       />
     );
     return (
-      <React.Fragment key={Layout.key++}>
+      <Fragment key={Layout.key++}>
         <Group
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
@@ -266,7 +266,7 @@ export class GlobalFnValue extends Value implements IHoverable {
         </Group>
         {this._arrow?.draw()}
         {this.tooltipArrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/components/values/PrimitiveValue.tsx
+++ b/src/features/cseMachine/components/values/PrimitiveValue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 
 import { Config } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
@@ -117,6 +117,6 @@ export class PrimitiveValue extends Value {
       this.text.setX(this.x());
       this.text.setY(this.y());
     }
-    return <React.Fragment key={Layout.key++}>{this.text.draw()}</React.Fragment>;
+    return <Fragment key={Layout.key++}>{this.text.draw()}</Fragment>;
   }
 }

--- a/src/features/cseMachine/components/values/UnassignedValue.tsx
+++ b/src/features/cseMachine/components/values/UnassignedValue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 
 import { Config } from '../../CseMachineConfig';
 import { Layout } from '../../CseMachineLayout';
@@ -45,6 +45,6 @@ export class UnassignedValue extends Value {
 
   draw(): React.ReactNode {
     this._isDrawn = true;
-    return <React.Fragment key={Layout.key++}>{this.text.draw()}</React.Fragment>;
+    return <Fragment key={Layout.key++}>{this.text.draw()}</Fragment>;
   }
 }

--- a/src/features/cseMachine/components/values/Value.tsx
+++ b/src/features/cseMachine/components/values/Value.tsx
@@ -1,5 +1,4 @@
 import { Label } from 'konva/lib/shapes/Label';
-import React, { RefObject } from 'react';
 import { Label as KonvaLabel, Tag as KonvaTag, Text as KonvaText } from 'react-konva';
 
 import CseMachine from '../../CseMachine';
@@ -18,8 +17,8 @@ type FunctionTooltipLabelsProps = {
   tooltip: string;
   strokeColor: string;
   textColor: string;
-  labelRef: RefObject<Label | null>;
-  revealLabelRef: RefObject<Label | null>;
+  labelRef: React.RefObject<Label | null>;
+  revealLabelRef: React.RefObject<Label | null>;
 };
 
 export const FunctionTooltipLabels = ({
@@ -35,7 +34,7 @@ export const FunctionTooltipLabels = ({
   labelRef,
   revealLabelRef
 }: FunctionTooltipLabelsProps): React.ReactNode => (
-  <React.Fragment>
+  <>
     <KonvaLabel
       x={x + Config.TextMargin}
       y={y + radius + Config.TextMargin + printDescriptionOffsetY}
@@ -85,7 +84,7 @@ export const FunctionTooltipLabels = ({
         />
       </KonvaLabel>
     )}
-  </React.Fragment>
+  </>
 );
 
 /** the value of a `Binding` or an `ArrayUnit` */

--- a/src/features/cseMachine/java/CseMachine.tsx
+++ b/src/features/cseMachine/java/CseMachine.tsx
@@ -1,6 +1,6 @@
 import { ECE } from 'java-slang';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef } from 'react';
 import { Layer, Rect, Stage } from 'react-konva';
 
 import { defaultBackgroundColor } from '../CseMachineUtils';
@@ -21,7 +21,7 @@ export class CseMachine {
   /** function to highlight editor lines */
   public static setEditorHighlightedLines: SetEditorHighlightedLines;
 
-  public static stageRef: RefObject<any> = React.createRef();
+  public static stageRef: React.RefObject<any> = createRef();
   /** scale factor for zooming and out of canvas */
   public static scaleFactor = 1.02;
 

--- a/src/features/cseMachine/java/components/Binding.tsx
+++ b/src/features/cseMachine/java/components/Binding.tsx
@@ -1,5 +1,5 @@
 import { ECE } from 'java-slang';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { Visible } from '../../components/Visible';
 import { Config } from '../../CseMachineConfig';
@@ -83,14 +83,14 @@ export class Binding extends Visible {
 
   draw(): React.ReactNode {
     return (
-      <React.Fragment key={CseMachine.key++}>
+      <Fragment key={CseMachine.key++}>
         {/* Name */}
         {this._name.draw()}
 
         {/* Value */}
         {this._value.draw()}
         {this._arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/java/components/ControlItem.tsx
+++ b/src/features/cseMachine/java/components/ControlItem.tsx
@@ -1,5 +1,5 @@
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Label, Tag, Text } from 'react-konva';
 
 import { Visible } from '../../components/Visible';
@@ -22,7 +22,7 @@ import { Frame } from './Frame';
 
 export class ControlItem extends Visible implements IHoverable {
   private readonly _arrow: Arrow | undefined;
-  private readonly _tooltipRef: RefObject<any>;
+  private readonly _tooltipRef: React.RefObject<any>;
 
   constructor(
     y: number,
@@ -50,7 +50,7 @@ export class ControlItem extends Visible implements IHoverable {
     );
 
     // Tooltip.
-    this._tooltipRef = React.createRef();
+    this._tooltipRef = createRef();
 
     // Height and width.
     this._height =
@@ -106,7 +106,7 @@ export class ControlItem extends Visible implements IHoverable {
       cornerRadius: ControlStashConfig.ControlItemCornerRadius
     };
     return (
-      <React.Fragment key={CseMachine.key++}>
+      <Fragment key={CseMachine.key++}>
         {/* Text */}
         <Label
           x={this.x()}
@@ -152,7 +152,7 @@ export class ControlItem extends Visible implements IHoverable {
 
         {/* Arrow */}
         {this._arrow?.draw()}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/java/components/Frame.tsx
+++ b/src/features/cseMachine/java/components/Frame.tsx
@@ -1,6 +1,6 @@
 import { ECE } from 'java-slang';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef } from 'react';
 import { Group, Label, Rect, Tag, Text as KonvaText } from 'react-konva';
 
 import { Visible } from '../../components/Visible';
@@ -15,7 +15,7 @@ import { Method } from './Method';
 import { Text } from './Text';
 
 export class Frame extends Visible implements IHoverable {
-  readonly tooltipRef: RefObject<any>;
+  readonly tooltipRef: React.RefObject<any>;
 
   readonly bindings: Binding[] = [];
   readonly name: Text;
@@ -59,7 +59,7 @@ export class Frame extends Visible implements IHoverable {
         b.setArrowToX(this._x + this._width + Config.FramePaddingX);
       });
 
-    this.tooltipRef = React.createRef();
+    this.tooltipRef = createRef();
   }
 
   setWidth(width: number) {

--- a/src/features/cseMachine/java/components/Method.tsx
+++ b/src/features/cseMachine/java/components/Method.tsx
@@ -1,6 +1,6 @@
 import { astToString, ECE } from 'java-slang';
 import { KonvaEventObject } from 'konva/lib/Node';
-import React, { RefObject } from 'react';
+import { createRef, Fragment } from 'react';
 import { Circle, Group, Label, Tag, Text } from 'react-konva';
 
 import { Visible } from '../../components/Visible';
@@ -20,7 +20,7 @@ import { CseMachine } from '../CseMachine';
 export class Method extends Visible implements IHoverable {
   private _centerX: number;
 
-  private readonly _tooltipRef: RefObject<any>;
+  private readonly _tooltipRef: React.RefObject<any>;
   private readonly _tooltip: string;
 
   constructor(
@@ -38,7 +38,7 @@ export class Method extends Visible implements IHoverable {
     this._centerX = this._x + Config.FnRadius * 2;
 
     // Tooltip.
-    this._tooltipRef = React.createRef();
+    this._tooltipRef = createRef();
     this._tooltip = astToString(this._method.mtdOrCon);
   }
 
@@ -63,7 +63,7 @@ export class Method extends Visible implements IHoverable {
 
   draw(): React.ReactNode {
     return (
-      <React.Fragment key={CseMachine.key++}>
+      <Fragment key={CseMachine.key++}>
         <Group
           onMouseEnter={e => this.onMouseEnter(e)}
           onMouseLeave={e => this.onMouseLeave(e)}
@@ -114,7 +114,7 @@ export class Method extends Visible implements IHoverable {
             key={CseMachine.key++}
           />
         </Label>
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/src/features/cseMachine/java/components/Object.tsx
+++ b/src/features/cseMachine/java/components/Object.tsx
@@ -1,5 +1,4 @@
 import { ECE } from 'java-slang';
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { Visible } from '../../components/Visible';

--- a/src/features/cseMachine/java/components/Stash.tsx
+++ b/src/features/cseMachine/java/components/Stash.tsx
@@ -1,5 +1,4 @@
 import { ECE } from 'java-slang';
-import React from 'react';
 import { Group } from 'react-konva';
 
 import { Visible } from '../../components/Visible';

--- a/src/features/cseMachine/java/components/StashItem.tsx
+++ b/src/features/cseMachine/java/components/StashItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Group as KonvaGroup,
   Label as KonvaLabel,

--- a/src/features/cseMachine/java/components/Text.tsx
+++ b/src/features/cseMachine/java/components/Text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Group as KonvaGroup, Label as KonvaLabel, Text as KonvaText } from 'react-konva';
 
 import { Visible } from '../../components/Visible';

--- a/src/features/cseMachine/java/components/Variable.tsx
+++ b/src/features/cseMachine/java/components/Variable.tsx
@@ -1,5 +1,4 @@
 import { ECE } from 'java-slang';
-import React from 'react';
 import { Group, Rect } from 'react-konva';
 
 import { Visible } from '../../components/Visible';

--- a/src/features/dataVisualizer/dataVisualizer.tsx
+++ b/src/features/dataVisualizer/dataVisualizer.tsx
@@ -1,5 +1,3 @@
-import type { JSX } from 'react';
-
 import { Config } from './Config';
 import { Data, Step } from './dataVisualizerTypes';
 import { Tree } from './tree/Tree';
@@ -254,7 +252,7 @@ export default class DataVisualizer {
     this.steps.push(step);
   }
 
-  private createDrawing(xs: Data, key: number): JSX.Element {
+  private createDrawing(xs: Data, key: number): React.ReactElement {
     const treeDrawer = Tree.fromSourceStructure(xs).draw();
 
     // To account for overflow to the left side due to a backward arrow

--- a/src/features/dataVisualizer/dataVisualizerTypes.ts
+++ b/src/features/dataVisualizer/dataVisualizerTypes.ts
@@ -1,5 +1,3 @@
-import type { JSX } from 'react';
-
 // Source-related types
 export type Data = any;
 export type Pair = [Data, Data];
@@ -7,5 +5,5 @@ export type EmptyList = null;
 export type List = [Data, List] | EmptyList;
 
 // Drawing-related types
-export type Drawing = JSX.Element;
+export type Drawing = React.ReactElement;
 export type Step = Drawing[];

--- a/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { PureComponent } from 'react';
 import { Group, Line, Rect, Text } from 'react-konva';
 
 import { Config } from '../Config';
@@ -17,7 +17,7 @@ type ArrayProps = {
 /**
  *  Represents an array in a tree.
  */
-class ArrayDrawable extends React.PureComponent<ArrayProps> {
+class ArrayDrawable extends PureComponent<ArrayProps> {
   render() {
     const createChildText = (node: DataTreeNode, index: number) => {
       const nodeValue = node.data;

--- a/src/features/dataVisualizer/drawable/ArrowDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/ArrowDrawable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Arrow } from 'react-konva';
 
 import { Config } from '../Config';
@@ -56,4 +56,4 @@ const ArrowDrawable: React.FC<Props> = props => {
   }
 };
 
-export default React.memo(ArrowDrawable);
+export default memo(ArrowDrawable);

--- a/src/features/dataVisualizer/drawable/BackwardArrowDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/BackwardArrowDrawable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Arrow } from 'react-konva';
 
 import { Config } from '../Config';
@@ -63,4 +63,4 @@ const BackwardArrowDrawable: React.FC<Props> = ({ from, to }) => {
   );
 };
 
-export default React.memo(BackwardArrowDrawable);
+export default memo(BackwardArrowDrawable);

--- a/src/features/dataVisualizer/drawable/FunctionDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/FunctionDrawable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { PureComponent } from 'react';
 import { Circle, Group } from 'react-konva';
 
 import { Config } from '../Config';
@@ -11,7 +11,7 @@ type FunctionProps = {
 /**
  * Represents a function object drawn using two circles.
  */
-class FunctionDrawable extends React.PureComponent<FunctionProps> {
+class FunctionDrawable extends PureComponent<FunctionProps> {
   render() {
     return (
       <Group {...this.props}>

--- a/src/features/dataVisualizer/drawable/NullDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/NullDrawable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { PureComponent } from 'react';
 import { Line } from 'react-konva';
 
 import { Config } from '../Config';
@@ -14,7 +14,7 @@ type NullProps = {
  *
  *  Used in conjunction with ArrayDrawable.
  */
-class NullDrawable extends React.PureComponent<NullProps> {
+class NullDrawable extends PureComponent<NullProps> {
   render() {
     return (
       <Line

--- a/src/features/dataVisualizer/tree/ArrayTreeNode.tsx
+++ b/src/features/dataVisualizer/tree/ArrayTreeNode.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from 'react';
 import { Group } from 'react-konva';
 
 import { Config } from '../Config';
@@ -16,7 +15,7 @@ export class ArrayTreeNode extends DrawableTreeNode {
     parentX: number,
     parentY: number,
     colorIndex: number
-  ): JSX.Element {
+  ): React.ReactElement {
     let color = '';
     color = colorIndex === -1 ? 'black' : this.Colors[colorIndex % this.Colors.length];
     const arrayProps = { nodes: this.children ?? [], x, y, color };

--- a/src/features/dataVisualizer/tree/BinaryTreeDrawer.tsx
+++ b/src/features/dataVisualizer/tree/BinaryTreeDrawer.tsx
@@ -1,5 +1,4 @@
 import Konva from 'konva';
-import type { JSX } from 'react';
 import { Layer, Stage, Text } from 'react-konva';
 
 import { Config } from '../Config';
@@ -20,7 +19,7 @@ import {
  * Tree drawer for binary tree view
  */
 export class BinaryTreeDrawer extends OriginalDrawer {
-  draw(x: number, y: number, key: number): JSX.Element {
+  draw(x: number, y: number, key: number): React.ReactElement {
     // NON-BINARY TREE WARNING
     if (!DataVisualizer.isBinTree) {
       return (
@@ -116,7 +115,7 @@ export class BinaryTreeDrawer extends OriginalDrawer {
 
       const isBackwardArrow = arrowProps.from.y >= arrowProps.to.y;
 
-      let arrow: JSX.Element;
+      let arrow: React.ReactElement;
 
       if (isBackwardArrow) {
         // Update the minX and minY, in case overflow to the top or left happens

--- a/src/features/dataVisualizer/tree/DrawableTreeNode.tsx
+++ b/src/features/dataVisualizer/tree/DrawableTreeNode.tsx
@@ -1,5 +1,3 @@
-import type { JSX } from 'react';
-
 import { TreeNode } from './BaseTreeNode';
 
 /**
@@ -8,7 +6,7 @@ import { TreeNode } from './BaseTreeNode';
  * Concrete implementations: ArrayTreeNode, FunctionTreeNode
  */
 export abstract class DrawableTreeNode extends TreeNode {
-  protected _drawable?: JSX.Element;
+  protected _drawable?: React.ReactElement;
   public drawableX?: number;
   public drawableY?: number;
 
@@ -31,5 +29,5 @@ export abstract class DrawableTreeNode extends TreeNode {
     parentX: number,
     parentY: number,
     colorIndex: number
-  ): JSX.Element;
+  ): React.ReactElement;
 }

--- a/src/features/dataVisualizer/tree/FunctionTreeNode.tsx
+++ b/src/features/dataVisualizer/tree/FunctionTreeNode.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from 'react';
 import { Group } from 'react-konva';
 
 import { Config } from '../Config';
@@ -15,7 +14,7 @@ export class FunctionTreeNode extends DrawableTreeNode {
     parentX: number,
     parentY: number,
     colorIndex: number
-  ): JSX.Element {
+  ): React.ReactElement {
     this._drawable = (
       <Group key={x + ', ' + y}>
         <FunctionDrawable {...{ x, y }}></FunctionDrawable>

--- a/src/features/dataVisualizer/tree/GeneralTreeDrawer.tsx
+++ b/src/features/dataVisualizer/tree/GeneralTreeDrawer.tsx
@@ -1,5 +1,4 @@
 import Konva from 'konva';
-import type { JSX } from 'react';
 import { Layer, Stage, Text } from 'react-konva';
 
 import { Config } from '../Config';
@@ -20,7 +19,7 @@ import {
  * Tree drawer for general tree view
  */
 export class GeneralTreeDrawer extends OriginalDrawer {
-  draw(x: number, y: number, key: number): JSX.Element {
+  draw(x: number, y: number, key: number): React.ReactElement {
     // NON-GENERAL TREE WARNING
     if (!DataVisualizer.isGenTree) {
       return (
@@ -108,7 +107,7 @@ export class GeneralTreeDrawer extends OriginalDrawer {
 
       const isBackwardArrow = arrowProps.from.y >= arrowProps.to.y;
 
-      let arrow: JSX.Element;
+      let arrow: React.ReactElement;
 
       if (isBackwardArrow) {
         // Update the minX and minY, in case overflow to the top or left happens

--- a/src/features/dataVisualizer/tree/OriginalDrawer.tsx
+++ b/src/features/dataVisualizer/tree/OriginalDrawer.tsx
@@ -1,5 +1,4 @@
 import Konva from 'konva';
-import type { JSX } from 'react';
 import { Layer, Stage, Text } from 'react-konva';
 
 import { Config } from '../Config';
@@ -27,7 +26,7 @@ export class OriginalDrawer {
   protected runningY: number = 0;
   protected runningX2: number = 0; // for rightCOUNTER
 
-  protected drawables: JSX.Element[];
+  protected drawables: React.ReactElement[];
   protected nodeWidths: Map<TreeNode, number>;
   public width: number = 0;
   public height: number = 0;
@@ -48,7 +47,7 @@ export class OriginalDrawer {
   /**
    * Draws a tree at x, y, by calling drawNode on the root at x, y.
    */
-  draw(x: number, y: number, key: number): JSX.Element {
+  draw(x: number, y: number, key: number): React.ReactElement {
     if (this.tree.rootNode instanceof DataTreeNode) {
       const text = toText(this.tree.rootNode.data);
       const textConfig = {
@@ -118,7 +117,7 @@ export class OriginalDrawer {
 
       const isBackwardArrow = arrowProps.from.y >= arrowProps.to.y;
 
-      let arrow: JSX.Element;
+      let arrow: React.ReactElement;
 
       if (isBackwardArrow) {
         // Update the minX and minY, in case overflow to the top or left happens

--- a/src/features/dataVisualizer/tree/TreeNode.ts
+++ b/src/features/dataVisualizer/tree/TreeNode.ts
@@ -1,5 +1,5 @@
+export { ArrayTreeNode } from './ArrayTreeNode';
 export { TreeNode } from './BaseTreeNode';
 export { DataTreeNode } from './DataTreeNode';
 export { DrawableTreeNode } from './DrawableTreeNode';
 export { FunctionTreeNode } from './FunctionTreeNode';
-export { ArrayTreeNode } from './ArrayTreeNode';

--- a/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
+++ b/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
+import { useState } from 'react';
 import { QrReader } from 'react-qr-reader';
 import { useDispatch } from 'react-redux';
 
@@ -50,10 +50,10 @@ const RemoteExecutionDeviceDialog: React.FC<Props> = ({
   const typeField = useField<HTMLSelectElement>();
   const secretField = useField<HTMLInputElement>(validateNotEmpty);
 
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
-  const [showScanner, setShowScanner] = React.useState(false);
-  const [cameraFacingMode, setCameraFacingMode] = React.useState(FACING_MODE.ENVIRONMENT);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [showScanner, setShowScanner] = useState(false);
+  const [cameraFacingMode, setCameraFacingMode] = useState(FACING_MODE.ENVIRONMENT);
 
   const onSubmit = async () => {
     const fields = collectFieldValues(nameField, typeField, secretField);

--- a/src/features/sicp/SourceTheme.ts
+++ b/src/features/sicp/SourceTheme.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 /**
  * Source Theme for use with react-syntax-highlighter.
  * Tries to match the Source Theme for Ace Editor in js-slang

--- a/src/features/sicp/TableOfContentsButton.tsx
+++ b/src/features/sicp/TableOfContentsButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ControlButton from '../../commons/ControlButton';
 
 type TableOfContentsButtonProps = {

--- a/src/features/sicp/errors/SicpErrorBoundary.tsx
+++ b/src/features/sicp/errors/SicpErrorBoundary.tsx
@@ -1,9 +1,9 @@
-import { Component, ErrorInfo, ReactNode } from 'react';
+import { Component } from 'react';
 
 import getSicpError, { SicpErrorType } from './SicpErrors';
 
 type Props = {
-  children: ReactNode;
+  children: React.ReactNode;
 };
 
 type State = {
@@ -20,7 +20,7 @@ class SicpErrorBoundary extends Component<Props, State> {
     return { hasError: true };
   }
 
-  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('Uncaught error:', error, errorInfo);
   }
 

--- a/src/features/sicp/errors/SicpErrors.tsx
+++ b/src/features/sicp/errors/SicpErrors.tsx
@@ -1,6 +1,5 @@
 import { NonIdealState } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import type { JSX } from 'react';
 
 export enum SicpErrorType {
   UNEXPECTED_ERROR,
@@ -40,7 +39,7 @@ const parsingError = (
   </div>
 );
 
-const errorComponent = (description: JSX.Element) => (
+const errorComponent = (description: React.ReactElement) => (
   <NonIdealState title="Something went wrong :(" description={description} icon={IconNames.ERROR} />
 );
 

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -1,6 +1,6 @@
 import { Blockquote, Code, H1, H2, H4, Icon, OL, Pre, UL } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { type JSX } from 'react';
+import { Fragment } from 'react';
 import { Link } from 'react-router';
 import Constants from 'src/commons/utils/Constants';
 import SicpExercise from 'src/pages/sicp/subcomponents/SicpExercise';
@@ -104,10 +104,10 @@ const handleEpigraph = (obj: JsonType, refs: RefType) => {
   const hasAttribution = author || title || date;
 
   const attribution = [];
-  attribution.push(<React.Fragment key="attribution">-</React.Fragment>);
+  attribution.push(<Fragment key="attribution">-</Fragment>);
 
   if (author) {
-    attribution.push(<React.Fragment key="author">{author}</React.Fragment>);
+    attribution.push(<Fragment key="author">{author}</Fragment>);
   }
 
   if (title) {
@@ -115,7 +115,7 @@ const handleEpigraph = (obj: JsonType, refs: RefType) => {
   }
 
   if (date) {
-    attribution.push(<React.Fragment key="date">{date}</React.Fragment>);
+    attribution.push(<Fragment key="date">{date}</Fragment>);
   }
 
   const text = child && parseArr(child, refs);
@@ -220,7 +220,10 @@ const handleLatex = (math: string) => {
   return <SicpLatex math={math} />;
 };
 
-export const processingFunctions: Record<string, (obj: JsonType, refs: RefType) => JSX.Element> = {
+export const processingFunctions: Record<
+  string,
+  (obj: JsonType, refs: RefType) => React.ReactElement
+> = {
   '#text': (obj, _refs) => handleText(obj.body!),
 
   B: (obj, refs) => <b>{parseArr(obj.child!, refs)}</b>,
@@ -312,12 +315,12 @@ export const parseArr = (arr: Array<JsonType>, refs: RefType) => {
 export const parseObj = (obj: JsonType, index: number | undefined, refs: RefType) => {
   if (obj.tag) {
     if (processingFunctions[obj.tag]) {
-      return <React.Fragment key={index}>{processingFunctions[obj.tag](obj, refs)}</React.Fragment>;
+      return <Fragment key={index}>{processingFunctions[obj.tag](obj, refs)}</Fragment>;
     } else {
       throw new ParseJsonError('Unrecognised Tag: ' + obj.tag);
     }
   } else {
     // Handle case where tag does not exists. Should not happen if json file is created properly.
-    return <React.Fragment key={index}>{parseArr(obj.child!, refs)}</React.Fragment>;
+    return <Fragment key={index}>{parseArr(obj.child!, refs)}</Fragment>;
   }
 };

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -1,7 +1,7 @@
 import { Card, Classes } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React, { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AceEditor from 'react-ace';
 import { useDispatch } from 'react-redux';
 import { ResultOutput, styliseSublanguage } from 'src/commons/application/ApplicationTypes';
@@ -76,7 +76,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   const output = useTypedSelector(store => store.stories.envs[env]?.output || []);
   const { selectedTab, setSelectedTab } = useSideContent(`stories.${env}`);
 
-  const onChangeTabs = React.useCallback(
+  const onChangeTabs = useCallback(
     (
       newTabId: SideContentType,
       prevTabId: SideContentType,
@@ -126,7 +126,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
     id: SideContentType.storiesRun
   };
 
-  const tabs = React.useMemo(() => {
+  const tabs = useMemo(() => {
     const tabs: SideContentTab[] = [outputTab];
 
     // TODO: Restore logic post refactor

--- a/src/features/stories/storiesComponents/UserBlogContent.tsx
+++ b/src/features/stories/storiesComponents/UserBlogContent.tsx
@@ -1,6 +1,6 @@
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import yaml from 'js-yaml';
-import React, { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import debounceRender from 'react-debounce-render';
 import Constants from 'src/commons/utils/Constants';
 import { propsAreEqual } from 'src/commons/utils/MemoizeHelper';
@@ -115,4 +115,4 @@ const UserBlogContent: React.FC<Props> = ({ fileContent }) => {
   );
 };
 
-export default React.memo(debounceRender(UserBlogContent, 500), propsAreEqual);
+export default memo(debounceRender(UserBlogContent, 500), propsAreEqual);

--- a/src/pages/academy/Academy.tsx
+++ b/src/pages/academy/Academy.tsx
@@ -1,6 +1,6 @@
 import { Card, Classes, NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Navigate, Outlet, useNavigate, useParams } from 'react-router';
 import ResearchAgreementPrompt from 'src/commons/researchAgreementPrompt/ResearchAgreementPrompt';
@@ -14,7 +14,7 @@ import RagChatbot from './ragChatbot/RagChatbot';
 
 const Academy: React.FC = () => {
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(SessionActions.fetchStudents());
     dispatch(SessionActions.fetchNotifications());
     dispatch(SessionActions.fetchTeamFormationOverviews(false));
@@ -40,7 +40,7 @@ const CourseSelectingAcademy: React.FC = () => {
   const { courseId: routeCourseIdStr } = useParams<{ courseId?: string }>();
   const routeCourseId = routeCourseIdStr != null ? parseInt(routeCourseIdStr, 10) : undefined;
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Regex to handle case where routeCourseIdStr is not a number
     if (!routeCourseIdStr?.match(numberRegExp)) {
       navigate('/');

--- a/src/pages/academy/adminPanel/AdminPanel.tsx
+++ b/src/pages/academy/adminPanel/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import { Button, Divider, H1, Intent, Tab, Tabs } from '@blueprintjs/core';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 import { useSession, useTypedSelector } from 'src/commons/utils/Hooks';

--- a/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
@@ -15,7 +15,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { type ColDef, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { uniqBy } from 'lodash';
-import React, { type JSX } from 'react';
+import { type JSX, useState } from 'react';
 import { useCSVReader } from 'react-papaparse';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 
@@ -45,8 +45,8 @@ const defaultColumnDefs: ColDef = {
 };
 
 const AddStoriesUserPanel: React.FC<Props> = props => {
-  const [users, setUsers] = React.useState<NameUsernameRole[]>([]);
-  const [invalidCsvMsg, setInvalidCsvMsg] = React.useState<string | JSX.Element>('');
+  const [users, setUsers] = useState<NameUsernameRole[]>([]);
+  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | JSX.Element>('');
   const { CSVReader } = useCSVReader();
 
   const grid = (
@@ -66,7 +66,7 @@ const AddStoriesUserPanel: React.FC<Props> = props => {
   );
 
   const htmlSelectOptions = [...Constants.authProviders.entries()].map(([id, _]) => id);
-  const [provider, setProvider] = React.useState(htmlSelectOptions[0]);
+  const [provider, setProvider] = useState(htmlSelectOptions[0]);
 
   const validateCsvInput = (results: any) => {
     const { data, errors }: { data: string[][]; errors: any[] } = results;

--- a/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
@@ -15,7 +15,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { type ColDef, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { uniqBy } from 'lodash';
-import { type JSX, useState } from 'react';
+import { useState } from 'react';
 import { useCSVReader } from 'react-papaparse';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 
@@ -46,7 +46,7 @@ const defaultColumnDefs: ColDef = {
 
 const AddStoriesUserPanel: React.FC<Props> = props => {
   const [users, setUsers] = useState<NameUsernameRole[]>([]);
-  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | JSX.Element>('');
+  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | React.ReactElement>('');
   const { CSVReader } = useCSVReader();
 
   const grid = (

--- a/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
@@ -15,7 +15,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { type ColDef, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { uniqBy } from 'lodash';
-import React, { type JSX } from 'react';
+import { type JSX, useState } from 'react';
 import { useCSVReader } from 'react-papaparse';
 import { Role } from 'src/commons/application/ApplicationTypes';
 
@@ -45,8 +45,8 @@ const defaultColumnDefs: ColDef = {
 };
 
 const AddUserPanel: React.FC<Props> = props => {
-  const [users, setUsers] = React.useState<UsernameRoleGroup[]>([]);
-  const [invalidCsvMsg, setInvalidCsvMsg] = React.useState<string | JSX.Element>('');
+  const [users, setUsers] = useState<UsernameRoleGroup[]>([]);
+  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | JSX.Element>('');
   const { CSVReader } = useCSVReader();
 
   const grid = (
@@ -66,7 +66,7 @@ const AddUserPanel: React.FC<Props> = props => {
   );
 
   const htmlSelectOptions = [...Constants.authProviders.entries()].map(([id, _]) => id);
-  const [provider, setProvider] = React.useState(htmlSelectOptions[0]);
+  const [provider, setProvider] = useState(htmlSelectOptions[0]);
 
   const validateCsvInput = (results: any) => {
     const { data, errors }: { data: string[][]; errors: any[] } = results;

--- a/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
@@ -15,7 +15,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { type ColDef, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { uniqBy } from 'lodash';
-import { type JSX, useState } from 'react';
+import { useState } from 'react';
 import { useCSVReader } from 'react-papaparse';
 import { Role } from 'src/commons/application/ApplicationTypes';
 
@@ -46,7 +46,7 @@ const defaultColumnDefs: ColDef = {
 
 const AddUserPanel: React.FC<Props> = props => {
   const [users, setUsers] = useState<UsernameRoleGroup[]>([]);
-  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | JSX.Element>('');
+  const [invalidCsvMsg, setInvalidCsvMsg] = useState<string | React.ReactElement>('');
   const { CSVReader } = useCSVReader();
 
   const grid = (

--- a/src/pages/academy/adminPanel/subcomponents/CourseConfigPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/CourseConfigPanel.tsx
@@ -13,7 +13,7 @@ import {
   TextArea
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
+import { useCallback, useState } from 'react';
 import { useResponsive } from 'src/commons/utils/Hooks';
 import classes from 'src/styles/CourseConfig.module.scss';
 
@@ -33,7 +33,7 @@ type Props = {
 const CourseConfigPanel: React.FC<Props> = props => {
   const { isMobileBreakpoint } = useResponsive();
   const [courseHelpTextSelectedTab, setCourseHelpTextSelectedTab] =
-    React.useState<CourseHelpTextEditorTab>(CourseHelpTextEditorTab.WRITE);
+    useState<CourseHelpTextEditorTab>(CourseHelpTextEditorTab.WRITE);
 
   const {
     courseName,
@@ -75,7 +75,7 @@ const CourseConfigPanel: React.FC<Props> = props => {
     </div>
   );
 
-  const onChangeTabs = React.useCallback(
+  const onChangeTabs = useCallback(
     (
       newTabId: CourseHelpTextEditorTab,
       prevTabId: CourseHelpTextEditorTab,

--- a/src/pages/academy/adminPanel/subcomponents/PixelbotConfigPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/PixelbotConfigPanel.tsx
@@ -10,7 +10,7 @@ import {
   TextArea
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import classes from 'src/styles/PixelbotConfig.module.scss';
 

--- a/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/AssessmentConfigPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/AssessmentConfigPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { cloneDeep, isEqual } from 'lodash';
-import React, {
+import {
   forwardRef,
   useCallback,
   useEffect,
@@ -63,7 +63,7 @@ const AssessmentConfigPanel: WithImperativeApi<
   React.FC<Props>
 > = forwardRef<ImperativeAssessmentConfigPanel, Props>(
   ({ setHasChangesAssessmentConfig, initialConfigs }, imperativeRef) => {
-    const gridApi = React.useRef<GridApi<AssessmentConfiguration>>(null);
+    const gridApi = useRef<GridApi<AssessmentConfiguration>>(null);
     // Create a mutable copy of the initialConfigs to track changes
     // to prevent UI flicker during state changes.
     const tableState = useRef(cloneDeep(initialConfigs));

--- a/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/BooleanCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/BooleanCell.tsx
@@ -1,6 +1,6 @@
 import { Switch } from '@blueprintjs/core';
 import { IRowNode } from 'ag-grid-community';
-import React from 'react';
+import { useCallback } from 'react';
 import { AssessmentConfiguration } from 'src/commons/assessment/AssessmentTypes';
 import { KeysOfType } from 'src/commons/utils/TypeHelper';
 
@@ -16,7 +16,7 @@ const BooleanCell: React.FC<Props> = props => {
   const { rowIndex } = props.node;
   const checked = data[props.field];
 
-  const changeHandler = React.useCallback(() => {
+  const changeHandler = useCallback(() => {
     props.setStateHandler(rowIndex!, !checked);
   }, [props, rowIndex, checked]);
 

--- a/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/DeleteRowCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/DeleteRowCell.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, DialogBody, DialogFooter, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { IRowNode } from 'ag-grid-community';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { AssessmentConfiguration } from 'src/commons/assessment/AssessmentTypes';
 import ControlButton from 'src/commons/ControlButton';
 

--- a/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/NumericCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/assessmentConfigPanel/NumericCell.tsx
@@ -1,6 +1,6 @@
 import { NumericInput } from '@blueprintjs/core';
 import { IRowNode } from 'ag-grid-community';
-import React from 'react';
+import { useCallback } from 'react';
 import { AssessmentConfiguration } from 'src/commons/assessment/AssessmentTypes';
 import { KeysOfType } from 'src/commons/utils/TypeHelper';
 
@@ -15,7 +15,7 @@ const NumericCell: React.FC<Props> = props => {
   const { data } = props;
   const { rowIndex } = props.node;
 
-  const changeHandler = React.useCallback(
+  const changeHandler = useCallback(
     (value: number) => {
       props.setStateHandler(rowIndex!, value);
     },

--- a/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/RolesCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/RolesCell.tsx
@@ -1,5 +1,5 @@
 import { HTMLSelect, Popover, Position } from '@blueprintjs/core';
-import React from 'react';
+import { useCallback } from 'react';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 import { AdminPanelStoriesUser } from 'src/features/stories/StoriesTypes';
 
@@ -13,7 +13,7 @@ type Props = {
 const RolesCell: React.FC<Props> = props => {
   const { data } = props;
 
-  const changeHandler = React.useCallback(
+  const changeHandler = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       props.handleUpdateStoriesUserRole(data.id, e.target.value as StoriesRole);
     },

--- a/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/StoriesUserActionsCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/StoriesUserActionsCell.tsx
@@ -8,7 +8,7 @@ import {
   Position
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 import ControlButton from 'src/commons/ControlButton';
 import { showWarningMessage } from 'src/commons/utils/notifications/NotificationsHelper';

--- a/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/StoriesUserConfigPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/storiesUserConfigPanel/StoriesUserConfigPanel.tsx
@@ -1,7 +1,7 @@
 import { Button, H2 } from '@blueprintjs/core';
 import { type ColDef, type GridApi, type GridReadyEvent, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import React from 'react';
+import { useRef } from 'react';
 import { StoriesRole } from 'src/commons/application/ApplicationTypes';
 import { AdminPanelStoriesUser } from 'src/features/stories/StoriesTypes';
 
@@ -30,7 +30,7 @@ const defaultColumnDefs: ColDef = {
  *   no admins left in a course)
  */
 const StoriesUserConfigPanel: React.FC<Props> = props => {
-  const gridApi = React.useRef<GridApi>(null);
+  const gridApi = useRef<GridApi>(null);
 
   const storiesUsers = props.storiesUsers?.map(e =>
     !e.name ? { ...e, name: '(user has yet to log in)' } : e

--- a/src/pages/academy/adminPanel/subcomponents/userConfigPanel/RolesCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/userConfigPanel/RolesCell.tsx
@@ -1,5 +1,5 @@
 import { HTMLSelect, Popover, Position } from '@blueprintjs/core';
-import React from 'react';
+import { useCallback } from 'react';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import { AdminPanelCourseRegistration } from 'src/commons/application/types/SessionTypes';
 
@@ -13,7 +13,7 @@ type Props = {
 const RolesCell: React.FC<Props> = props => {
   const { data } = props;
 
-  const changeHandler = React.useCallback(
+  const changeHandler = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       props.handleUpdateUserRole(data.courseRegId, e.target.value as Role);
     },

--- a/src/pages/academy/adminPanel/subcomponents/userConfigPanel/UserActionsCell.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/userConfigPanel/UserActionsCell.tsx
@@ -8,7 +8,7 @@ import {
   Position
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import { AdminPanelCourseRegistration } from 'src/commons/application/types/SessionTypes';
 import ControlButton from 'src/commons/ControlButton';

--- a/src/pages/academy/adminPanel/subcomponents/userConfigPanel/UserConfigPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/userConfigPanel/UserConfigPanel.tsx
@@ -1,7 +1,7 @@
 import { Button, H2 } from '@blueprintjs/core';
 import { type ColDef, type GridApi, type GridReadyEvent, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import React from 'react';
+import { useRef } from 'react';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import { AdminPanelCourseRegistration } from 'src/commons/application/types/SessionTypes';
 
@@ -30,7 +30,7 @@ const defaultColumnDefs: ColDef = {
  *   no admins left in a course)
  */
 const UserConfigPanel: React.FC<Props> = props => {
-  const gridApi = React.useRef<GridApi>(null);
+  const gridApi = useRef<GridApi>(null);
 
   const userCourseRegistrations = props.userCourseRegistrations?.map(e =>
     !e.name ? { ...e, name: '(user has yet to log in)' } : e

--- a/src/pages/academy/dashboard/Dashboard.tsx
+++ b/src/pages/academy/dashboard/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { type ColDef, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { startCase } from 'lodash';
-import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 

--- a/src/pages/academy/game/Game.tsx
+++ b/src/pages/academy/game/Game.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useFullscreenElement } from '@mantine/hooks';
-import React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import AchievementActions from 'src/features/achievement/AchievementActions';
@@ -19,16 +19,16 @@ const Game: React.FC = () => {
   const achievements = useTypedSelector(state => state.achievement.achievements);
   const goals = useTypedSelector(state => state.achievement.goals);
 
-  const [isTestStudent, setIsTestStudent] = React.useState(false);
-  const [isUsingMock, setIsUsingMock] = React.useState(false);
+  const [isTestStudent, setIsTestStudent] = useState(false);
+  const [isUsingMock, setIsUsingMock] = useState(false);
   const isVscode = useTypedSelector(state => state.vscode.isVscode);
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(AchievementActions.getAchievements());
     dispatch(AchievementActions.getOwnGoals());
   }, [dispatch]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const game = createSourceAcademyGame();
     return () => {
       game.isMounted = false;
@@ -37,7 +37,7 @@ const Game: React.FC = () => {
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     SourceAcademyGame.getInstance().setAccountInfo({
       accessToken: session.accessToken,
       refreshToken: session.refreshToken,
@@ -83,11 +83,11 @@ const Game: React.FC = () => {
     }
   };
 
-  const gameDisplayRef = React.useRef<HTMLDivElement | null>(null);
+  const gameDisplayRef = useRef<HTMLDivElement | null>(null);
 
   // This function sets the gameDisplayRef and also calls the ref callback from useFullscreen
   // to attach the fullscreen logic to the game display element
-  const setGameDisplayRefs = React.useCallback(
+  const setGameDisplayRefs = useCallback(
     (node: HTMLDivElement | null) => {
       // Refs returned by useRef()
       gameDisplayRef.current = node;
@@ -100,10 +100,10 @@ const Game: React.FC = () => {
 
   // Logic for the fullscreen button to dynamically adjust its size, position and padding
   // based on the size of the game display.
-  const [iconLeft, setIconLeft] = React.useState('0px');
-  const [iconPadding, setIconPadding] = React.useState('0px');
+  const [iconLeft, setIconLeft] = useState('0px');
+  const [iconPadding, setIconPadding] = useState('0px');
 
-  const handleResize = React.useCallback(() => {
+  const handleResize = useCallback(() => {
     if (gameDisplayRef.current) {
       const aspectRatio = 16 / 9;
       const height = gameDisplayRef.current.offsetHeight;
@@ -120,11 +120,11 @@ const Game: React.FC = () => {
   // at the time handleResize is called, so the height of gameDisplayRef.current
   // is still the fullscreen height.
   // To fix this, we delay handleResize by 100ms.
-  const delayedHandleResize = React.useCallback(() => {
+  const delayedHandleResize = useCallback(() => {
     setTimeout(handleResize, 100);
   }, [handleResize]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('resize', delayedHandleResize);
     delayedHandleResize();
 

--- a/src/pages/academy/gameSimulator/GameSimulator.tsx
+++ b/src/pages/academy/gameSimulator/GameSimulator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import SourceAcademyGame, { AccountInfo, GameType } from 'src/features/game/SourceAcademyGame';
 import { gameSimulatorConfig } from 'src/features/gameSimulator/GameSimulatorConstants';
@@ -26,11 +26,9 @@ const createGameSimulatorGame = () => {
  */
 const GameSimulator: React.FC = () => {
   const session = useTypedSelector(state => state.session);
-  const [gameSimulatorState, setGameSimulatorState] = React.useState<string>(
-    GameSimulatorState.DEFAULT
-  );
+  const [gameSimulatorState, setGameSimulatorState] = useState<string>(GameSimulatorState.DEFAULT);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const game = createGameSimulatorGame();
     game.setGameSimStateSetter(setGameSimulatorState);
     return () => {
@@ -40,7 +38,7 @@ const GameSimulator: React.FC = () => {
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     SourceAcademyGame.getInstance().setAccountInfo({
       accessToken: session.accessToken,
       refreshToken: session.refreshToken,

--- a/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewer.tsx
+++ b/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewer.tsx
@@ -1,6 +1,6 @@
 import { Icon, Tab, Tabs, Tooltip, Tree, TreeNodeInfo } from '@blueprintjs/core';
 import { cloneDeep } from 'lodash';
-import { type JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRequest } from 'src/commons/utils/Hooks';
 import {
   deleteS3File,
@@ -25,7 +25,7 @@ const AssetViewer: React.FC = () => {
   const [assetTree, setAssetTree] = useState<TreeNodeInfo[]>([]);
 
   useEffect(() => {
-    const deleteIcon = (filePath: string): JSX.Element => {
+    const deleteIcon = (filePath: string): React.ReactElement => {
       const deleteFile = async () => {
         const confirm = window.confirm(`Are you sure you want to delete ${filePath}?`);
         alert(

--- a/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewer.tsx
+++ b/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewer.tsx
@@ -1,9 +1,12 @@
 import { Icon, Tab, Tabs, Tooltip, Tree, TreeNodeInfo } from '@blueprintjs/core';
 import { cloneDeep } from 'lodash';
-import React, { type JSX } from 'react';
+import { type JSX, useEffect, useState } from 'react';
 import { useRequest } from 'src/commons/utils/Hooks';
-import { fetchAssetPaths, s3AssetFolders } from 'src/features/gameSimulator/GameSimulatorService';
-import { deleteS3File } from 'src/features/gameSimulator/GameSimulatorService';
+import {
+  deleteS3File,
+  fetchAssetPaths,
+  s3AssetFolders
+} from 'src/features/gameSimulator/GameSimulatorService';
 
 import AssetViewerPreview from './AssetViewerPreview';
 import AssetViewerUpload from './AssetViewerUpload';
@@ -18,10 +21,10 @@ import { convertAssetPathsToTree, treeMap } from './AssetViewerUtils';
 const AssetViewer: React.FC = () => {
   const { value: assetPaths } = useRequest<string[]>(fetchAssetPaths, []);
 
-  const [currentAsset, setCurrentAsset] = React.useState('');
-  const [assetTree, setAssetTree] = React.useState<TreeNodeInfo[]>([]);
+  const [currentAsset, setCurrentAsset] = useState('');
+  const [assetTree, setAssetTree] = useState<TreeNodeInfo[]>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const deleteIcon = (filePath: string): JSX.Element => {
       const deleteFile = async () => {
         const confirm = window.confirm(`Are you sure you want to delete ${filePath}?`);

--- a/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewerUpload.tsx
+++ b/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewerUpload.tsx
@@ -1,5 +1,5 @@
 import { Button, InputGroup, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { s3AssetFolders, uploadAssetsToS3 } from 'src/features/gameSimulator/GameSimulatorService';
 
 /**

--- a/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewerUtils.tsx
+++ b/src/pages/academy/gameSimulator/subcomponents/assetViewer/AssetViewerUtils.tsx
@@ -1,6 +1,5 @@
 import { TreeNodeInfo } from '@blueprintjs/core';
 import { set } from 'lodash';
-import type { JSX } from 'react';
 
 type Tree = Record<any, any> | string[] | any;
 
@@ -21,7 +20,7 @@ type Tree = Record<any, any> | string[] | any;
  */
 export function convertAssetPathsToTree(
   assetPaths: string[],
-  iconRenderer: (pathName: string) => JSX.Element,
+  iconRenderer: (pathName: string) => React.ReactElement,
   rootFolders: string[] = []
 ): TreeNodeInfo[] {
   const assetObj: Tree = {};

--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -1,6 +1,6 @@
 import { Button, Icon, NonIdealState, Position, Spinner, SpinnerSize } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Navigate, useParams } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';

--- a/src/pages/academy/grading/subcomponents/GradingActions.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingActions.tsx
@@ -1,6 +1,5 @@
 import { Button, Icon, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';

--- a/src/pages/academy/grading/subcomponents/GradingBadges.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingBadges.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React from 'react';
 import { ProgressStatus, ProgressStatuses } from 'src/commons/assessment/AssessmentTypes';
 import { ColumnFilter } from 'src/features/grading/GradingTypes';
 import classes from 'src/styles/Grading.module.scss';

--- a/src/pages/academy/grading/subcomponents/GradingColumnCustomHeaders.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingColumnCustomHeaders.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@blueprintjs/core';
 import { CustomHeaderProps } from 'ag-grid-react';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { SortStates } from 'src/features/grading/GradingTypes';

--- a/src/pages/academy/grading/subcomponents/GradingColumnFilters.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingColumnFilters.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ColumnFilterBadge } from './GradingBadges';
 
 type Props = {

--- a/src/pages/academy/grading/subcomponents/GradingCommentSelector.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingCommentSelector.tsx
@@ -1,5 +1,4 @@
 import { H5, NonIdealState, Spinner } from '@blueprintjs/core';
-import React from 'react';
 import styles from 'src/styles/GradingCommentSelector.module.scss';
 
 type Props = {

--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -21,8 +21,7 @@ import SessionActions from '../../../../commons/application/actions/SessionActio
 import ControlButton from '../../../../commons/ControlButton';
 import Markdown from '../../../../commons/Markdown';
 import { Prompt } from '../../../../commons/ReactRouterPrompt';
-import { postGenerateComments } from '../../../../commons/sagas/RequestsSaga';
-import { saveFinalComment } from '../../../../commons/sagas/RequestsSaga';
+import { postGenerateComments, saveFinalComment } from '../../../../commons/sagas/RequestsSaga';
 import { getPrettyDate } from '../../../../commons/utils/DateHelper';
 import { showSimpleConfirmDialog } from '../../../../commons/utils/DialogHelper';
 import {

--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -11,7 +11,7 @@ import {
   Pre
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ReactMde, { ReactMdeProps } from 'react-mde';
 import { useDispatch } from 'react-redux';
 import { AutogradingResult, LLMPrompt } from 'src/commons/assessment/AssessmentTypes';

--- a/src/pages/academy/grading/subcomponents/GradingFilterable.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingFilterable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import classes from 'src/styles/Grading.module.scss';
 
 type Props = {

--- a/src/pages/academy/grading/subcomponents/GradingSubmissionFilters.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingSubmissionFilters.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import { ColumnFilter, ColumnFiltersState } from 'src/features/grading/GradingTypes';
 

--- a/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
@@ -4,7 +4,7 @@ import { CellClickedEvent, ColDef, themeQuartz } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import classNames from 'classnames';
 import { debounce } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import { ProgressStatuses } from 'src/commons/assessment/AssessmentTypes';

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -2,7 +2,7 @@ import { Classes, NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';

--- a/src/pages/academy/groundControl/GroundControl.tsx
+++ b/src/pages/academy/groundControl/GroundControl.tsx
@@ -10,7 +10,7 @@ import {
 import { IconNames } from '@blueprintjs/icons';
 import { type ColDef, type GridApi, type GridReadyEvent, themeBalham } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useSession } from 'src/commons/utils/Hooks';
 
 import { AssessmentOverview } from '../../../commons/assessment/AssessmentTypes';

--- a/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
+++ b/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
@@ -10,7 +10,7 @@ import {
 import { IconNames } from '@blueprintjs/icons';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
 import { Variant } from 'js-slang/dist/langs';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import Constants from 'src/commons/utils/Constants';
 import { useSession } from 'src/commons/utils/Hooks';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlConfigureCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlConfigureCell.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import { IconNames, Team } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';
 import ControlButton from '../../../../commons/ControlButton';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlDeleteCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlDeleteCell.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogBody, DialogFooter, Intent, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';
 import ControlButton from '../../../../commons/ControlButton';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlDropzone.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlDropzone.tsx
@@ -1,7 +1,7 @@
 import { Card, Elevation, HTMLSelect, Intent, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FileRejection, useDropzone } from 'react-dropzone';
 import { AssessmentConfiguration } from 'src/commons/assessment/AssessmentTypes';
 
@@ -19,12 +19,12 @@ type StateProps = {
 };
 
 const MaterialDropzone: React.FC<DropzoneProps> = props => {
-  const [file, setFile] = React.useState<File | undefined>(undefined);
-  const [isWarningShown, setPromptShown] = React.useState(false);
-  const [forceUpdate, setForceUpdate] = React.useState(false);
-  const [assessmentConfigId, setAssessmentConfigId] = React.useState(-1);
+  const [file, setFile] = useState<File | undefined>(undefined);
+  const [isWarningShown, setPromptShown] = useState(false);
+  const [forceUpdate, setForceUpdate] = useState(false);
+  const [assessmentConfigId, setAssessmentConfigId] = useState(-1);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (props.assessmentConfigurations && assessmentConfigId === -1) {
       setAssessmentConfigId(props.assessmentConfigurations[0].assessmentConfigId);
     }
@@ -32,7 +32,7 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
 
   const { handleUploadAssessment } = props;
 
-  const htmlSelectOptions = React.useMemo(() => {
+  const htmlSelectOptions = useMemo(() => {
     return props.assessmentConfigurations?.map(e => {
       return {
         value: e.assessmentConfigId,
@@ -41,7 +41,7 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
     });
   }, [props.assessmentConfigurations]);
 
-  const handleConfirmUpload = React.useCallback(() => {
+  const handleConfirmUpload = useCallback(() => {
     if (assessmentConfigId === -1) {
       showWarningMessage('Please select a valid assessment type before uploading!');
       return;
@@ -52,16 +52,16 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
     }
     setFile(undefined);
   }, [file, forceUpdate, handleUploadAssessment, assessmentConfigId]);
-  const handleCancelUpload = React.useCallback(() => setFile(undefined), [setFile]);
+  const handleCancelUpload = useCallback(() => setFile(undefined), [setFile]);
 
-  const handleDropAccepted = React.useCallback(
+  const handleDropAccepted = useCallback(
     (acceptedFiles: File[]) => {
       setFile(acceptedFiles[0]);
       setForceUpdate(false);
     },
     [setFile]
   );
-  const handleDropRejected = React.useCallback((rejectedFiles: FileRejection[]) => {
+  const handleDropRejected = useCallback((rejectedFiles: FileRejection[]) => {
     if (rejectedFiles.length > 1) {
       showWarningMessage('Uploading multiple files at once is not currently supported!', 2000);
     }
@@ -74,7 +74,7 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
       onDropRejected: handleDropRejected
     });
 
-  const classList = React.useMemo(() => {
+  const classList = useMemo(() => {
     return classNames(
       'dropzone-base',
       isFocused || isDragActive ? 'dropzone-active' : undefined,
@@ -83,7 +83,7 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
     );
   }, [isFocused, isDragActive, isDragAccept, isDragReject]);
 
-  const handleSwitchOnChange = React.useCallback(() => {
+  const handleSwitchOnChange = useCallback(() => {
     if (!forceUpdate) {
       setPromptShown(true);
     } else {
@@ -91,7 +91,7 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
     }
   }, [forceUpdate, setPromptShown, setForceUpdate]);
 
-  const toggleButton = React.useMemo(
+  const toggleButton = useMemo(
     () => (
       <div className="toggle-button-wrapper">
         <Switch checked={forceUpdate} onChange={handleSwitchOnChange} />
@@ -100,15 +100,15 @@ const MaterialDropzone: React.FC<DropzoneProps> = props => {
     [forceUpdate, handleSwitchOnChange]
   );
 
-  const handleConfirmForceUpdate = React.useCallback(() => {
+  const handleConfirmForceUpdate = useCallback(() => {
     setForceUpdate(true);
     setPromptShown(false);
   }, [setForceUpdate]);
-  const handleCancelForceUpdate = React.useCallback(() => {
+  const handleCancelForceUpdate = useCallback(() => {
     setPromptShown(false);
   }, [setPromptShown]);
 
-  const confirmationPrompt = React.useMemo(
+  const confirmationPrompt = useMemo(
     () => (
       <div className="dropzone-controls">
         <ControlButton

--- a/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
@@ -1,7 +1,7 @@
 import { Dialog, DialogBody, DialogFooter, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import dayjs from 'dayjs';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { DateInput } from 'src/commons/DateTimePickers';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlEditCell.tsx
@@ -51,11 +51,11 @@ const EditCell: React.FC<Props> = ({ data, forOpenDate, handleAssessmentChangeDa
   };
   const handleFormatDate = (date: Date) => dayjs(date).format(dateDisplayFormat);
 
-  const handleDateChange = React.useCallback(
+  const handleDateChange = useCallback(
     (selectedDate: string | null) => setNewDate(dayjs(selectedDate)),
     []
   );
-  const handleDateError = React.useCallback(() => {
+  const handleDateError = useCallback(() => {
     // Reset date to current date if user enters an invalid date string
     showWarningMessage('Failed to parse date string! Defaulting to current date.', 2000);
     setNewDate(currentDate);

--- a/src/pages/academy/groundControl/subcomponents/GroundControlEditTeamSizeCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlEditTeamSizeCell.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlPublishCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlPublishCell.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogBody, DialogFooter, Intent, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';
 import ControlButton from '../../../../commons/ControlButton';

--- a/src/pages/academy/groundControl/subcomponents/GroundControlReleaseGradingCell.tsx
+++ b/src/pages/academy/groundControl/subcomponents/GroundControlReleaseGradingCell.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, DialogBody, DialogFooter, Intent, Tooltip } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { AssessmentOverview } from '../../../../commons/assessment/AssessmentTypes';
 import ControlButton from '../../../../commons/ControlButton';

--- a/src/pages/academy/ragChatbot/RagChatBox.tsx
+++ b/src/pages/academy/ragChatbot/RagChatBox.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Tokens } from 'src/commons/application/types/SessionTypes';

--- a/src/pages/academy/ragChatbot/RagChatbot.tsx
+++ b/src/pages/academy/ragChatbot/RagChatbot.tsx
@@ -1,5 +1,5 @@
 import { AnchorButton, Icon } from '@blueprintjs/core';
-import * as React from 'react';
+import { useRef, useState } from 'react';
 import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 import pixelLogo from 'src/assets/pixel.jpg';
 import { useSession } from 'src/commons/utils/Hooks';
@@ -40,14 +40,14 @@ const clampPosition = (
 
 const RagChatbot: React.FC = () => {
   const { isLoggedIn } = useSession();
-  const [isPop, setPop] = React.useState(false);
-  const [isDivVisible, setIsDivVisible] = React.useState(false);
-  const [tipsMessage, setTipsMessage] = React.useState('Click me for a chat!');
-  const [activeSnippetId, setActiveSnippetId] = React.useState('');
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
-  const [isDragging, setIsDragging] = React.useState(false);
-  const nodeRef = React.useRef<HTMLDivElement>(null);
+  const [isPop, setPop] = useState(false);
+  const [isDivVisible, setIsDivVisible] = useState(false);
+  const [tipsMessage, setTipsMessage] = useState('Click me for a chat!');
+  const [activeSnippetId, setActiveSnippetId] = useState('');
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const nodeRef = useRef<HTMLDivElement>(null);
 
   const isSnippetOpen = activeSnippetId !== '';
 

--- a/src/pages/academy/teamFormation/TeamFormation.tsx
+++ b/src/pages/academy/teamFormation/TeamFormation.tsx
@@ -1,5 +1,4 @@
 import { NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core';
-import React from 'react';
 import { useSession } from 'src/commons/utils/Hooks';
 
 import ContentDisplay from '../../../commons/ContentDisplay';

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationActions.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationActions.tsx
@@ -1,6 +1,6 @@
 import { Button, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationBadges.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationBadges.tsx
@@ -1,7 +1,6 @@
 import { Button, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ColumnFilter } from '@tanstack/react-table';
-import React from 'react';
 
 import { getBadgeColorFromLabelLegacy } from '../../grading/subcomponents/GradingBadges';
 

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationFilters.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationFilters.tsx
@@ -1,5 +1,4 @@
 import { ColumnFilter, ColumnFiltersState } from '@tanstack/react-table';
-import React from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 
 import { FilterBadge } from './TeamFormationBadges';

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationForm.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationForm.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Form, useNavigate, useParams } from 'react-router';
 import Select, { ActionMeta, MultiValue } from 'react-select';

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationTable.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationTable.tsx
@@ -12,7 +12,7 @@ import {
   Row,
   useReactTable
 } from '@tanstack/react-table';
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import GradingText from 'src/commons/grading/GradingText';
 import { objectKeys } from 'src/commons/utils/TypeHelper';
@@ -41,12 +41,12 @@ const columns = [
     header: 'Students',
     cell: info =>
       info.getValue().map((name: string, index: number) => (
-        <React.Fragment key={index}>
+        <Fragment key={index}>
           <Filterable column={info.column} value={name}>
             {name}
           </Filterable>
           {', '}
-        </React.Fragment>
+        </Fragment>
       )),
     filterFn: (row, id: string | number, filterValue: any): boolean => {
       const rowValue = row.original[id as keyof typeof row.original];

--- a/src/pages/academy/teamFormation/subcomponents/TeamFormationTable.tsx
+++ b/src/pages/academy/teamFormation/subcomponents/TeamFormationTable.tsx
@@ -12,7 +12,7 @@ import {
   Row,
   useReactTable
 } from '@tanstack/react-table';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import GradingText from 'src/commons/grading/GradingText';
 import { objectKeys } from 'src/commons/utils/TypeHelper';

--- a/src/pages/achievement/Achievement.tsx
+++ b/src/pages/achievement/Achievement.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { SentryRoutes } from 'src/routes/routerConfig';

--- a/src/pages/achievement/control/AchievementControl.tsx
+++ b/src/pages/achievement/control/AchievementControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 

--- a/src/pages/achievement/subcomponents/AchievementDashboard.tsx
+++ b/src/pages/achievement/subcomponents/AchievementDashboard.tsx
@@ -1,5 +1,5 @@
 import { IconNames } from '@blueprintjs/icons';
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import { useResponsive, useSession, useTypedSelector } from 'src/commons/utils/Hooks';

--- a/src/pages/contributors/Contributors.tsx
+++ b/src/pages/contributors/Contributors.tsx
@@ -1,5 +1,4 @@
 import { Card, Elevation } from '@blueprintjs/core';
-import React from 'react';
 
 import ContributorsDetails from './subcomponents/ContributorsDetails';
 import ContributorsList from './subcomponents/ContributorsList';

--- a/src/pages/contributors/subcomponents/ContributorsDetails.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsDetails.tsx
@@ -1,5 +1,4 @@
 import { Card, Elevation, H3, H5 } from '@blueprintjs/core';
-import React from 'react';
 import classes from 'src/styles/Contributors.module.scss';
 
 import { Links } from '../../../commons/utils/Constants';

--- a/src/pages/contributors/subcomponents/ContributorsList.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsList.tsx
@@ -1,5 +1,5 @@
 import { Card, Elevation, H2, H3, H5 } from '@blueprintjs/core';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import classes from 'src/styles/Contributors.module.scss';
 
 import { Contributor, Repo } from '../../../features/contributors/ContributorsTypes';

--- a/src/pages/featureFlags/FeatureFlags.tsx
+++ b/src/pages/featureFlags/FeatureFlags.tsx
@@ -12,7 +12,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { BlueprintIcons_16Id } from '@blueprintjs/icons/lib/esm/generated/16px/blueprint-icons-16';
-import React, { ChangeEventHandler, MouseEvent, PropsWithChildren, useRef, useState } from 'react';
+import { ChangeEventHandler, PropsWithChildren, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { FeatureFlagsActions } from '../../commons/featureFlags';
@@ -121,7 +121,7 @@ const FeatureFlagSection: React.FC<FlagCardProps<any> & { icon: BlueprintIcons_1
 
   const isModified = modifiedFlag !== undefined;
 
-  const onReset = (e: MouseEvent) => {
+  const onReset = (e: React.MouseEvent) => {
     dispatch(FeatureFlagsActions.resetFlag({ featureFlag: flag }));
     e.stopPropagation();
   };

--- a/src/pages/githubCallback/__tests__/GitHubCallback.test.tsx
+++ b/src/pages/githubCallback/__tests__/GitHubCallback.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { act, type JSX } from 'react';
+import { act } from 'react';
 import { Route, Routes, StaticRouter } from 'react-router';
 import { Mock, vi } from 'vitest';
 
@@ -7,7 +7,7 @@ import Constants from '../../../commons/utils/Constants';
 import { exchangeAccessCode } from '../../../features/github/GitHubUtils';
 import GitHubCallback from '../GitHubCallback';
 
-function renderWithLocation(element: JSX.Element, location: string) {
+function renderWithLocation(element: React.ReactElement, location: string) {
   return render(
     <StaticRouter location={location}>
       <Routes>

--- a/src/pages/leaderboard/subcomponents/ContestLeaderboard.tsx
+++ b/src/pages/leaderboard/subcomponents/ContestLeaderboard.tsx
@@ -2,7 +2,7 @@ import 'src/styles/Leaderboard.scss';
 
 import { type ColDef, themeAlpine } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import { useTypedSelector } from 'src/commons/utils/Hooks';

--- a/src/pages/leaderboard/subcomponents/ContestLeaderboardWrapper.tsx
+++ b/src/pages/leaderboard/subcomponents/ContestLeaderboardWrapper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 

--- a/src/pages/leaderboard/subcomponents/LeaderboardDropdown.tsx
+++ b/src/pages/leaderboard/subcomponents/LeaderboardDropdown.tsx
@@ -1,6 +1,6 @@
 import 'src/styles/Leaderboard.scss';
 
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 

--- a/src/pages/leaderboard/subcomponents/LeaderboardExportButton.tsx
+++ b/src/pages/leaderboard/subcomponents/LeaderboardExportButton.tsx
@@ -1,6 +1,5 @@
 import 'src/styles/Leaderboard.scss';
 
-import React from 'react';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import {
   getAllOverallLeaderboardXP,

--- a/src/pages/leaderboard/subcomponents/LeaderboardPodium.tsx
+++ b/src/pages/leaderboard/subcomponents/LeaderboardPodium.tsx
@@ -1,6 +1,5 @@
 import 'src/styles/Leaderboard.scss';
 
-import React from 'react';
 import { ContestLeaderboardRow, LeaderboardRow } from 'src/features/leaderboard/LeaderboardTypes';
 
 type Props =

--- a/src/pages/leaderboard/subcomponents/OverallLeaderboard.tsx
+++ b/src/pages/leaderboard/subcomponents/OverallLeaderboard.tsx
@@ -2,7 +2,7 @@ import 'src/styles/Leaderboard.scss';
 
 import { ColDef, IDatasource, themeAlpine } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import default_avatar from 'src/assets/default-avatar.jpg';
 import { useTypedSelector } from 'src/commons/utils/Hooks';

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router';
 import { useSession } from 'src/commons/utils/Hooks';
 

--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -1,7 +1,7 @@
 import { Card, Classes, Elevation, NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core';
 import classNames from 'classnames';
 import Cookies from 'js-cookie';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';

--- a/src/pages/login/LoginVscodeCallback.tsx
+++ b/src/pages/login/LoginVscodeCallback.tsx
@@ -12,7 +12,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';

--- a/src/pages/login/NusLogin.tsx
+++ b/src/pages/login/NusLogin.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Card, Divider, Elevation, H1, H3 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';

--- a/src/pages/missionControl/MissionControl.tsx
+++ b/src/pages/missionControl/MissionControl.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { useSession } from 'src/commons/utils/Hooks';
 import { numberRegExp } from 'src/features/academy/AcademyTypes';

--- a/src/pages/notFound/NotFound.tsx
+++ b/src/pages/notFound/NotFound.tsx
@@ -1,7 +1,6 @@
 import { Classes, NonIdealState } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import React from 'react';
 
 const NotFound: React.FC = () => (
   <div className={classNames('NoPage', Classes.DARK)} data-testid="NotFound-Component">

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import { isEqual } from 'lodash';
 import { decompressFromEncodedURIComponent } from 'lz-string';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
 import InterpreterActions from 'src/commons/application/actions/InterpreterActions';
@@ -384,7 +384,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     }
   }, [isMobileBreakpoint, isVscode, selectedTab, setSelectedTab]);
 
-  const onEditorValueChange = React.useCallback(
+  const onEditorValueChange = useCallback(
     (editorTabIndex: number, newEditorValue: string) => {
       setLastEdit(new Date());
       handleEditorValueChange(editorTabIndex, newEditorValue);

--- a/src/pages/sicp/Sicp.tsx
+++ b/src/pages/sicp/Sicp.tsx
@@ -2,7 +2,7 @@ import 'katex/dist/katex.min.css';
 
 import { Button, Classes, NonIdealState, Spinner } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React, { useRef, useState } from 'react';
+import { createContext, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import Constants from 'src/commons/utils/Constants';
@@ -28,7 +28,7 @@ const baseUrl = Constants.sicpBackendUrl + 'json/';
 const extension = '.json';
 
 // Context to determine which code snippet is active
-export const CodeSnippetContext = React.createContext({
+export const CodeSnippetContext = createContext({
   active: '0',
   setActive: (x: string) => {}
 });
@@ -87,7 +87,7 @@ const Sicp: React.FC = () => {
   };
 
   // Handle loading of latest viewed section and fetch json data
-  React.useEffect(() => {
+  useEffect(() => {
     if (!section) {
       /**
        * Handles rerouting to the latest viewed section when clicking from
@@ -141,7 +141,7 @@ const Sicp: React.FC = () => {
   }, [section, navigate]);
 
   // Scroll to correct position
-  React.useEffect(() => {
+  useEffect(() => {
     if (loading) {
       return;
     }
@@ -153,7 +153,7 @@ const Sicp: React.FC = () => {
   }, [location.hash, loading]);
 
   // Close all active code snippet when new page is loaded
-  React.useEffect(() => {
+  useEffect(() => {
     setActive('0');
   }, [data]);
 

--- a/src/pages/sicp/subcomponents/CodeSnippet.tsx
+++ b/src/pages/sicp/subcomponents/CodeSnippet.tsx
@@ -1,7 +1,7 @@
 import { Card, Elevation, Pre } from '@blueprintjs/core';
 import { HighlightRulesSelector, ModeSelector } from 'js-slang/dist/editors/ace/modes/source';
 import { Resizable } from 're-resizable';
-import React from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import ControlBar from 'src/commons/controlBar/ControlBar';
 import { ControlBarCloseButton } from 'src/commons/controlBar/ControlBarCloseButton';
@@ -41,14 +41,14 @@ const resizableProps = {
 
 const CodeSnippet: React.FC<CodeSnippetProps> = props => {
   const { body, output, id } = props;
-  const context = React.useContext(CodeSnippetContext);
+  const context = useContext(CodeSnippetContext);
   const { isMobileBreakpoint } = useResponsive();
 
   const handleOpen = () => {
     context.setActive(id);
   };
 
-  const handleClose = React.useCallback(() => {
+  const handleClose = useCallback(() => {
     context.setActive('0');
   }, [context]);
 
@@ -63,7 +63,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = props => {
   HighlightRulesSelector(4);
   ModeSelector(4);
 
-  const closeButton = React.useMemo(
+  const closeButton = useMemo(
     () => <ControlBarCloseButton key="close" handleClose={handleClose} />,
     [handleClose]
   );

--- a/src/pages/sicp/subcomponents/SicpExercise.tsx
+++ b/src/pages/sicp/subcomponents/SicpExercise.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, Collapse, Elevation } from '@blueprintjs/core';
-import { type JSX, useState } from 'react';
+import { useState } from 'react';
 
 export const noSolutionPlaceholder = (
   <span>
@@ -15,8 +15,8 @@ export const noSolutionPlaceholder = (
 
 type Props = {
   title: string;
-  body: JSX.Element;
-  solution: JSX.Element | undefined;
+  body: React.ReactElement;
+  solution: React.ReactElement | undefined;
 };
 
 const SicpExercise: React.FC<Props> = props => {

--- a/src/pages/sicp/subcomponents/SicpExercise.tsx
+++ b/src/pages/sicp/subcomponents/SicpExercise.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, Collapse, Elevation } from '@blueprintjs/core';
-import React, { type JSX } from 'react';
+import { type JSX, useState } from 'react';
 
 export const noSolutionPlaceholder = (
   <span>
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const SicpExercise: React.FC<Props> = props => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   const onClick = () => {
     setIsOpen(!isOpen);

--- a/src/pages/sicp/subcomponents/SicpIndexPage.tsx
+++ b/src/pages/sicp/subcomponents/SicpIndexPage.tsx
@@ -1,5 +1,4 @@
 import { H1, H2, H4 } from '@blueprintjs/core';
-import React from 'react';
 
 import SicpToc from './SicpToc';
 

--- a/src/pages/sicp/subcomponents/SicpLatex.tsx
+++ b/src/pages/sicp/subcomponents/SicpLatex.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Latex from 'react-latex-next';
 
 type Props = {

--- a/src/pages/sicp/subcomponents/SicpToc.tsx
+++ b/src/pages/sicp/subcomponents/SicpToc.tsx
@@ -1,6 +1,6 @@
 import { Tree, TreeNodeInfo } from '@blueprintjs/core';
 import { cloneDeep } from 'lodash';
-import React, { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import toc from '../../../features/sicp/data/toc.json';
@@ -30,7 +30,7 @@ const SicpToc: React.FC<TocProps> = props => {
     setSidebarContent(newState);
   };
 
-  const handleNodeClicked = React.useCallback(
+  const handleNodeClicked = useCallback(
     (node: TreeNodeInfo) => {
       if (props.handleCloseToc) {
         props.handleCloseToc();

--- a/src/pages/sicp/subcomponents/chatbot/ChatBox.tsx
+++ b/src/pages/sicp/subcomponents/chatbot/ChatBox.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { useTokens } from 'src/commons/utils/Hooks';
 import { continueChat, initChat } from 'src/features/sicp/chatCompletion/api';
 import { SicpSection } from 'src/features/sicp/chatCompletion/chatCompletion';
@@ -200,10 +200,10 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
       parts.push(
         <div key={`${messageId}-text-${lastIndex}`} style={{ marginBottom: '0.5em' }}>
           {text.split('\n').map((line, i) => (
-            <React.Fragment key={i}>
+            <Fragment key={i}>
               {line}
               <br />
-            </React.Fragment>
+            </Fragment>
           ))}
         </div>
       );
@@ -259,10 +259,10 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
     parts.push(
       <div key={`${messageId}-text-end`} style={{ marginBottom: '0.5em' }}>
         {text.split('\n').map((line, i) => (
-          <React.Fragment key={i}>
+          <Fragment key={i}>
             {line}
             <br />
-          </React.Fragment>
+          </Fragment>
         ))}
       </div>
     );

--- a/src/pages/sicp/subcomponents/chatbot/Chatbot.tsx
+++ b/src/pages/sicp/subcomponents/chatbot/Chatbot.tsx
@@ -1,5 +1,5 @@
 import { AnchorButton, Icon } from '@blueprintjs/core';
-import * as React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 import logo from 'src/assets/SA.jpg';
 import { useSession } from 'src/commons/utils/Hooks';
@@ -45,19 +45,19 @@ const clampPosition = (
 };
 
 const Chatbot: React.FC<Props> = ({ getSection, getText }) => {
-  const [isPop, setPop] = React.useState(false);
-  const [isDivVisible, setIsDivVisible] = React.useState(false);
-  const [tipsMessage, setTipsMessage] = React.useState('You can click me for a chat');
-  const [activeSnippetId, setActiveSnippetId] = React.useState('');
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
-  const [isDragging, setIsDragging] = React.useState(false);
+  const [isPop, setPop] = useState(false);
+  const [isDivVisible, setIsDivVisible] = useState(false);
+  const [tipsMessage, setTipsMessage] = useState('You can click me for a chat');
+  const [activeSnippetId, setActiveSnippetId] = useState('');
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
   const { isLoggedIn } = useSession();
-  const nodeRef = React.useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLDivElement>(null);
 
   const isSnippetOpen = activeSnippetId !== '';
 
-  const toggleExpanded = React.useCallback(() => {
+  const toggleExpanded = useCallback(() => {
     setIsExpanded(prev => {
       const next = !prev;
       setPosition(pos => clampPosition(pos.x, pos.y, true, next));
@@ -79,7 +79,7 @@ const Chatbot: React.FC<Props> = ({ getSection, getText }) => {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleResize = () => {
       setPosition(pos => clampPosition(pos.x, pos.y, isPop, isExpanded));
     };

--- a/src/pages/sicp/subcomponents/chatbot/ChatbotCodeSnippet.tsx
+++ b/src/pages/sicp/subcomponents/chatbot/ChatbotCodeSnippet.tsx
@@ -1,6 +1,6 @@
 import { Card, Elevation, Overlay2 } from '@blueprintjs/core';
 import { compressToEncodedURIComponent } from 'lz-string';
-import React from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import ControlBar from 'src/commons/controlBar/ControlBar';
@@ -48,7 +48,7 @@ const ChatbotCodeSnippet: React.FC<ChatbotCodeSnippetProps> = ({
     setActiveSnippet(id);
   };
 
-  const handleClose = React.useCallback(() => {
+  const handleClose = useCallback(() => {
     setActiveSnippet('');
   }, [setActiveSnippet]);
 

--- a/src/pages/stories/Stories.tsx
+++ b/src/pages/stories/Stories.tsx
@@ -1,6 +1,6 @@
 import { Button, InputGroup, NonIdealState } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';

--- a/src/pages/stories/StoriesTable.tsx
+++ b/src/pages/stories/StoriesTable.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ColDef, themeQuartz } from 'ag-grid-community';
 import { AgGridReact, CustomCellRendererProps } from 'ag-grid-react';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import { StoryListView } from 'src/features/stories/StoriesTypes';
 import classes from 'src/styles/Stories.module.scss';

--- a/src/pages/stories/StoryActions.tsx
+++ b/src/pages/stories/StoryActions.tsx
@@ -1,6 +1,5 @@
 import { Button, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
 import { useNavigate } from 'react-router';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since it's not needed with "new" React JSX transform introduced in React 17.

Also standardizes coding style:

* Never have `React` default or namespace import
* When used at runtime: always use named imports of members directly
* For types: Use the fully qualified `React.SomeType` name (since it's a global, there's no need to import React default or namespace still)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
