### PR TITLE
fix: route REPL evaluation through conductor for conductor languages

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/index.ts
+++ b/src/commons/sagas/WorkspaceSaga/index.ts
@@ -248,10 +248,11 @@ const WorkspaceSaga = combineSagaHandlers({
     yield put(actions.clearReplInput(workspaceLocation));
     yield put(actions.sendReplInputToOutput(code, workspaceLocation));
 
+    const context: Context = yield select(
+      (state: OverallState) => state.workspaces[workspaceLocation].context,
+    );
+
     if (yield select(selectConductorEnable)) {
-      const context: Context = yield select(
-        (state: OverallState) => state.workspaces[workspaceLocation].context,
-      );
       const codeFilePath = '/code.js';
       yield call(
         evalCodeConductorSaga,
@@ -265,9 +266,6 @@ const WorkspaceSaga = combineSagaHandlers({
       return;
     }
 
-    const context: Context = yield select(
-      (state: OverallState) => state.workspaces[workspaceLocation].context,
-    );
     // Reset old context.errors
     context.errors = [];
     const codeFilePath = '/code.js';

--- a/src/commons/sagas/WorkspaceSaga/index.ts
+++ b/src/commons/sagas/WorkspaceSaga/index.ts
@@ -40,7 +40,7 @@ import {
 import { showFullJSDisclaimer, showFullTSDisclaimer } from '../../utils/WarningDialogHelper';
 import { getPreparedConductorSaga } from '../helpers/conductorEvaluatorCache';
 import { selectWorkspace } from '../SafeEffects';
-import { evalCodeSaga } from './helpers/evalCode';
+import { evalCodeConductorSaga, evalCodeSaga } from './helpers/evalCode';
 import { evalEditorSaga } from './helpers/evalEditor';
 import { runTestCase } from './helpers/runTestCase';
 import {
@@ -241,15 +241,30 @@ const WorkspaceSaga = combineSagaHandlers({
     );
   },
   [WorkspaceActions.evalRepl.type]: function* (action) {
-    if (yield select(selectConductorEnable)) {
-      return; // no-op: evalCodeConductorSaga will pick up this action and handle it from there
-    }
     const workspaceLocation = action.payload.workspaceLocation;
     const { replValue: code, execTime } = yield* selectWorkspace(workspaceLocation);
 
     yield put(actions.beginInterruptExecution(workspaceLocation));
     yield put(actions.clearReplInput(workspaceLocation));
     yield put(actions.sendReplInputToOutput(code, workspaceLocation));
+
+    if (yield select(selectConductorEnable)) {
+      const context: Context = yield select(
+        (state: OverallState) => state.workspaces[workspaceLocation].context,
+      );
+      const codeFilePath = '/code.js';
+      yield call(
+        evalCodeConductorSaga,
+        { [codeFilePath]: code },
+        codeFilePath,
+        context,
+        execTime,
+        workspaceLocation,
+        WorkspaceActions.evalRepl.type,
+      );
+      return;
+    }
+
     const context: Context = yield select(
       (state: OverallState) => state.workspaces[workspaceLocation].context,
     );


### PR DESCRIPTION
Fixes #4011

## Problem

The REPL panel does not work for conductor languages (e.g. Python §3/§4). Typing code in the REPL and pressing Enter clears the input but produces no output — the evaluation is silently dropped.

The `evalRepl` saga handler short-circuits when conductor is enabled:

```ts
if (yield select(selectConductorEnable)) {
  return; // no-op: evalCodeConductorSaga will pick up this action and handle it from there
}
```

The comment is stale. The original conductor integration (#3084) handled REPL inputs via a `take(actions.evalRepl)` race inside `evalCodeConductorSaga`. That was removed in a later refactor but the early return was kept, so `evalRepl` actions are now silently dropped for all conductor languages.

Closes [issue](https://github.com/source-academy/py-slang/issues/159) since the _undefined/None_ are not displayed anymore.

<img width="220" height="293" alt="image" src="https://github.com/user-attachments/assets/065850ef-db6c-4fdb-a9ac-609fff84e461" />

## Fix

When conductor is enabled, run the same preamble (`clearReplInput`, `sendReplInputToOutput`) and then call `evalCodeConductorSaga` directly with the REPL code — the same routing pattern `evalEditorSaga` uses for the Run button.

## Notes

- Non-conductor languages (js-slang) are unaffected; their path is unchanged
- REPL state does not persist across evaluations (each conductor run is stateless); this is a separate, deeper limitation not addressed here