### PR TITLE
fix: stale envFrameMap

### DIFF
--- a/src/features/cseMachine/CseMachineLayout.tsx
+++ b/src/features/cseMachine/CseMachineLayout.tsx
@@ -18,6 +18,7 @@ import classes from 'src/styles/Draggable.module.scss';
 import { arrowSelection } from './components/arrows/ArrowSelection';
 import { Binding } from './components/Binding';
 import { ControlStack } from './components/ControlStack';
+import { Frame as FrameComponent } from './components/Frame';
 import { Level } from './components/Level';
 import { StashStack } from './components/StashStack';
 import { ArrayValue } from './components/values/ArrayValue';
@@ -415,6 +416,7 @@ export class Layout {
   /** initializes grid */
   private static initializeGrid(): void {
     this.levels = [];
+    FrameComponent.clearMap();
     let frontier: EnvTreeNode[] = Layout.clearDeadFrames
       ? Layout.getVisibleChildren([Layout.globalEnvNode])
       : [Layout.globalEnvNode];

--- a/src/features/cseMachine/components/Frame.tsx
+++ b/src/features/cseMachine/components/Frame.tsx
@@ -48,6 +48,9 @@ export class Frame extends Visible implements IHoverable {
   public static getFrom(environment: Env): Frame | undefined {
     return Frame.envFrameMap.get(environment.id);
   }
+  public static clearMap(): void {
+    Frame.envFrameMap.clear();
+  }
 
   /** total height = frame height + frame title height */
   readonly totalHeight: number;


### PR DESCRIPTION
### Description

Closes #3127 

Frame.envFrameMap is a static Map<string, Frame> that maps environment IDs to their rendered Frame objects. It was never cleared between steps, so stale Frame objects from previous render passes persisted in the map.

The symptom: FnValue.draw() calls Frame.getFrom(this.data.environment) to find the enclosing frame and draw an arrow to it. This lookup returned a Frame from an earlier step — one that applyFixedPositions() had never updated. The stale frame had its original computed _y (e.g. 215) while the current layout's frame had the correct cached _y (e.g. 240) after applyFixedPositions ran. So enclosingFrame pointed to a ghost frame at the wrong position, not the live one in the current layout.

Fix: call Frame.clearMap() at the top of initializeGrid() so the map is wiped before new Frame objects are registered for the current step. After this, FnValue.draw() always resolves enclosingFrame to the current step's Frame, which has had its coordinates correctly updated by applyFixedPositions.

Refer to the comment section [here](https://github.com/source-academy/frontend/issues/3127#issuecomment-4603519312) for how the debugging happened and a clearer understanding on what the bug actually is and what the cause of it actually is.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

```js
function test_func() {
    const x = [];
    const a = d => d + 1;
    return a;
}

const result = test_func();
result(5);
```

To test and see how to use the Chrome dev tools along with the breakpoints feature, refer to the actual issue at #3127.

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
