### PR TITLE
chore: bump language-directory to 0.0.10 (§ signs in chapter names)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663",
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/conductor": "^0.5.0",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2",
     "@sourceacademy/sharedb-ace": "2.1.1",
     "@sourceacademy/sling-client": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,10 +3162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.9":
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.10":
   version: 0.0.9
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=425c4485ff8b0cea495332eadc0b650b0815225a"
-  checksum: 10c0/6405f860bf8ad41bc0206e6addabf3d9d556811ef533a053f4bcdcab3c188b7dd0962621f9c19e4e4785b8365709f675e1f3ec46de83a58f149ec040f54911b1
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=7a9b32d7fff0434172d8f065c3035a222c2dc391"
+  checksum: 10c0/08ce7e500ec20baeeb44c86843c26286d376a6d9d4fd7f9807b4543b61ec81d1ef85761356a62ec31aba31835a114292d7b4c5d572d20d67605b83bb0eb9fd3c
   languageName: node
   linkType: hard
 
@@ -7244,7 +7244,7 @@ __metadata:
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#e669d9ed98753350a3c8433a92985227eb789663"
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/conductor": "npm:^0.5.0"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.9"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"


### PR DESCRIPTION
Fixes the § chapter signs (Martin Henz, language-directory#30) not appearing.

## Root cause

The language-directory was tagged `0.0.9` before PR#30 (§ signs) was merged. Main moved 3 commits ahead of the tag. `LanguageDirectorySaga` short-circuits to the locally installed package when the URL is the default — so the installed `0.0.9` package (no §) was always used instead of fetching from GitHub Pages.

## Fix

- Tagged `0.0.10` on language-directory `main` HEAD
- Bumped `package.json` from `#0.0.9` → `#0.0.10`
- Re-ran `yarn install` to update `yarn.lock`

Only 2 files changed.

## Test plan
- [ ] Go to `/features`, enable `conductor.enable`
- [ ] Nav bar language dropdown shows "Source §1"…"Source §4" and "Python §1"…"Python §4"