### PR TITLE
feat: set language-specific default editor program on evaluator selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@sentry/react": "^10.5.0",
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663",
     "@sourceacademy/c-slang": "^1.0.21",
-
     "@sourceacademy/conductor": "^0.5.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@sentry/react": "^10.5.0",
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663",
     "@sourceacademy/c-slang": "^1.0.21",
+
     "@sourceacademy/conductor": "^0.5.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2",

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -8,7 +8,9 @@ import { selectDirectoryLanguageUrl } from 'src/features/directory/flagDirectory
 import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
 import type { LanguageDirectoryState } from '../../features/directory/LanguageDirectoryTypes';
 import type { OverallState } from '../application/ApplicationTypes';
+import { defaultEditorValue } from '../application/ApplicationTypes';
 import { combineSagaHandlers } from '../redux/utils';
+import WorkspaceActions from '../workspace/WorkspaceActions';
 import { preloadConductorEvaluatorSaga } from './helpers/conductorEvaluatorCache';
 
 export function* getLanguageDefinitionSaga() {
@@ -50,6 +52,16 @@ const languageDirectoryHandlers = combineSagaHandlers({
       result = yield call([response, 'json']);
     }
     yield put(LanguageDirectoryActions.setLanguages(result));
+  },
+  [LanguageDirectoryActions.setSelectedEvaluator.type]: function* () {
+    const evaluator = yield call(getEvaluatorDefinitionSaga);
+    if (!evaluator?.defaultProgram) return;
+    const editorValue: string = yield select(
+      (state: OverallState) => state.workspaces.playground.editorTabs[0]?.value ?? '',
+    );
+    if (editorValue === defaultEditorValue) {
+      yield put(WorkspaceActions.updateEditorValue('playground', 0, evaluator.defaultProgram));
+    }
   },
   [LanguageDirectoryActions.setSelectedLanguage.type]: function* () {
     const language = yield call(getLanguageDefinitionSaga);

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -55,12 +55,14 @@ const languageDirectoryHandlers = combineSagaHandlers({
   },
   [LanguageDirectoryActions.setSelectedEvaluator.type]: function* () {
     const evaluator = yield call(getEvaluatorDefinitionSaga);
-    if (!evaluator?.defaultProgram) return;
-    const editorValue: string = yield select(
-      (state: OverallState) => state.workspaces.playground.editorTabs[0]?.value ?? '',
-    );
+    if (evaluator?.defaultProgram == null) return;
+    const playground = yield select((state: OverallState) => state.workspaces.playground);
+    const activeTabIndex: number = playground.activeEditorTabIndex ?? 0;
+    const editorValue: string = playground.editorTabs[activeTabIndex]?.value ?? '';
     if (editorValue === defaultEditorValue) {
-      yield put(WorkspaceActions.updateEditorValue('playground', 0, evaluator.defaultProgram));
+      yield put(
+        WorkspaceActions.updateEditorValue('playground', activeTabIndex, evaluator.defaultProgram),
+      );
     }
   },
   [LanguageDirectoryActions.setSelectedLanguage.type]: function* () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,17 +2850,17 @@ __metadata:
   linkType: hard
 
 "@rsbuild/plugin-react@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "@rsbuild/plugin-react@npm:2.1.0"
+  version: 2.0.1
+  resolution: "@rsbuild/plugin-react@npm:2.0.1"
   dependencies:
-    "@rspack/plugin-react-refresh": "npm:^2.0.2"
+    "@rspack/plugin-react-refresh": "npm:2.0.0"
     react-refresh: "npm:^0.18.0"
   peerDependencies:
-    "@rsbuild/core": ^2.0.0
+    "@rsbuild/core": ^2.0.0-0
   peerDependenciesMeta:
     "@rsbuild/core":
       optional: true
-  checksum: 10c0/8f50c1d1554a09835f8bf9bb30c72f5373314a5158cdc4c5e7314791877a71fad2ff1b75f3327c10e7c4a4ec3ec4c80a45afd7c16460653192f8e185aac2d166
+  checksum: 10c0/b9bb8941ca8081a7231e5b61fe071f8eda79f09ef3177b1ba4d2472ad6df749931446e0a3c71f2de930b8cdf05eac90d37d7f50f498752577516a694c2ee43e9
   languageName: node
   linkType: hard
 
@@ -3045,16 +3045,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/plugin-react-refresh@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@rspack/plugin-react-refresh@npm:2.0.2"
+"@rspack/plugin-react-refresh@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@rspack/plugin-react-refresh@npm:2.0.0"
   peerDependencies:
-    "@rspack/core": ^2.0.0
+    "@rspack/core": ^2.0.0-0
     react-refresh: ">=0.10.0 <1.0.0"
   peerDependenciesMeta:
     "@rspack/core":
       optional: true
-  checksum: 10c0/1291689c3fcdfc4bc62e9fd032786d0f72a24b8e3c844974367a54b9b640534836f1ac945b1f1342f877332a584440a71631761a3569dad3e76c30655f20b9bb
+  checksum: 10c0/ee8e6492c0772536abb98ab5ec92d0e4ad092613a3a6085542f0b354131eef48f4d7cbe9a8cf9a9389d5e51d623d08a2c07594c8add5ad5fb54fd5543150ead1
   languageName: node
   linkType: hard
 
@@ -11164,15 +11164,15 @@ __metadata:
   linkType: hard
 
 "react-draggable@npm:^4.4.5":
-  version: 4.7.0
-  resolution: "react-draggable@npm:4.7.0"
+  version: 4.6.0
+  resolution: "react-draggable@npm:4.6.0"
   dependencies:
     clsx: "npm:^2.1.1"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     react: ">= 16.3.0"
     react-dom: ">= 16.3.0"
-  checksum: 10c0/4bfd46025b6009585a644d17721cafcd7976c058c250086c06c1a952724230c83caa548c54f9b5849c3a148144e3ed6610a1745b2afc6db685c85c56a0b4f775
+  checksum: 10c0/4fc196136a86054f18a005d77a33d0bf214751b2534e38b76f8d588df865b8230b6084c1645040c243d83b191723fc133653ec372db45ab4bea0b1842c42a38a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- When an evaluator is selected, if the editor still shows the generic Source default (`// Type your program in here!`), it is replaced with the evaluator's `defaultProgram` from the language directory
- Falls back to the existing default if the evaluator has no `defaultProgram` defined
- Only replaces the placeholder — never overwrites code a user has already written

## Context

Closes source-academy/language-directory#29. Depends on language-directory adding the `defaultProgram` field (source-academy/language-directory#32). Once that merges and the `0.0.9` tag is live, the frontend will automatically pick up `defaultProgram` values via the deployed `directory.json`.

The change is in `LanguageDirectorySaga` — hooked into the existing `setSelectedEvaluator` action so it fires whenever the user (or initial load) selects an evaluator.