### PR TITLE
fix: bump conductor to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@sentry/react": "^10.5.0",
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663",
     "@sourceacademy/c-slang": "^1.0.21",
-    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.4.0",
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.5.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.6",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2",
     "@sourceacademy/sharedb-ace": "2.1.1",

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -448,14 +448,15 @@ function* handleResults(
   workspaceLocation: WorkspaceLocation,
 ): SagaIterator {
   const resultChan = eventChannel(emitter => {
-    hostPlugin.receiveResult = emitter;
+    const onReceiveResult = (result: any) => emitter({ value: result });
+    hostPlugin.receiveResult = onReceiveResult;
     return () => {
-      if (hostPlugin.receiveResult === emitter) delete hostPlugin.receiveResult;
+      if (hostPlugin.receiveResult === onReceiveResult) delete hostPlugin.receiveResult;
     };
   });
   try {
     while (true) {
-      const result = yield take(resultChan);
+      const { value: result } = yield take(resultChan);
       yield put(actions.appendInterpreterResult(result, workspaceLocation));
     }
   } finally {
@@ -558,20 +559,9 @@ export function* evalCodeConductorSaga(
   const statusTask = yield fork(handleStatuses, hostPlugin, workspaceLocation);
   yield call([hostPlugin, 'startEvaluator'], entrypointFilePath);
 
-  // This exit logic of this while loop might be causing an unintended infinite loop in the REPL
-  while (true) {
-    const { stop } = yield race({
-      repl: take(actions.evalRepl.type),
-      stop: take(actions.beginInterruptExecution.type),
-    });
-    if (stop) break;
-    const code: string = yield select(
-      (state: OverallState) => state.workspaces[workspaceLocation].replValue,
-    );
-    yield put(actions.sendReplInputToOutput(code, workspaceLocation));
-    yield put(actions.clearReplInput(workspaceLocation));
-    yield call([hostPlugin, 'sendChunk'], code);
-  }
+  // OneShot: wait for the runner to send STOPPED/ERROR (dispatched by handleStatuses),
+  // or for the user to manually interrupt execution.
+  yield take(actions.beginInterruptExecution.type);
   yield cancel(statusTask);
   yield call([conduit, 'terminate']);
   yield cancel(stdoutTask);

--- a/src/features/conductor/BrowserHostPlugin.ts
+++ b/src/features/conductor/BrowserHostPlugin.ts
@@ -1,6 +1,5 @@
 import type { IChannel, IConduit } from '@sourceacademy/conductor/conduit';
 import { BasicHostPlugin } from '@sourceacademy/conductor/host';
-import type { IResultMessage } from '@sourceacademy/conductor/types';
 
 export class BrowserHostPlugin extends BasicHostPlugin {
   requestFile(fileName: string): Promise<string | undefined> {
@@ -18,7 +17,6 @@ export class BrowserHostPlugin extends BasicHostPlugin {
   private __onRequestFile: (fileName: string) => Promise<string | undefined>;
   private __onRequestLoadPlugin: (pluginName: string) => void;
 
-  static readonly channelAttach = [...super.channelAttach, '__result'] as any;
   constructor(
     conduit: IConduit,
     channels: IChannel<any>[],
@@ -28,9 +26,5 @@ export class BrowserHostPlugin extends BasicHostPlugin {
     super(conduit, channels);
     this.__onRequestFile = onRequestFile;
     this.__onRequestLoadPlugin = onRequestLoadPlugin;
-    const resultChannel = channels.find(
-      (channel): channel is IChannel<IResultMessage> => channel.name === '__result',
-    );
-    resultChannel?.subscribe(resultMessage => this.receiveResult?.(resultMessage.result));
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,10 +3155,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@https://github.com/source-academy/conductor.git#0.4.0":
-  version: 0.4.0
-  resolution: "@sourceacademy/conductor@https://github.com/source-academy/conductor.git#commit=00a0d5fdce269d62a0feb33230300db27121be05"
-  checksum: 10c0/1e92b0eb3d9c67f3ab5fd7768e24a33941a006df85770aaf1938c9484a4d466c6136202ad06a202a257bc7117b87907dda6e3c695340c24f5ab8ada8d12b5c77
+"@sourceacademy/conductor@https://github.com/source-academy/conductor.git#0.5.0":
+  version: 0.5.0
+  resolution: "@sourceacademy/conductor@https://github.com/source-academy/conductor.git#commit=2349aa912b32ff4f8b5bad2666243c6adad5677e"
+  checksum: 10c0/6f17b0f9bbd4630d73a3c4df043e05140f9c77b735fba4956442d3574c54f5918dd6113b3d52b1ed4238febc9ff2c03676c0200f7f1c5b5a3bc5eea92ecebea9
   languageName: node
   linkType: hard
 
@@ -7233,7 +7233,7 @@ __metadata:
     "@sentry/react": "npm:^10.5.0"
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663"
     "@sourceacademy/c-slang": "npm:^1.0.21"
-    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.4.0"
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.5.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.6"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"


### PR DESCRIPTION
## Summary
- Bumps `@sourceacademy/conductor` from `0.4.0` to `0.5.0`

Closes [issue](https://github.com/source-academy/conductor/issues/34)

## Why
Conductor 0.4.0 used `const enum` for `ServiceMessageType`, `InternalChannelName`, and other enums. Vite/esbuild (used by this frontend) compiles with `isolatedModules`, which erases `const enum` values from external packages to `undefined` at runtime. This caused the Conductor protocol handshake to silently fail — making the **Run button appear to do nothing**.

Conductor 0.5.0 converts all exported `const enum`s to regular `enum`s, fixing the runtime erasure. It also adds `BasicHostPlugin.receiveResult` so evaluation results are correctly received by the host.

## Changes in Conductor 0.5.0 (vs 0.4.0)
- `fix: remove const keyword from all remaining exported enums (#35)`
- `feat(host): add receiveResult callback to BasicHostPlugin (#33)`
- `fix(stepper): handle evaluator errors gracefully in BasicEvaluator and RunnerPlugin (#30)`
- `Modules: Switch Module Closures to be AsyncGenerators (#29)`