### PR TITLE
CSE Machine -fix: CSE/stepper and SICP JS not working together in frontend

### DIFF
--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -54,7 +54,8 @@ const PlaygroundSaga = combineSagaHandlers({
   [SideContentActions.visitSideContent.type]: function* ({
     payload: { newId, prevId, workspaceLocation },
   }) {
-    if (workspaceLocation !== 'playground' || newId === prevId) return;
+    if ((workspaceLocation !== 'playground' && workspaceLocation !== 'sicp') || newId === prevId)
+      return;
 
     // Do nothing when clicking the mobile 'Run' tab while on the stepper tab.
     if (prevId === SideContentType.substVisualizer && newId === SideContentType.mobileEditorRun) {
@@ -64,7 +65,7 @@ const PlaygroundSaga = combineSagaHandlers({
     const {
       context: { chapter: playgroundSourceChapter },
       editorTabs,
-    } = yield* selectWorkspace('playground');
+    } = yield* selectWorkspace(workspaceLocation);
 
     if (prevId === SideContentType.substVisualizer) {
       const hasBreakpoints = editorTabs.some(({ breakpoints }) => breakpoints.some(Boolean));


### PR DESCRIPTION
### Description

There is a small if conditional bug where we simply returned if we werent in the playground. Another consideration that is clear is that even if the workingSpace is the SICP JS, we still need the CSE Machine and the Stepper tools to work!

Closes #2993 

Further considerations are if the changes made by #3903 by @Shrey5132 will take place inside the SICP as well i.e., when we run incorrect buggy code, we get redirected to the home tab! We await that PR being merged for testing that.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Refer to #2993 and run any CSE Machine program inside the SICP JS.

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
