### PR TITLE
fix: use textbook cover image from language directory; fix language switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#5b8871b8852815184af291f2622788fbc1263911",
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/conductor": "^0.5.0",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.11",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3",
     "@sourceacademy/sharedb-ace": "2.1.1",
     "@sourceacademy/sling-client": "^0.1.0",

--- a/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.test.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import userEvent, { type UserEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SupportedLanguage } from '../../../commons/application/ApplicationTypes';
@@ -16,7 +17,9 @@ const createAppWithStore = () => {
   const store = createStore();
   const app = (
     <Provider store={store}>
-      <NavigationBarLangSelectButton />
+      <MemoryRouter>
+        <NavigationBarLangSelectButton />
+      </MemoryRouter>
     </Provider>
   );
   return { app, store };

--- a/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -1,6 +1,7 @@
 import { Position } from '@blueprintjs/core';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router';
 import { useFeature } from 'src/commons/featureFlags/useFeature';
 import SimpleDropdown from 'src/commons/SimpleDropdown';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
@@ -18,9 +19,12 @@ function useDirectoryOptions() {
 const NavigationBarLangSelectButton = () => {
   const [isOpen, setIsOpen] = useState(false);
   const selectedDirLanguageId = useTypedSelector(s => s.languageDirectory.selectedLanguageId);
+  const languageMap = useTypedSelector(s => s.languageDirectory.languageMap);
 
   const dispatch = useDispatch();
   const dirOptions = useDirectoryOptions();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const directoryEnabled = useFeature(flagConductorEnable);
   if (!directoryEnabled) {
@@ -30,6 +34,20 @@ const NavigationBarLangSelectButton = () => {
   const selectDirLanguage = (languageId: string) => {
     dispatch(LanguageDirectoryActions.setSelectedLanguage(languageId));
     setIsOpen(false);
+
+    const isInTextbook =
+      location.pathname.startsWith('/sicpjs') || location.pathname.startsWith('/sicppy');
+    if (isInTextbook) {
+      const newLang = languageMap[languageId];
+      if (newLang?.textbook) {
+        const newPath = newLang.textbook.url.endsWith('json_py/')
+          ? '/sicppy/index'
+          : '/sicpjs/index';
+        navigate(newPath);
+      } else {
+        navigate('/playground');
+      }
+    }
   };
 
   return (

--- a/src/commons/sagas/helpers/conductorEvaluatorCache.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.ts
@@ -101,7 +101,6 @@ async function loadWebPlugin(
   if (!hostPlugin) return;
   const url = await resolveWebPluginUrl(pluginId);
   if (!url) {
-    // eslint-disable-next-line no-console
     console.warn(
       `Conductor: no web resolution for plugin "${pluginId}" (is directory.plugin.url set?)`,
     );
@@ -113,7 +112,6 @@ async function loadWebPlugin(
     // surfaced to the UI while this conductor is the active one (see DeferredConductorTabService).
     await importAndRegisterWebPlugin(hostPlugin, url, tabService);
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.warn(`Conductor: failed to load web plugin "${pluginId}"`, error);
   }
 }

--- a/src/new_routes/sicpjs/[section].tsx
+++ b/src/new_routes/sicpjs/[section].tsx
@@ -2,6 +2,7 @@ import 'katex/dist/katex.min.css';
 
 import { Button } from '@blueprintjs/core';
 import { Link, useNavigate, useOutletContext, useParams } from 'react-router';
+import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { getNext, getPrev } from 'src/features/sicp/TableOfContentsHelper';
 
 import SicpIndexPage from '../../pages/sicp/subcomponents/sicpIndexPage/SicpIndexPage';
@@ -9,6 +10,9 @@ import SicpIndexPage from '../../pages/sicp/subcomponents/sicpIndexPage/SicpInde
 function SicpPage() {
   const { section } = useParams<{ section: string }>();
   const navigate = useNavigate();
+  const titleImageUrl = useTypedSelector(
+    s => s.languageDirectory.languageMap['source1']?.textbook?.titleImageUrl,
+  );
 
   const handleNavigation = (sect: string) => {
     navigate('/sicpjs/' + sect);
@@ -29,7 +33,7 @@ function SicpPage() {
   const { data } = useOutletContext<{ data: React.ReactNode }>();
 
   return section === 'index' ? (
-    <SicpIndexPage />
+    <SicpIndexPage titleImageUrl={titleImageUrl ?? undefined} />
   ) : (
     <div className="sicp-content">
       <Link id="begin" to="#begin" />

--- a/src/new_routes/sicppy/[section].tsx
+++ b/src/new_routes/sicppy/[section].tsx
@@ -2,23 +2,13 @@ import 'katex/dist/katex.min.css';
 
 import { Button, H2 } from '@blueprintjs/core';
 import { Link, useNavigate, useOutletContext, useParams } from 'react-router';
-import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { getNextPy, getPrevPy } from 'src/features/sicp/TableOfContentsHelperPy';
 
 import SicpPyToc from '../../pages/sicp/subcomponents/SicpPyToc';
 
 function SicpPyIndexPage() {
-  const titleImageUrl = useTypedSelector(
-    s => s.languageDirectory.languageMap['python1']?.textbook?.titleImageUrl,
-  );
-
   return (
     <div className="sicp-index-page">
-      {titleImageUrl && (
-        <div className="sicp-cover">
-          <img src={titleImageUrl} alt="SICPy" />
-        </div>
-      )}
       <div style={{ padding: '2rem 2rem 0' }}>
         <H2>Structure and Interpretation of Computer Programs</H2>
         <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>

--- a/src/new_routes/sicppy/[section].tsx
+++ b/src/new_routes/sicppy/[section].tsx
@@ -15,7 +15,9 @@ function SicpPyIndexPage() {
   return (
     <div className="sicp-index-page">
       <div className="sicp-cover">
-        {titleImageUrl && <img src={titleImageUrl} alt="SICPy" style={{ maxHeight: '400px', width: 'auto' }} />}
+        {titleImageUrl && (
+          <img src={titleImageUrl} alt="SICPy" style={{ maxHeight: '400px', width: 'auto' }} />
+        )}
         <div className="sicp-cover-text">
           <H2>Structure and Interpretation of Computer Programs</H2>
           <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>

--- a/src/new_routes/sicppy/[section].tsx
+++ b/src/new_routes/sicppy/[section].tsx
@@ -2,16 +2,24 @@ import 'katex/dist/katex.min.css';
 
 import { Button, H2 } from '@blueprintjs/core';
 import { Link, useNavigate, useOutletContext, useParams } from 'react-router';
+import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { getNextPy, getPrevPy } from 'src/features/sicp/TableOfContentsHelperPy';
 
 import SicpPyToc from '../../pages/sicp/subcomponents/SicpPyToc';
 
 function SicpPyIndexPage() {
+  const titleImageUrl = useTypedSelector(
+    s => s.languageDirectory.languageMap['python1']?.textbook?.titleImageUrl,
+  );
+
   return (
     <div className="sicp-index-page">
-      <div style={{ padding: '2rem 2rem 0' }}>
-        <H2>Structure and Interpretation of Computer Programs</H2>
-        <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>
+      <div className="sicp-cover">
+        {titleImageUrl && <img src={titleImageUrl} alt="SICPy" />}
+        <div className="sicp-cover-text">
+          <H2>Structure and Interpretation of Computer Programs</H2>
+          <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>
+        </div>
       </div>
       <H2 style={{ paddingLeft: '2rem' }}>Contents</H2>
       <SicpPyToc />

--- a/src/new_routes/sicppy/[section].tsx
+++ b/src/new_routes/sicppy/[section].tsx
@@ -15,7 +15,7 @@ function SicpPyIndexPage() {
   return (
     <div className="sicp-index-page">
       <div className="sicp-cover">
-        {titleImageUrl && <img src={titleImageUrl} alt="SICPy" />}
+        {titleImageUrl && <img src={titleImageUrl} alt="SICPy" style={{ maxHeight: '400px', width: 'auto' }} />}
         <div className="sicp-cover-text">
           <H2>Structure and Interpretation of Computer Programs</H2>
           <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>

--- a/src/new_routes/sicppy/[section].tsx
+++ b/src/new_routes/sicppy/[section].tsx
@@ -2,13 +2,23 @@ import 'katex/dist/katex.min.css';
 
 import { Button, H2 } from '@blueprintjs/core';
 import { Link, useNavigate, useOutletContext, useParams } from 'react-router';
+import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { getNextPy, getPrevPy } from 'src/features/sicp/TableOfContentsHelperPy';
 
 import SicpPyToc from '../../pages/sicp/subcomponents/SicpPyToc';
 
 function SicpPyIndexPage() {
+  const titleImageUrl = useTypedSelector(
+    s => s.languageDirectory.languageMap['python1']?.textbook?.titleImageUrl,
+  );
+
   return (
     <div className="sicp-index-page">
+      {titleImageUrl && (
+        <div className="sicp-cover">
+          <img src={titleImageUrl} alt="SICPy" />
+        </div>
+      )}
       <div style={{ padding: '2rem 2rem 0' }}>
         <H2>Structure and Interpretation of Computer Programs</H2>
         <p style={{ color: 'grey', marginTop: 0 }}>Python Edition</p>

--- a/src/pages/sicp/subcomponents/sicpIndexPage/SicpIndexPage.tsx
+++ b/src/pages/sicp/subcomponents/sicpIndexPage/SicpIndexPage.tsx
@@ -5,11 +5,17 @@ import SicpAuthors from './subcomponents/SicpAuthors';
 import SicpLicenses from './subcomponents/SicpLicenses';
 import SicpTitle from './subcomponents/SicpTitle';
 
-function SicpIndexPage() {
+type Props = {
+  titleImageUrl?: string;
+};
+
+function SicpIndexPage({
+  titleImageUrl = 'https://source-academy.github.io/sicp/sicpjs.png',
+}: Props) {
   return (
     <div className="sicp-index-page">
       <div className="sicp-cover">
-        <img src="https://source-academy.github.io/sicp/sicpjs.png" alt="SICP" />
+        <img src={titleImageUrl} alt="SICP" />
         <div className="sicp-cover-text">
           <SicpTitle />
           <SicpAuthors />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,10 +3222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.10":
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.11":
   version: 0.0.9
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=7a9b32d7fff0434172d8f065c3035a222c2dc391"
-  checksum: 10c0/08ce7e500ec20baeeb44c86843c26286d376a6d9d4fd7f9807b4543b61ec81d1ef85761356a62ec31aba31835a114292d7b4c5d572d20d67605b83bb0eb9fd3c
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=54fd0c7e006c142eca44d03a2b3562203420b20a"
+  checksum: 10c0/1329a5b8d68fba14cfa48c7812de68ecdc7cdaf0d6e241b9972207017b83bade79cd766a0fee3f1c40784968bbe954917887c122a014bbc3896e13992580f939
   languageName: node
   linkType: hard
 
@@ -7304,7 +7304,7 @@ __metadata:
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#5b8871b8852815184af291f2622788fbc1263911"
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/conductor": "npm:^0.5.0"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.10"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.11"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,11 +7305,7 @@ __metadata:
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/conductor": "npm:^0.5.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.11"
-<<<<<<< HEAD
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
-=======
-    "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2"
->>>>>>> 7162d50e (chore: bump @sourceacademy/language-directory to 0.0.11)
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"
     "@sourceacademy/web-cse-machine": "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,7 +7305,11 @@ __metadata:
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/conductor": "npm:^0.5.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.11"
+<<<<<<< HEAD
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
+=======
+    "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.2"
+>>>>>>> 7162d50e (chore: bump @sourceacademy/language-directory to 0.0.11)
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"
     "@sourceacademy/web-cse-machine": "npm:^1.0.0"


### PR DESCRIPTION
## Summary

- **Closes #4015** — `SicpIndexPage` now receives `titleImageUrl` from the language directory (via Redux state) instead of hardcoding `sicpjs.png`. The Python textbook index page (`SicpPyIndexPage`) likewise shows its cover image from the language directory.
- **Closes #4017** — Switching language while inside a textbook now navigates correctly: to the new language's textbook index if one exists, or to the playground if the new language has no textbook.
- Bumps `@sourceacademy/language-directory` to the commit that adds `titleImageUrl` (source-academy/language-directory#36); the package.json reference should be updated to the released version once that PR is merged.

## Test plan

- [ ] Open `/sicpjs/index` — SICP JS cover image renders from the language directory URL
- [ ] Open `/sicppy/index` — SICPy cover image renders
- [ ] While on `/sicpjs/...`, switch language to a Python variant — page redirects to `/sicppy/index`
- [ ] While on `/sicppy/...`, switch language to a Source variant — page redirects to `/sicpjs/index`
- [ ] While on `/sicpjs/...`, switch language to Scheme (no textbook) — page redirects to `/playground`
- [ ] Snapshot test still passes (`yarn test SicpIndexPage`)