### PR TITLE
chore: bump language-directory to 0.0.10 (§ signs in chapter names)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663",
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/conductor": "^0.5.0",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2",
     "@sourceacademy/sharedb-ace": "2.1.1",
     "@sourceacademy/sling-client": "^0.1.0",

--- a/src/new_routes/nus_login.module.scss
+++ b/src/new_routes/nus_login.module.scss
@@ -1,0 +1,66 @@
+.container {
+  display: flex;
+  min-height: 100dvh;
+}
+
+.row {
+  margin: 0 !important;
+}
+
+.unpadded {
+  padding: 0 !important;
+}
+
+.header {
+  padding-top: 3rem;
+  border-radius: 0;
+  box-shadow: 0 0 0 0 transparent;
+  max-height: 120px;
+  display: flex;
+  gap: 0.75rem;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.logo {
+  display: inline-block;
+  height: 100%;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.buttons-wrapper {
+  width: 70%;
+
+  button:not(.outlined) {
+    box-shadow: 0 0 0 0 transparent !important;
+    background-color: #013399 !important;
+
+    &:hover {
+      background-color: #70a3cf !important;
+    }
+  }
+
+  > * {
+    border-radius: 24px !important;
+    width: 100%;
+  }
+
+  > * + * {
+    margin-top: 1rem;
+  }
+}
+
+.body {
+  border-radius: 0;
+  box-shadow: 0 0 0 0 transparent;
+  width: 100%;
+  height: 100%;
+
+  > * + * {
+    margin-top: 1rem;
+  }
+}

--- a/src/pages/academy/grading/subcomponents/GradingBadges.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingBadges.tsx
@@ -1,0 +1,189 @@
+import { Icon } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import classNames from 'classnames';
+import type { ProgressStatus } from 'src/commons/assessment/AssessmentTypes';
+import { ProgressStatuses } from 'src/commons/assessment/AssessmentTypes';
+import type { ColumnFilter } from 'src/features/grading/GradingTypes';
+import classes from 'src/styles/Grading.module.scss';
+import badgeClasses from 'src/styles/GradingBadges.module.scss';
+
+declare const sizeValues: readonly ['xs', 'sm', 'md', 'lg', 'xl'];
+declare type Size = (typeof sizeValues)[number];
+
+type BadgeProps = {
+  text: string;
+  /** First color is bg, second is text. Refer to {typeof AVAILABLE_COLORS} */
+  color?: readonly [string, string];
+  size?: Size;
+  icon?: React.ReactNode;
+};
+
+const Badge: React.FC<BadgeProps> = props => {
+  return (
+    <div
+      className={classNames(
+        badgeClasses['grading-badge'],
+        badgeClasses[`grading-badge-${props.size ?? 'sm'}`],
+      )}
+      style={{
+        color: props.color?.[1] ?? '#000000',
+        backgroundColor: props.color ? props.color[0] + '40' : '',
+      }}
+    >
+      {props.icon}
+      <span className={badgeClasses['grading-badge-text']}>{props.text}</span>
+    </div>
+  );
+};
+
+// First color is bg, second is text (text is more saturated/darker). Colors are referenced from tailwind css.
+const AVAILABLE_COLORS = {
+  indigo: ['#818cf8', '#4f46e5'],
+  emerald: ['#6ee7b7', '#059669'],
+  sky: ['#7dd3fc', '#0284c7'],
+  green: ['#4ade80', '#15803d'],
+  yellow: ['#fde047', '#ca8a04'],
+  red: ['#f87171', '#b91c1c'],
+  gray: ['#9ca3af', '#374151'],
+  purple: ['#c084fc', '#7e22ce'],
+  blue: ['#93c5fd', '#2563eb'],
+} as const;
+
+const BADGE_COLORS = Object.freeze({
+  // assessment types
+  missions: AVAILABLE_COLORS.indigo,
+  quests: AVAILABLE_COLORS.emerald,
+  paths: AVAILABLE_COLORS.sky,
+
+  // submission status
+  [ProgressStatuses.autograded]: AVAILABLE_COLORS.purple,
+  [ProgressStatuses.not_attempted]: AVAILABLE_COLORS.gray,
+  [ProgressStatuses.attempting]: AVAILABLE_COLORS.red,
+  [ProgressStatuses.attempted]: AVAILABLE_COLORS.red,
+
+  // grading status
+  [ProgressStatuses.submitted]: AVAILABLE_COLORS.yellow,
+  [ProgressStatuses.graded]: AVAILABLE_COLORS.green,
+  [ProgressStatuses.published]: AVAILABLE_COLORS.blue,
+});
+
+// For supporting tables that still use Tremor & Tanstack (e.g TeamFormationBadges since they copied the old tanstack grading code)
+// TO BE REMOVED AFTER THEY MIGRATE TO BLUEPRINTJS/AGGRID
+const BADGE_COLORS_LEGACY = Object.freeze({
+  // assessment types
+  missions: 'indigo',
+  quests: 'emerald',
+  paths: 'sky',
+
+  // submission status
+  [ProgressStatuses.autograded]: 'purple',
+  [ProgressStatuses.not_attempted]: 'gray',
+  [ProgressStatuses.attempting]: 'red',
+  [ProgressStatuses.attempted]: 'red',
+
+  // grading status
+  [ProgressStatuses.submitted]: 'yellow',
+  [ProgressStatuses.graded]: 'green',
+  [ProgressStatuses.published]: 'blue',
+});
+
+function getBadgeColorFromLabel(label: string) {
+  const maybeKey = label.toLowerCase() as keyof typeof BADGE_COLORS;
+  return BADGE_COLORS[maybeKey] || AVAILABLE_COLORS.gray;
+}
+
+// For supporting tables that still use Tremor & Tanstack (e.g TeamFormationBadges since they copied the old tanstack grading code)
+// TO BE REMOVED AFTER THEY MIGRATE TO BLUEPRINTJS/AGGRID
+export function getBadgeColorFromLabelLegacy(label: string) {
+  const maybeKey = label.toLowerCase() as keyof typeof BADGE_COLORS_LEGACY;
+  return BADGE_COLORS_LEGACY[maybeKey] || 'gray';
+}
+
+type AssessmentTypeBadgeProps = {
+  type: string;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+};
+
+const AssessmentTypeBadge: React.FC<AssessmentTypeBadgeProps> = ({ type, size = 'sm' }) => {
+  return (
+    <Badge
+      text={size === 'xs' ? type.charAt(0).toUpperCase() : type}
+      size={size}
+      color={getBadgeColorFromLabel(type)}
+    />
+  );
+};
+
+type ColumnFilterBadgeProps = {
+  filter: string;
+  onRemove: (toRemove: string) => void;
+  filtersName: string;
+};
+
+const ColumnFilterBadge: React.FC<ColumnFilterBadgeProps> = ({ filter, onRemove, filtersName }) => {
+  return (
+    <button
+      type="button"
+      className={classes['grading-overview-filterable-btns']}
+      onClick={() => onRemove(filter)}
+      style={{ marginLeft: '5px' }}
+    >
+      <Badge
+        text={filtersName}
+        icon={<Icon icon={IconNames.CROSS} style={{ marginRight: '0.25rem' }} />}
+        color={getBadgeColorFromLabel(filter)}
+      />
+    </button>
+  );
+};
+
+type FilterBadgeProps = {
+  filter: ColumnFilter;
+  onRemove: (filter: ColumnFilter) => void;
+};
+
+const FilterBadge: React.FC<FilterBadgeProps> = ({ filter, onRemove }) => {
+  let filterValue = filter.value as string;
+  filterValue = filterValue.charAt(0).toUpperCase() + filterValue.slice(1);
+  return (
+    <button
+      type="button"
+      className={classes['grading-overview-filterable-btns']}
+      onClick={() => onRemove(filter)}
+      style={{ marginLeft: '5px' }}
+    >
+      <Badge
+        text={filterValue}
+        icon={<Icon icon={IconNames.CROSS} style={{ marginRight: '0.25rem' }} />}
+        color={getBadgeColorFromLabel(filterValue)}
+      />
+    </button>
+  );
+};
+
+type ProgressStatusBadgeProps = {
+  progress: ProgressStatus;
+};
+
+const ProgressStatusBadge: React.FC<ProgressStatusBadgeProps> = ({ progress }) => {
+  const statusText = progress.charAt(0).toUpperCase() + progress.slice(1);
+  const badgeIcon = (
+    <Icon
+      icon={
+        progress === ProgressStatuses.autograded
+          ? IconNames.AIRPLANE
+          : progress === ProgressStatuses.published
+            ? IconNames.ENDORSED
+            : progress === ProgressStatuses.graded
+              ? IconNames.TICK
+              : progress === ProgressStatuses.submitted
+                ? IconNames.TIME
+                : IconNames.DISABLE
+      }
+      style={{ marginRight: '0.5rem' }}
+    />
+  );
+  return <Badge text={statusText} color={getBadgeColorFromLabel(progress)} icon={badgeIcon} />;
+};
+
+export { AssessmentTypeBadge, ColumnFilterBadge, FilterBadge, ProgressStatusBadge };

--- a/src/pages/welcome/Welcome.module.scss
+++ b/src/pages/welcome/Welcome.module.scss
@@ -1,0 +1,14 @@
+.fullpage {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.fullpage-content {
+  display: flex;
+  justify-content: center;
+}
+
+.text-left {
+  text-align: left;
+}

--- a/src/styles/Academy.module.scss
+++ b/src/styles/Academy.module.scss
@@ -1,0 +1,22 @@
+@import '_global';
+
+.Academy {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 100%;
+}
+
+.Academy-switching-courses {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.listing-xp {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/src/styles/AchievementCommentCard.module.scss
+++ b/src/styles/AchievementCommentCard.module.scss
@@ -1,0 +1,46 @@
+.assessment-feedback {
+  padding-left: 2rem;
+}
+
+.feedback-list {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.assessment-comments {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.question-header {
+  margin-top: 0;
+}
+
+.box-comment {
+  flex-grow: 1;
+  display: block;
+  padding-top: 0.1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  .xp {
+    font-weight: 700;
+    color: orange;
+  }
+}
+
+.to-assessment-button {
+  flex: none;
+
+  height: 2rem;
+  width: 6rem;
+
+  margin-top: 0.1rem;
+  margin-bottom: 1rem;
+  border-radius: 5px;
+
+  cursor: pointer;
+}

--- a/src/styles/Chatbot.module.scss
+++ b/src/styles/Chatbot.module.scss
@@ -1,0 +1,264 @@
+.bot-container {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  max-width: 100vw;
+  max-height: 100vh;
+}
+
+.chat-container {
+  position: relative;
+  width: 400px;
+  height: 450px;
+  max-height: 80vh;
+  max-width: 100vw;
+  border-radius: 8px;
+  background-color: #f1f1f1;
+  padding: 16px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  transition:
+    width 0.2s ease,
+    height 0.2s ease;
+}
+
+.chat-container-expanded {
+  width: 700px;
+  max-width: 100vw;
+  height: 80vh;
+  max-height: 800px;
+}
+
+.expand-button {
+  min-width: 24px;
+  min-height: 24px;
+}
+
+.control-container {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  & > :first-child {
+    margin-top: 10px;
+  }
+}
+
+.bot-area {
+  position: relative;
+}
+
+.tips-box {
+  position: absolute;
+  padding-right: 10px;
+  bottom: 10px;
+  right: 65px;
+  width: 260px;
+  height: auto;
+  border: 1px solid black;
+  background-color: #f1f1f1;
+  border-radius: 5px;
+}
+
+.tips-message {
+  padding: 4px 8px;
+  margin: 0;
+  font-size: 13px;
+  text-align: right;
+  white-space: normal;
+  word-break: normal;
+}
+
+.bot-button {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  cursor: grab;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  -webkit-user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.iSA {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  pointer-events: none;
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+.chat-message {
+  flex: 1;
+  border: 1px solid #ddd;
+  overflow-y: scroll;
+  border-radius: 5px;
+  padding: 16px;
+  min-height: 0;
+}
+
+.user-input {
+  width: 100%;
+  font-size: 20px;
+  color: black;
+  background-color: white;
+  border: 1px solid black;
+  margin-bottom: 0px;
+  padding-left: 10px;
+}
+
+.user {
+  background-color: #a3a3a4;
+  color: #fff;
+  font-size: 15px;
+  text-align: left;
+  padding: 10px;
+  line-height: 1.5;
+  border-radius: 10px;
+  display: block;
+  margin-bottom: 5px;
+}
+
+.assistant {
+  background-color: #e1e1e1;
+  font-size: 15px;
+  color: #333;
+  text-align: left;
+  padding: 10px;
+  line-height: 1.5;
+  border-radius: 10px;
+  display: block;
+  margin-bottom: 10px;
+
+  p {
+    margin: 0 0 8px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  ul,
+  ol {
+    margin: 4px 0;
+    padding-left: 20px;
+  }
+
+  code {
+    background-color: rgba(0, 0, 0, 0.08);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+
+  pre {
+    margin: 8px 0;
+    border-radius: 6px;
+    overflow-x: auto;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: 8px 0;
+    font-size: 14px;
+
+    th,
+    td {
+      border: 1px solid #ccc;
+      padding: 4px 8px;
+    }
+
+    th {
+      background-color: rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  blockquote {
+    margin: 8px 0;
+    padding-left: 12px;
+    border-left: 3px solid #999;
+    color: #555;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin: 8px 0 4px;
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 1.3em;
+  }
+  h2 {
+    font-size: 1.15em;
+  }
+  h3 {
+    font-size: 1.05em;
+  }
+}
+
+.button-container {
+  height: 8%;
+  text-align: center;
+  margin-top: 0px;
+  padding: 0px;
+}
+
+.button-send {
+  width: 40%;
+  height: 100%;
+  background-color: gray;
+  font-size: 15px;
+  margin-right: 5%;
+  margin-top: 0%;
+  border: 1px;
+  border-radius: 10px;
+  vertical-align: top;
+}
+
+.button-clean {
+  width: 40%;
+  margin-top: 0%;
+  height: 100%;
+  margin-left: 5%;
+  background-color: gray;
+  font-size: 15px;
+  border: 1px;
+  border-radius: 10px;
+  vertical-align: top;
+}
+
+.input-count-container {
+  justify-content: flex-end;
+  display: flex;
+  align-items: center;
+  height: 20px;
+}
+.input-count {
+  font-size: 10px;
+  color: #666;
+  margin: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}

--- a/src/styles/ChatbotCodeSnippet.module.scss
+++ b/src/styles/ChatbotCodeSnippet.module.scss
@@ -1,0 +1,85 @@
+@import './_global';
+
+.snippet-open {
+  inset: 0;
+  margin: auto;
+  width: 80vw;
+  max-width: 1200px;
+  height: 80vh;
+  max-height: 800px;
+  display: flex;
+  flex-flow: column nowrap;
+  background-color: #1e1e1e;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+
+  > :global(.ControlBar) {
+    display: flex;
+    background-color: $cadet-color-1;
+    color: white;
+    padding: 5px 10px;
+    width: 100%;
+
+    :global(.ControlBar_flow) {
+      flex-grow: 1;
+    }
+
+    // Close button text color
+    button {
+      color: white;
+
+      &:hover {
+        color: white;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 768px) {
+    width: 100vw;
+    height: 100vh;
+    max-width: unset;
+    max-height: unset;
+    border-radius: 0;
+  }
+}
+
+.desktop-open {
+  position: relative;
+  width: 100%;
+  height: calc(100% - 40px);
+  overflow: hidden;
+}
+
+.workspace-container {
+  position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  height: 100%;
+  overflow: hidden;
+
+  :global(.workspace) {
+    position: relative;
+    color: white;
+    overflow-y: auto;
+
+    // Ensure right-parent contains the fullscreen button
+    :global(.right-parent) {
+      position: relative;
+    }
+  }
+}
+
+.snippet-closed {
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: 0 0 0 2px rgba(19, 124, 189, 0.5);
+  }
+
+  pre {
+    margin: 0 !important;
+  }
+}

--- a/src/styles/ConfigureControls.module.scss
+++ b/src/styles/ConfigureControls.module.scss
@@ -1,0 +1,22 @@
+/* Container for warnings upon clicking assign entries button */
+.reassign-voting-warning {
+  font-size: 11px;
+  margin-left: 38px;
+}
+
+.confirm-assign-voting,
+.current-voting-status {
+  max-height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 15px;
+
+  .confirm-assign-text {
+    margin-top: 9px;
+  }
+
+  .voting-status-text {
+    margin-top: 10px;
+  }
+}

--- a/src/styles/ConfirmDialog.module.scss
+++ b/src/styles/ConfirmDialog.module.scss
@@ -1,0 +1,11 @@
+.ConfirmDialog {
+  .large-button:not(:first-of-type) {
+    margin-top: 0.5em;
+  }
+
+  @media only screen and (max-width: 500px) {
+    // Set width to 98% when screen width is less than 500px
+    // 500px is the default width of the component
+    width: 98%;
+  }
+}

--- a/src/styles/ContextMenu.module.scss
+++ b/src/styles/ContextMenu.module.scss
@@ -1,0 +1,18 @@
+@import '_global';
+
+.context-menu {
+  background-color: $cadet-color-1;
+  padding: 5px 1px;
+  z-index: 5;
+}
+
+.context-menu-item {
+  list-style: none;
+  user-select: none;
+  padding: 3px 16px;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: $cadet-color-3;
+  }
+}

--- a/src/styles/Contributors.module.scss
+++ b/src/styles/Contributors.module.scss
@@ -1,0 +1,130 @@
+@import '_global';
+
+// Styling components of the ContributorsDetails
+
+.outsideDetails {
+  text-align: center;
+
+  .contributorsDetails {
+    background-color: $cadet-color-4;
+    display: inline-block;
+    margin-top: 2%;
+    margin-bottom: 2%;
+    padding: 1% 1% 1% 1%;
+
+    h3 {
+      font-weight: bold;
+      font-style: oblique;
+    }
+
+    p {
+      margin-right: 0.5%;
+      margin-left: 0.5%;
+    }
+
+    p.description {
+      text-align: justify;
+      text-align-last: center;
+    }
+
+    span.dot {
+      padding: 0 0.2rem 0 0.2rem;
+    }
+
+    div.leadership {
+      margin-top: 10px;
+      text-align: center;
+
+      p {
+        vertical-align: top;
+        display: inline-block;
+        width: 120px;
+        &.wider {
+          width: 140px;
+        }
+        &.evenWider {
+          width: 200px;
+        }
+      }
+    }
+
+    div.hallOfFame {
+      margin-top: 10px;
+      text-align: center;
+    }
+
+    div.contributors {
+      margin-top: 10px;
+      text-align: center;
+
+      h5 {
+        text-align: center;
+      }
+    }
+  }
+}
+
+// Styling components of the ContributorsList
+
+.containerPermalink {
+  background-color: $cadet-color-4;
+  margin-bottom: 2%;
+}
+
+div.inPermalink {
+  background-color: $cadet-color-4;
+  text-align: justify;
+
+  div {
+    text-align: center;
+    vertical-align: top;
+    display: inline-block;
+    width: 20%;
+    height: 20%;
+    margin-top: 1%;
+    margin-bottom: 0.5%;
+
+    @media screen and (max-width: 1000px) {
+      width: 33.3%;
+      height: 33.3%;
+    }
+  }
+
+  img {
+    width: 90%;
+    height: 90%;
+  }
+
+  p {
+    margin-bottom: 0.2rem;
+    color: $cadet-color-2;
+  }
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+    color: $cadet-color-1;
+    &:hover {
+      color: $cadet-color-3;
+    }
+  }
+}
+
+div.repoDetailsPermalink {
+  text-align: center;
+
+  h3 {
+    margin: 0% 2% 0.5% 2%;
+    color: $cadet-color-2;
+  }
+
+  h3::first-letter {
+    text-transform: uppercase;
+  }
+
+  h5 {
+    margin: 0% 2% 1% 2%;
+    font-style: italic;
+    color: $cadet-color-1;
+  }
+}

--- a/src/styles/FileSystemView.module.scss
+++ b/src/styles/FileSystemView.module.scss
@@ -1,0 +1,67 @@
+@import '_global';
+
+.file-system-view-container {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  padding: 1px;
+  display: flex;
+  flex-direction: column;
+
+  // Remove the white space at the intersection of the x-axis & y-axis
+  // scrollbars on Chromium browsers.
+  &::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}
+
+.file-system-view-error {
+  text-align: center;
+}
+
+.file-system-view-empty-space {
+  flex-grow: 1;
+}
+
+.file-system-view-list-container {
+  min-width: 100%;
+  width: min-content;
+  display: flex;
+  flex-direction: column;
+}
+
+.file-system-view-spinner {
+  padding: 5px;
+}
+
+.file-system-view-directory-node-container {
+  min-width: 100%;
+  width: min-content;
+}
+
+.file-system-view-node-container {
+  min-width: 100%;
+  width: min-content;
+  display: flex;
+  flex-direction: row;
+  column-gap: 3px;
+  user-select: none;
+  padding: 2px 5px;
+
+  &:hover {
+    background: $cadet-color-3;
+  }
+}
+
+.file-system-view-input {
+  width: 100%;
+  background: transparent;
+  border: thin solid $cadet-color-4;
+  padding: 0;
+}
+
+.file-system-view-file-name {
+  // Should be the line-width & line-style as the border of .file-system-view-input
+  // to prevent shifting of file entries in the file system view when renaming.
+  border: thin solid transparent;
+}

--- a/src/styles/Grading.module.scss
+++ b/src/styles/Grading.module.scss
@@ -1,0 +1,160 @@
+@import '_global';
+
+.grading-overview-unfilterable-btns,
+.grading-overview-filterable-btns {
+  padding: 0 2px;
+  text-align: inherit;
+  outline: none;
+  line-height: 1.5;
+
+  a {
+    text-decoration: none;
+    color: black;
+  }
+
+  &,
+  p {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}
+
+.grading-overview-filterable-btns {
+  &:hover:not(:has(> .grading-badge)) {
+    text-decoration: underline;
+  }
+
+  &:hover:has(> .grading-badge) {
+    filter: brightness(0.75);
+  }
+}
+
+.grading-overview-unfilterable-btns,
+.grading-overview-filterable-btns {
+  border-radius: 9999px;
+}
+
+.grading-table-col-icons {
+  pointer-events: none;
+  opacity: 0;
+  padding: 6px;
+  height: fit-content;
+  line-height: initial !important;
+  border-radius: 5px;
+  margin-right: 2.5px;
+  position: absolute;
+  right: 0;
+
+  &:hover {
+    background-color: #00000022;
+  }
+}
+
+:global(.ag-header-cell).grading-left-align {
+  :global(span.ag-header-cell-text) {
+    margin: auto auto auto 0px;
+  }
+}
+
+.grading-default-headers {
+  justify-content: space-between;
+  width: 100%;
+  transition: 0.1s ease;
+  cursor: pointer;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+
+  &:not(.grading-left-align) {
+    padding: 0 !important;
+  }
+
+  :global(span.ag-header-cell-text) {
+    margin: 0 auto;
+    font-size: 0.8rem;
+    color: #6b7280;
+    font-weight: 600;
+    margin: auto;
+    padding: 0 5px;
+  }
+
+  &:hover {
+    --ag-header-cell-hover-background-color: #e5e7eb;
+  }
+
+  &:hover .grading-table-col-icons {
+    pointer-events: all;
+    opacity: 1;
+    position: relative;
+    transition: 0.1s ease;
+  }
+}
+
+.grading-table-header-individual {
+  width: 100%;
+}
+
+.grading-table-rows {
+  &:global(.ag-row-hover) {
+    --ag-row-hover-color: #f5f5f5;
+  }
+
+  &:global(.ag-row.ag-row-last) {
+    border-bottom: 0px !important;
+  }
+}
+
+.grading-filter-btn {
+  padding: 7.5px 15px;
+  border-radius: 25px;
+  margin: 0 15px 0 auto;
+  background-color: #dbeafef5 !important;
+  color: #3b82f6 !important;
+  min-width: fit-content;
+
+  &.grading-filter-btn-on {
+    background-color: #f5f5f5 !important;
+    color: black !important;
+  }
+
+  &:hover {
+    filter: contrast(0.9);
+  }
+}
+
+.grading-def-cell {
+  text-align: center;
+  display: flex !important;
+  justify-content: center;
+  flex-direction: column;
+  font-size: 0.875rem;
+  user-select: text;
+  border: 0px !important;
+
+  &:hover:has(.grading-overview-filterable-btns) {
+    .grading-overview-filterable-btns {
+      text-decoration: underline;
+    }
+  }
+
+  &:active {
+    border-style: outset;
+  }
+
+  &.grading-def-cell-pointer {
+    cursor: pointer;
+  }
+
+  &.grading-def-cell-selectable {
+    cursor: text;
+    border-style: outset;
+  }
+
+  &.grading-cell-align-left {
+    text-align: left !important;
+  }
+
+  &.grading-xp-cell {
+    text-wrap: wrap;
+    line-height: 15px;
+  }
+}

--- a/src/styles/GradingBadges.module.scss
+++ b/src/styles/GradingBadges.module.scss
@@ -1,0 +1,58 @@
+@import '_global';
+
+.grading-badge {
+  border-radius: 9999px;
+  padding: 0.1rem 0.2rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  line-height: normal !important;
+  width: fit-content;
+  max-width: max(1200px * 0.2, 20vw);
+  margin: auto;
+  color: rgba(0, 0, 0, 0.7);
+  text-wrap: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+
+  &.grading-badge-xs {
+    padding: 0.25rem 0.6rem;
+    font-size: 0.7rem;
+  }
+
+  &.grading-badge-sm {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.8rem;
+  }
+
+  &.grading-badge-md {
+    padding: 0.5rem 1rem;
+    font-size: 0.9rem;
+  }
+
+  &.grading-badge-lg {
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+  }
+
+  &.grading-badge-xl {
+    padding: 1rem 2rem;
+    font-size: 1.25rem;
+  }
+
+  // div: .grading-def-cell
+  // button: .grading-overview-filterable-btns
+  // TODO: This also affects .grading-overview-unfilterable-btns
+  div:hover > button:has(&) {
+    text-decoration: none !important;
+    filter: brightness(0.75);
+  }
+}
+
+.grading-badge-text {
+  line-height: normal !important;
+  width: fit-content;
+  max-width: max(calc(1200px * 0.2 - 16px - 2rem), calc(20vw - 16px - 2rem));
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/styles/GradingCommentSelector.module.scss
+++ b/src/styles/GradingCommentSelector.module.scss
@@ -1,0 +1,31 @@
+@import '_global';
+
+.grading-comment-selector {
+  text-align: center;
+  display: flex !important;
+  justify-content: center;
+  flex-direction: column;
+  font-size: 0.875rem;
+  border-radius: 4px;
+  background-color: $cadet-color-1;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  padding: 8px;
+}
+
+.grading-comment-selector-title {
+  margin-bottom: 12px;
+}
+
+.grading-comment-selector-item {
+  margin: 3px;
+  padding: 7px;
+  background-color: $cadet-color-2;
+  border: 1px solid $cadet-color-3;
+  width: 100%;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $cadet-color-3;
+  }
+}

--- a/src/styles/NavigationBar.module.scss
+++ b/src/styles/NavigationBar.module.scss
@@ -1,0 +1,7 @@
+@import '_global';
+
+.primary-navbar {
+  background: #141e30; /* fallback for old browsers */
+  background: -webkit-linear-gradient(to right, #141e30, #243b55); /* Chrome 10-25, Safari 5.1-6 */
+  background: linear-gradient(to right, $cadet-color-1, $cadet-color-2);
+}

--- a/src/styles/PixelbotConfig.module.scss
+++ b/src/styles/PixelbotConfig.module.scss
@@ -1,0 +1,83 @@
+.pixelbot-config {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 20px;
+
+  .description {
+    color: #5c7080;
+    margin-bottom: 24px;
+    line-height: 1.5;
+  }
+
+  .section {
+    margin-bottom: 28px;
+
+    .section-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+
+    .section-header-center {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-bottom: 8px;
+      position: relative;
+
+      .edit-icon {
+        position: absolute;
+        right: 0;
+      }
+    }
+
+    .section-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    .section-helper {
+      color: #5c7080;
+      font-size: 12px;
+    }
+
+    .edit-icon {
+      color: #a7b6c2;
+      cursor: pointer;
+      padding: 4px;
+      margin-top: 2px;
+      flex-shrink: 0;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: #5c7080;
+      }
+    }
+
+    .prompt-textarea {
+      height: 400px;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      resize: vertical;
+    }
+
+    .document-map-textarea {
+      height: 300px;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      background-color: #f5f8fa;
+      resize: vertical;
+    }
+
+    .action-buttons {
+      display: flex;
+      gap: 8px;
+      margin-top: 10px;
+    }
+  }
+}

--- a/src/styles/RagChatbot.module.scss
+++ b/src/styles/RagChatbot.module.scss
@@ -1,0 +1,289 @@
+.bot-container {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  max-width: 100vw;
+  max-height: 100vh;
+}
+
+.chat-container {
+  position: relative;
+  width: 400px;
+  height: 450px;
+  border-radius: 8px;
+  background-color: #f1f1f1;
+  padding: 16px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  transition:
+    width 0.2s ease,
+    height 0.2s ease;
+}
+
+.chat-container-expanded {
+  width: 700px;
+  height: 80vh;
+  max-height: 800px;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  flex-shrink: 0;
+}
+
+.feedback-link {
+  font-size: 11px;
+  color: #888;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #333;
+    text-decoration: underline;
+  }
+}
+
+.chat-header-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+}
+
+.expand-button {
+  min-width: 24px;
+  min-height: 24px;
+}
+
+.control-container {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  & > :first-child {
+    margin-top: 10px;
+  }
+}
+
+.bot-area {
+  position: relative;
+}
+
+.tips-box {
+  position: absolute;
+  padding-right: 10px;
+  bottom: 10px;
+  right: 65px;
+  width: 260px;
+  height: auto;
+  border: 1px solid black;
+  background-color: #f1f1f1;
+  border-radius: 5px;
+}
+
+.tips-message {
+  padding: 4px 8px;
+  margin: 0;
+  font-size: 13px;
+  text-align: right;
+  white-space: normal;
+  word-break: normal;
+}
+
+.bot-button {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  background-color: #e8e8e8;
+  border: none;
+  padding: 6px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  cursor: grab;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  -webkit-user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.pixel-avatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  pointer-events: none;
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+.chat-message {
+  flex: 1;
+  border: 1px solid #ddd;
+  overflow-y: scroll;
+  border-radius: 5px;
+  padding: 16px;
+  min-height: 0;
+}
+
+.user-input {
+  width: 100%;
+  font-size: 20px;
+  color: black;
+  background-color: white;
+  border: 1px solid black;
+  margin-bottom: 0px;
+  padding-left: 10px;
+}
+
+.user {
+  background-color: #a3a3a4;
+  color: #fff;
+  font-size: 15px;
+  text-align: left;
+  padding: 10px;
+  line-height: 1.5;
+  border-radius: 10px;
+  display: block;
+  margin-bottom: 5px;
+}
+
+.assistant {
+  background-color: #e1e1e1;
+  font-size: 15px;
+  color: #333;
+  text-align: left;
+  padding: 10px;
+  line-height: 1.5;
+  border-radius: 10px;
+  display: block;
+  margin-bottom: 10px;
+
+  p {
+    margin: 0 0 8px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  ul,
+  ol {
+    margin: 4px 0;
+    padding-left: 20px;
+  }
+
+  code {
+    background-color: rgba(0, 0, 0, 0.08);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+
+  pre {
+    margin: 8px 0;
+    border-radius: 6px;
+    overflow-x: auto;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: 8px 0;
+    font-size: 14px;
+
+    th,
+    td {
+      border: 1px solid #ccc;
+      padding: 4px 8px;
+    }
+
+    th {
+      background-color: rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  blockquote {
+    margin: 8px 0;
+    padding-left: 12px;
+    border-left: 3px solid #999;
+    color: #555;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin: 8px 0 4px;
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 1.3em;
+  }
+  h2 {
+    font-size: 1.15em;
+  }
+  h3 {
+    font-size: 1.05em;
+  }
+}
+
+.button-container {
+  height: 8%;
+  text-align: center;
+  margin-top: 0px;
+  padding: 0px;
+}
+
+.button-send {
+  width: 40%;
+  height: 100%;
+  background-color: gray;
+  font-size: 15px;
+  margin-right: 5%;
+  margin-top: 0%;
+  border: 1px;
+  border-radius: 10px;
+  vertical-align: top;
+}
+
+.button-clean {
+  width: 40%;
+  margin-top: 0%;
+  height: 100%;
+  margin-left: 5%;
+  background-color: gray;
+  font-size: 15px;
+  border: 1px;
+  border-radius: 10px;
+  vertical-align: top;
+}
+
+.input-count-container {
+  justify-content: flex-end;
+  display: flex;
+  align-items: center;
+  height: 20px;
+}
+
+.input-count {
+  font-size: 10px;
+  color: #666;
+  margin: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}

--- a/src/styles/Stories.module.scss
+++ b/src/styles/Stories.module.scss
@@ -1,0 +1,5 @@
+@import '_global';
+
+.highlight-row {
+  background-color: #e0f2fe;
+}

--- a/src/styles/TeamFormation.module.scss
+++ b/src/styles/TeamFormation.module.scss
@@ -1,0 +1,58 @@
+/* Form container */
+.form-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background-color: #ffffff;
+  margin-top: 20px;
+}
+
+/* Form fields */
+.form-field {
+  width: 300px;
+  margin-bottom: 20px;
+  margin-right: 80px;
+}
+
+.student-form-field {
+  margin-bottom: 25px;
+  width: 800px;
+}
+
+/* Input container */
+.input-container {
+  display: flex;
+  align-items: center;
+}
+
+/* Labels */
+.form-label {
+  font-size: 16px;
+  margin-bottom: 15px;
+}
+
+/* Select inputs */
+.form-select {
+  flex: 1; /* Take all available space */
+  width: 100%;
+  height: 36px;
+  border-radius: 4px;
+  font-size: 14px;
+  transition: height 0.3s; /* Add transition for smooth height change */
+}
+
+/* Form footer */
+.form-footer {
+  margin-top: 20px;
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-field-row {
+  display: flex;
+  align-items: center;
+  gap: 16px; /* Adjust the spacing as needed */
+}

--- a/src/styles/VersionHistoryPanel.module.scss
+++ b/src/styles/VersionHistoryPanel.module.scss
@@ -1,0 +1,179 @@
+.drawer {
+  .body {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .list {
+    width: 280px;
+    flex-shrink: 0;
+    overflow-y: auto;
+    border-right: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 4px 0;
+  }
+
+  .group {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .groupHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background-color 0.1s ease;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.06);
+    }
+
+    &.groupHeaderContainsSelected {
+      border-left: 3px solid #137cbd;
+      padding-left: 9px;
+    }
+  }
+
+  .groupHeaderInfo {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .groupLabel {
+    font-weight: 600;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .groupCount {
+    font-size: 11px;
+    opacity: 0.55;
+    margin-top: 2px;
+  }
+
+  .groupChevron {
+    font-size: 18px;
+    line-height: 1;
+    opacity: 0.6;
+    margin-left: 6px;
+    transform: rotate(0deg);
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+
+    &.groupChevronOpen {
+      transform: rotate(90deg);
+    }
+  }
+
+  .groupBody {
+    background-color: rgba(0, 0, 0, 0.15);
+  }
+
+  .item {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    transition: background-color 0.1s ease;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.06);
+    }
+
+    &.itemSelected {
+      background-color: rgba(255, 255, 255, 0.12);
+      border-left: 3px solid #137cbd;
+      padding-left: 9px;
+    }
+
+    &.itemNested {
+      padding-left: 20px;
+
+      &.itemSelected {
+        padding-left: 17px;
+      }
+    }
+  }
+
+  .itemInfo {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .itemName {
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+
+  .itemTimestamp {
+    font-size: 12px;
+    opacity: 0.6;
+  }
+
+  .preview {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .previewContent {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .previewHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+  }
+
+  .diffLabels {
+    display: flex;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .diffLabel {
+    flex: 1;
+    font-size: 12px;
+    font-weight: 600;
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: center;
+  }
+
+  .diffContainer {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+
+    :global(.ace-diff-container) {
+      position: absolute;
+      inset: 0;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,10 +3162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.9":
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.10":
   version: 0.0.9
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=425c4485ff8b0cea495332eadc0b650b0815225a"
-  checksum: 10c0/6405f860bf8ad41bc0206e6addabf3d9d556811ef533a053f4bcdcab3c188b7dd0962621f9c19e4e4785b8365709f675e1f3ec46de83a58f149ec040f54911b1
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=7a9b32d7fff0434172d8f065c3035a222c2dc391"
+  checksum: 10c0/08ce7e500ec20baeeb44c86843c26286d376a6d9d4fd7f9807b4543b61ec81d1ef85761356a62ec31aba31835a114292d7b4c5d572d20d67605b83bb0eb9fd3c
   languageName: node
   linkType: hard
 
@@ -7244,7 +7244,7 @@ __metadata:
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663"
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/conductor": "npm:^0.5.0"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"


### PR DESCRIPTION
## Problem

The § signs added by Martin Henz in language-directory#30 were not showing up in the frontend. The language-directory was tagged `0.0.9` _before_ that PR landed, so three commits were stranded on `main` with no released tag:

- `cda61b04` feat(stepper): register python1Stepper in Python 1
- `ee2701a9` **adding chapter sign (§) in front of Python and Source chapter numbers**
- `7a9b32d7` feat(python): add Python §1 and §2 Stepper evaluators

The root cause is a short-circuit in `LanguageDirectorySaga.ts`: when the feature flag URL equals the default (`source-academy.github.io/language-directory/directory.json`), the saga skips the network fetch and uses the locally-installed npm package directly. That package was pinned to `0.0.9` → no § signs.

## Fix

- Tagged `0.0.10` on language-directory `main` HEAD (`7a9b32d7`)
- Bumped `package.json` from `#0.0.9` → `#0.0.10`
- Re-ran `yarn install` to update `yarn.lock`

After this change the installed package exports `"Source §1"`, `"Python §1"`, etc.

## Test plan
- [ ] Language selector shows "Source §1" … "Source §4" and "Python §1" … "Python §4"