### PR TITLE
CSE Machine fix: arrow routing from stastItem to FnValue

### DIFF
--- a/src/features/cseMachine/components/arrows/ArrowFromStashItemComponent.tsx
+++ b/src/features/cseMachine/components/arrows/ArrowFromStashItemComponent.tsx
@@ -46,9 +46,16 @@ export class ArrowFromStashItemComponent extends GenericArrow<
         return [to instanceof ContValue ? targetCX - 1.5 * r : targetCX - r, targetCY]; // same level: left face
       };
 
+      // For FnValue, turn at its enclosing frame's top so the horizontal segment is visible
+      // above the frame rather than hidden inside it.
+      const approachTargetY =
+        to instanceof FnValue && to.enclosingFrame
+          ? to.enclosingFrame.y() - terminalSegmentLength
+          : targetCY - terminalSegmentLength;
+
       const approachY =
         targetCY >= sourceBottomY
-          ? Math.max(sourceBottomY + postSourceStraightLength, targetCY - terminalSegmentLength)
+          ? Math.max(sourceBottomY + postSourceStraightLength, approachTargetY)
           : Math.max(sourceBottomY + postSourceStraightLength, targetCY + terminalSegmentLength);
 
       const [landX, landY] = getLanding(approachY);

--- a/src/features/cseMachine/components/arrows/ArrowFromStashItemComponent.tsx
+++ b/src/features/cseMachine/components/arrows/ArrowFromStashItemComponent.tsx
@@ -48,10 +48,10 @@ export class ArrowFromStashItemComponent extends GenericArrow<
 
       // For FnValue, turn at its enclosing frame's top so the horizontal segment is visible
       // above the frame rather than hidden inside it.
-      const approachTargetY =
-        to instanceof FnValue && to.enclosingFrame
-          ? to.enclosingFrame.y() - terminalSegmentLength
-          : targetCY - terminalSegmentLength;
+      const enclosingFrame = to instanceof FnValue ? Frame.getFrom(to.data.environment) : undefined;
+      const approachTargetY = enclosingFrame
+        ? enclosingFrame.y() - terminalSegmentLength
+        : targetCY - terminalSegmentLength;
 
       const approachY =
         targetCY >= sourceBottomY


### PR DESCRIPTION
### Description

Closes #4009.

I have made sure that the arrow coming for FnValue from stashItems will always bend before the parentFrame's y coordinate irrespective of how far below the binding is.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

```python
def f(n):
    return (1 if n == 1 
            else n * f(n - 1))
def g(n):
    return n
def h(n):
    return n
         
h(4)
```
<img width="508" height="525" alt="image" src="https://github.com/user-attachments/assets/59deb2f2-3512-4268-a7b2-945df2293042" />

---

```python
def f(n):
    return (1 if n == 1 
            else n * f(n - 1))

f(4)
```

<img width="535" height="417" alt="image" src="https://github.com/user-attachments/assets/28cedb49-5dc0-4413-b008-20443ff39232" />


### Checklist

- [X] I have tested this code
- [ ] I have updated the documentation
