### PR TITLE
fix: conductor run button stuck on first click

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -458,6 +458,10 @@ function* handleResults(
     while (true) {
       const { value: result } = yield take(resultChan);
       yield put(actions.appendInterpreterResult(result, workspaceLocation));
+      // The OneShot evaluator sends exactly one result then stops. Trigger cleanup
+      // via beginInterruptExecution so the parent saga exits even if the STATUS
+      // channel is broken (e.g. const-enum erasure in older evaluator bundles).
+      yield put(actions.beginInterruptExecution(workspaceLocation));
     }
   } finally {
     if (yield cancelled()) {
@@ -493,8 +497,10 @@ function* handleStatuses(
   workspaceLocation: WorkspaceLocation,
 ): SagaIterator {
   const statusChan = eventChannel<{ status: RunnerStatus; isActive: boolean }>(emitter => {
-    const onStatusUpdate = (status: RunnerStatus, isActive: boolean) =>
+    const onStatusUpdate = (status: RunnerStatus, isActive: boolean) => {
+      console.log('[conductor] status update received:', status, 'isActive:', isActive, 'STOPPED=', RunnerStatus.STOPPED);
       emitter({ status, isActive });
+    };
     hostPlugin.receiveStatusUpdate = onStatusUpdate;
     return () => {
       if (hostPlugin.receiveStatusUpdate === onStatusUpdate) delete hostPlugin.receiveStatusUpdate;
@@ -503,13 +509,12 @@ function* handleStatuses(
   try {
     while (true) {
       const { status, isActive } = yield take(statusChan);
+      const isTerminalStatus =
+        isActive && (status === RunnerStatus.STOPPED || status === RunnerStatus.ERROR);
+      console.log('[conductor] handleStatuses loop: status=', status, 'isActive=', isActive, 'isTerminal=', isTerminalStatus);
       if (status === RunnerStatus.RUNNING) {
         yield put(actions.setIsRunning(isActive, workspaceLocation));
       }
-
-      const isTerminalStatus =
-        isActive && (status === RunnerStatus.STOPPED || status === RunnerStatus.ERROR);
-
       if (isTerminalStatus) {
         yield put(actions.beginInterruptExecution(workspaceLocation));
       }
@@ -546,30 +551,43 @@ export function* evalCodeConductorSaga(
     if (!evaluator?.path) throw Error('no evaluator');
   }
 
-  // Reuse a preloaded conductor instance when available.
-  const { hostPlugin, conduit }: { hostPlugin: BrowserHostPlugin; conduit: IConduit } = yield call(
-    getPreparedConductorSaga,
-    { files, consume: true },
-  );
+  let conduit: IConduit | undefined;
+  let stdoutTask: any;
+  let resultTask: any;
+  let errorTask: any;
+  let statusTask: any;
 
-  // Begin evaluation
-  const stdoutTask = yield fork(handleStdout, hostPlugin, workspaceLocation);
-  const resultTask = yield fork(handleResults, hostPlugin, workspaceLocation);
-  const errorTask = yield fork(handleErrors, hostPlugin, workspaceLocation);
-  const statusTask = yield fork(handleStatuses, hostPlugin, workspaceLocation);
-  yield call([hostPlugin, 'startEvaluator'], entrypointFilePath);
+  try {
+    // Reuse a preloaded conductor instance when available.
+    const prepared: { hostPlugin: BrowserHostPlugin; conduit: IConduit } = yield call(
+      getPreparedConductorSaga,
+      { files, consume: true },
+    );
+    const hostPlugin = prepared.hostPlugin;
+    conduit = prepared.conduit;
 
-  // OneShot: wait for the runner to send STOPPED/ERROR (dispatched by handleStatuses),
-  // or for the user to manually interrupt execution.
-  yield take(actions.beginInterruptExecution.type);
-  yield cancel(statusTask);
-  yield call([conduit, 'terminate']);
-  yield cancel(stdoutTask);
-  yield cancel(resultTask);
-  yield cancel(errorTask);
-  //yield put(actions.debuggerReset(workspaceLocation));
-  yield put(actions.endInterruptExecution(workspaceLocation));
-  console.log('killed');
+    // Begin evaluation
+    stdoutTask = yield fork(handleStdout, hostPlugin, workspaceLocation);
+    resultTask = yield fork(handleResults, hostPlugin, workspaceLocation);
+    errorTask = yield fork(handleErrors, hostPlugin, workspaceLocation);
+    statusTask = yield fork(handleStatuses, hostPlugin, workspaceLocation);
+
+    yield call([hostPlugin, 'startEvaluator'], entrypointFilePath);
+
+    // OneShot: wait for the runner to send STOPPED/ERROR (dispatched by handleStatuses),
+    // or for the user to manually interrupt execution.
+    yield race({
+      done: take(actions.beginInterruptExecution.type),
+      timeout: call(() => new Promise(resolve => setTimeout(resolve, execTime + 10000))),
+    });
+  } finally {
+    if (statusTask) yield cancel(statusTask);
+    if (conduit) yield call([conduit, 'terminate']);
+    if (stdoutTask) yield cancel(stdoutTask);
+    if (resultTask) yield cancel(resultTask);
+    if (errorTask) yield cancel(errorTask);
+    yield put(actions.endInterruptExecution(workspaceLocation));
+  }
 }
 
 // Special module errors

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -497,10 +497,8 @@ function* handleStatuses(
   workspaceLocation: WorkspaceLocation,
 ): SagaIterator {
   const statusChan = eventChannel<{ status: RunnerStatus; isActive: boolean }>(emitter => {
-    const onStatusUpdate = (status: RunnerStatus, isActive: boolean) => {
-      console.log('[conductor] status update received:', status, 'isActive:', isActive, 'STOPPED=', RunnerStatus.STOPPED);
+    const onStatusUpdate = (status: RunnerStatus, isActive: boolean) =>
       emitter({ status, isActive });
-    };
     hostPlugin.receiveStatusUpdate = onStatusUpdate;
     return () => {
       if (hostPlugin.receiveStatusUpdate === onStatusUpdate) delete hostPlugin.receiveStatusUpdate;
@@ -511,7 +509,6 @@ function* handleStatuses(
       const { status, isActive } = yield take(statusChan);
       const isTerminalStatus =
         isActive && (status === RunnerStatus.STOPPED || status === RunnerStatus.ERROR);
-      console.log('[conductor] handleStatuses loop: status=', status, 'isActive=', isActive, 'isTerminal=', isTerminalStatus);
       if (status === RunnerStatus.RUNNING) {
         yield put(actions.setIsRunning(isActive, workspaceLocation));
       }

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -578,12 +578,15 @@ export function* evalCodeConductorSaga(
       timeout: call(() => new Promise(resolve => setTimeout(resolve, execTime + 10000))),
     });
   } finally {
-    if (statusTask) yield cancel(statusTask);
-    if (conduit) yield call([conduit, 'terminate']);
-    if (stdoutTask) yield cancel(stdoutTask);
-    if (resultTask) yield cancel(resultTask);
-    if (errorTask) yield cancel(errorTask);
-    yield put(actions.endInterruptExecution(workspaceLocation));
+    try {
+      if (statusTask) yield cancel(statusTask);
+      if (stdoutTask) yield cancel(stdoutTask);
+      if (resultTask) yield cancel(resultTask);
+      if (errorTask) yield cancel(errorTask);
+      if (conduit) yield call([conduit, 'terminate']);
+    } finally {
+      yield put(actions.endInterruptExecution(workspaceLocation));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Wrap the entire `evalCodeConductorSaga` body in `try/finally` so `endInterruptExecution` is always dispatched — prevents the run button from being permanently stuck if `getPreparedConductorSaga` throws or hangs
- Add a `race` with `execTime + 10s` timeout as a hard fallback so the saga never waits forever for a terminal signal
- Dispatch `beginInterruptExecution` from `handleResults` after the program result is received, so the saga exits cleanly even when the STATUS channel is not functional

## Root cause

The deployed evaluator bundles were built with an older conductor version that used `const enum InternalChannelName`. When bundled (Vite/esbuild with `isolatedModules`), these const enum values were erased to `undefined`. The host (conductor 0.5.0) listens on `"__status"` for status updates; the worker sends on `undefined`. They never match, so `receiveStatusUpdate` is never called and the saga waits forever for a STOPPED signal that never arrives.

The RESULT channel works through a different path, so the fix is to trigger saga exit from `handleResults` when the program result is received, rather than relying solely on the STATUS channel. Once evaluator bundles are rebuilt with conductor 0.5.0, the STATUS channel will also work — but either way the run button will unlock correctly.

## Test plan

- [ ] Run Python code (CSE machine) — first click should complete immediately without getting stuck
- [ ] Run button re-enables after program finishes
- [ ] Manually clicking Stop mid-run still works (interrupts correctly)
- [ ] Second and subsequent runs work as before