### PR TITLE
Fix SICPy textbook URL typo (/sicppy -> /sicpy)

### DIFF
--- a/src/commons/navigationBar/NavigationBar.tsx
+++ b/src/commons/navigationBar/NavigationBar.tsx
@@ -94,7 +94,7 @@ function useSecondaryNavbarType() {
   const isAchievements = useMatch('/courses/:courseId/achievements/*');
   const isLeaderboard = useMatch('/courses/:courseId/leaderboard/*');
   const isSicp = useMatch('/sicpjs/:section?');
-  const isSicpPy = useMatch('/sicppy/:section?');
+  const isSicpPy = useMatch('/sicpy/:section?');
 
   const isHidden = isPlayground || isContributors || isAchievements || isLeaderboard;
 
@@ -148,7 +148,7 @@ function NavigationBar() {
     () =>
       selectedLanguage?.textbook
         ? {
-            to: selectedLanguage.textbook.url.endsWith('json_py/') ? '/sicppy' : '/sicpjs',
+            to: selectedLanguage.textbook.url.endsWith('json_py/') ? '/sicpy' : '/sicpjs',
             icon: IconNames.BOOK,
             text: selectedLanguage.textbook.name,
           }
@@ -244,7 +244,7 @@ function NavigationBar() {
     const topNavbarNavlinks = [
       '/playground',
       '/sicpjs',
-      '/sicppy',
+      '/sicpy',
       '/contributors',
       `/courses/${courseId}/achievements`,
       `/courses/${courseId}/leaderboard`,

--- a/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -36,12 +36,12 @@ const NavigationBarLangSelectButton = () => {
     setIsOpen(false);
 
     const isInTextbook =
-      location.pathname.startsWith('/sicpjs') || location.pathname.startsWith('/sicppy');
+      location.pathname.startsWith('/sicpjs') || location.pathname.startsWith('/sicpy');
     if (isInTextbook) {
       const newLang = languageMap[languageId];
       if (newLang?.textbook) {
         const newPath = newLang.textbook.url.endsWith('json_py/')
-          ? '/sicppy/index'
+          ? '/sicpy/index'
           : '/sicpjs/index';
         navigate(newPath);
       } else {

--- a/src/commons/navigationBar/subcomponents/SicpPyNavigationBar.tsx
+++ b/src/commons/navigationBar/subcomponents/SicpPyNavigationBar.tsx
@@ -24,7 +24,7 @@ function SicpPyNavigationBar() {
   const handleCloseToc = () => setIsTocOpen(false);
 
   const handleNavigation = (sect: string) => {
-    navigate('/sicppy/' + sect);
+    navigate('/sicpy/' + sect);
   };
 
   // Button to open table of contents

--- a/src/new_routes/sicpy/[section].tsx
+++ b/src/new_routes/sicpy/[section].tsx
@@ -35,7 +35,7 @@ function SicpPyPage() {
 
   const prev = getPrevPy(section ?? '');
   const next = getNextPy(section ?? '');
-  const handleNavigation = (sect: string) => navigate('/sicppy/' + sect);
+  const handleNavigation = (sect: string) => navigate('/sicpy/' + sect);
 
   const navigationButtons = (
     <div className="sicp-navigation-buttons">

--- a/src/new_routes/sicpy/_layout.tsx
+++ b/src/new_routes/sicpy/_layout.tsx
@@ -44,7 +44,7 @@ function SicpPyLayout() {
   useEffect(() => {
     if (!section) {
       const cached = readLocalStorage(SICPPY_CACHE_KEY, SICPPY_DEFAULT_SECTION);
-      navigate(`/sicppy/${cached}`, { replace: true });
+      navigate(`/sicpy/${cached}`, { replace: true });
       return;
     }
 

--- a/src/pages/sicp/subcomponents/SicpPyToc.tsx
+++ b/src/pages/sicp/subcomponents/SicpPyToc.tsx
@@ -28,7 +28,7 @@ function SicpPyToc({ handleCloseToc }: Props) {
   const handleNodeClicked = useCallback(
     (node: TreeNodeInfo) => {
       handleCloseToc?.();
-      navigate('/sicppy/' + String(node.nodeData));
+      navigate('/sicpy/' + String(node.nodeData));
     },
     [navigate, handleCloseToc],
   );

--- a/src/routes/routerConfig.ts
+++ b/src/routes/routerConfig.ts
@@ -24,9 +24,9 @@ const commonRoutes: RouteObject = {
       children: [{ path: ':section', lazy: () => import('../new_routes/sicpjs/[section]') }],
     },
     {
-      path: 'sicppy',
-      lazy: () => import('../new_routes/sicppy/_layout'),
-      children: [{ path: ':section', lazy: () => import('../new_routes/sicppy/[section]') }],
+      path: 'sicpy',
+      lazy: () => import('../new_routes/sicpy/_layout'),
+      children: [{ path: ':section', lazy: () => import('../new_routes/sicpy/[section]') }],
     },
   ],
 };


### PR DESCRIPTION
## Summary
- The SICPy textbook route was `/sicppy` (extra "p") instead of the intended `/sicpy`.
- Renamed the route folder and updated all internal `navigate()`/`useMatch()` references across the navbar and SICPy route components to use `/sicpy`.

Fixes #4054

## Test plan
- [x] `tsc -b --noEmit` passes with no errors
- [x] Manually verify `/sicpy` loads the SICPy textbook and the language switcher / nav links route correctly