### PR TITLE
Modules: Add Additional Require Provider Exports

### DIFF
--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -3,14 +3,19 @@ import * as bpcore from '@blueprintjs/core';
 import * as bpicons from '@blueprintjs/icons';
 import * as jsslang from 'js-slang';
 import * as jsslangDist from 'js-slang/dist';
+import * as jsslangErrors from 'js-slang/dist/errors/base';
+import * as rttcErrors from 'js-slang/dist/errors/rttcErrors';
+import * as jsslangOperators from 'js-slang/dist/utils/operators';
+import * as jsslangRttc from 'js-slang/dist/utils/rttc';
 import * as lodash from 'lodash-es';
 // We need it to inject modules into the context
 // eslint-disable-next-line no-restricted-imports
 import * as React from 'react';
 import { useCallback } from 'react';
-import JSXRuntime from 'react/jsx-runtime';
-import ace from 'react-ace';
-import ReactDOM from 'react-dom';
+import * as JSXRuntime from 'react/jsx-runtime';
+import * as ace from 'react-ace';
+import * as ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import { useDispatch } from 'react-redux';
 
 import { useTypedSelector } from '../utils/Hooks';
@@ -31,10 +36,15 @@ export const requireProvider = (x: string) => {
     'react/jsx-runtime': JSXRuntime,
     'react-ace': ace,
     'react-dom': ReactDOM,
+    'react-dom/client': ReactDOMClient,
     '@blueprintjs/core': bpcore,
     '@blueprintjs/icons': bpicons,
     'js-slang': jsslang,
     'js-slang/dist': jsslangDist,
+    'js-slang/dist/utils/operators': jsslangOperators,
+    'js-slang/dist/utils/rttc': jsslangRttc,
+    'js-slang/dist/errors/base': jsslangErrors,
+    'js-slang/dist/errors/rttcErrors': rttcErrors,
     lodash,
   };
 

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -12,9 +12,9 @@ import * as lodash from 'lodash-es';
 // eslint-disable-next-line no-restricted-imports
 import * as React from 'react';
 import { useCallback } from 'react';
-import * as JSXRuntime from 'react/jsx-runtime';
-import * as ace from 'react-ace';
-import * as ReactDOM from 'react-dom';
+import JSXRuntime from 'react/jsx-runtime';
+import ace from 'react-ace';
+import ReactDOM from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
 import { useDispatch } from 'react-redux';
 


### PR DESCRIPTION
### Description

Fixes #4043
Adds subpaths of `js-slang` used by the module tabs, as well as `react-dom/client`. The list of paths was verified against the `require`s of every tab, as listed below

```js
{
  '@blueprintjs/core': [
    'ArcadeTwod',      'ArcadeTwod',      'ArcadeTwod',
    'CopyGc',          'Csg',             'Csg',
    'Csg',             'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Curve',           'Curve',           'MarkSweep',
    'Nbody',           'Nbody',           'Nbody',
    'Nbody',           'Physics2D',       'Physics2D',
    'Physics2D',       'Physics2D',       'Pixnflix',
    'Repl',            'RobotSimulation', 'RobotSimulation',
    'RobotSimulation', 'Rune',            'Rune',
    'Rune',            'Rune',            'Rune',
    'Rune',            'Rune',            'Sound',
    'SoundMatrix',     'StereoSound',     'UnityAcademy',
    'UnityAcademy'
  ],
  'react/jsx-runtime': [
    'ArcadeTwod',      'ArcadeTwod',      'ArcadeTwod',
    'CopyGc',          'Csg',             'Csg',
    'Csg',             'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Game',            'MarkSweep',       'Nbody',
    'Nbody',           'Nbody',           'Nbody',
    'Painter',         'Painter',         'Physics2D',
    'Physics2D',       'Physics2D',       'Physics2D',
    'Physics2D',       'Pixnflix',        'Plotly',
    'Plotly',          'Repeat',          'Repl',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'Rune',            'Rune',            'Rune',
    'Rune',            'Rune',            'Rune',
    'Rune',            'Rune',            'Rune',
    'Sound',           'Sound',           'SoundMatrix',
    'StereoSound',     'StereoSound',     'Unittest',
    'UnityAcademy',    'UnityAcademy'
  ],
  react: [
    'ArcadeTwod',      'CopyGc',          'Csg',
    'Curve',           'Curve',           'Curve',
    'Curve',           'Curve',           'Curve',
    'Curve',           'MarkSweep',       'Nbody',
    'Nbody',           'Painter',         'Physics2D',
    'Physics2D',       'Physics2D',       'Pixnflix',
    'Plotly',          'Repl',            'RobotSimulation',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'RobotSimulation', 'RobotSimulation', 'RobotSimulation',
    'Rune',            'Rune',            'Rune',
    'Rune',            'Rune',            'Sound',
    'SoundMatrix',     'StereoSound',     'UnityAcademy',
    'UnityAcademy'
  ],
  'js-slang/dist/errors/rttcErrors': [ 'Csg', 'Curve', 'Rune', 'UnityAcademy' ],
  'js-slang/dist/errors/base': [ 'Csg', 'Curve', 'Rune', 'UnityAcademy' ],
  'js-slang/dist/utils/rttc': [ 'Csg', 'Curve', 'Rune' ],
  'js-slang/dist/utils/operators': [ 'Csg', 'Curve', 'Rune' ],
  'react-ace': [ 'Repl' ],
  '@blueprintjs/icons': [ 'UnityAcademy' ],
  'react-dom/client': [ 'UnityAcademy' ]
}
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Open the frontend without the Conductor enabled
2. Run
```js
import { show, heart } from 'rune';
show(heart)
```
as well as
```js
import {init_unity_academy_3d, instantiate, set_start, set_update, set_position, vector3, set_rotation_euler} from 'unity_academy';
init_unity_academy_3d(); // Correct, since this function is under the "Outside Lifecycle" category and it can be called outside lifecycle event functions.
const cube = instantiate("cube"); // Correct
function my_start(gameObject){ // A sample Start event function which will be binded to cube by my_start later.
    set_position(gameObject, vector3(1, 2, 3)); // Correct, since the call to set_position is inside a lifecycle event function
    something_else(gameObject);
}
function something_else(obj){
   set_rotation_euler(obj, vector3(0, 45, 45));  // Correct, since the function "set_rotation_euler" is intermediately called by the lifecycle event function "my_start" through "something_else"
}
set_start(cube, my_start); // Correct
```

### Checklist

- [x] I have tested this code
