### PR TITLE
fix(playground): reset side content tab to Introduction on language switch

### DIFF
--- a/src/pages/playground/Playground.test.tsx
+++ b/src/pages/playground/Playground.test.tsx
@@ -11,7 +11,10 @@ import {
   type OverallState,
 } from 'src/commons/application/ApplicationTypes';
 import type { Router } from 'src/commons/application/types/CommonsTypes';
+import { visitSideContent } from 'src/commons/sideContent/SideContentActions';
+import { SideContentType } from 'src/commons/sideContent/SideContentTypes';
 import { EditorBinding, WorkspaceSettingsContext } from 'src/commons/WorkspaceSettingsContext';
+import LanguageDirectoryActions from 'src/features/directory/LanguageDirectoryActions';
 import { createStore } from 'src/pages/createStore';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -87,6 +90,40 @@ describe('Playground tests', () => {
 
     expect(getSourceChapterFromStore(mockStore)).toBe(Chapter.SOURCE_2);
     expect(getEditorValueFromStore(mockStore)).toBe("display('hello!');");
+  });
+
+  test('switching the Conductor-selected language resets the side content tab to Introduction (#4061)', async () => {
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/playground'],
+      initialIndex: 0,
+    });
+    await renderTree(router);
+
+    await act(() => {
+      mockStore.dispatch(
+        LanguageDirectoryActions.setLanguages([
+          { id: 'python1', name: 'Python §1', evaluators: [] },
+          { id: 'python2', name: 'Python §2', evaluators: [] },
+        ]),
+      );
+      mockStore.dispatch(LanguageDirectoryActions.setSelectedLanguage('python1'));
+    });
+
+    // Land on some other tab (e.g. the Stepper tab, as in the reported bug).
+    await act(() => {
+      mockStore.dispatch(visitSideContent('stepper', SideContentType.introduction, 'playground'));
+    });
+    expect(mockStore.getState().sideContent.playground.selectedTab).toBe('stepper');
+
+    // Switch to Python §2. Previously this left the (now-defunct) Stepper tab active, which hung
+    // forever since it belonged to the Python §1 evaluator instance.
+    await act(() => {
+      mockStore.dispatch(LanguageDirectoryActions.setSelectedLanguage('python2'));
+    });
+
+    expect(mockStore.getState().sideContent.playground.selectedTab).toBe(
+      SideContentType.introduction,
+    );
   });
 
   describe('handleHash', () => {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -776,9 +776,8 @@ function Playground(props: PlaygroundProps) {
     if (!selectConductorEnable(state)) {
       return null;
     }
-    const lang = selectedLanguageId
-      ? state.languageDirectory.languageMap[selectedLanguageId]
-      : undefined;
+    const { selectedLanguageId: langId, languageMap } = state.languageDirectory;
+    const lang = langId ? languageMap[langId] : undefined;
     const evaluator = lang?.evaluators.find(e =>
       (e.capabilities as string[] | undefined)?.includes(STEPPER_EVALUATOR_CAPABILITY),
     );
@@ -788,9 +787,8 @@ function Playground(props: PlaygroundProps) {
     if (!selectConductorEnable(state)) {
       return null;
     }
-    const lang = selectedLanguageId
-      ? state.languageDirectory.languageMap[selectedLanguageId]
-      : undefined;
+    const { selectedLanguageId: langId, languageMap } = state.languageDirectory;
+    const lang = langId ? languageMap[langId] : undefined;
     const evaluator = lang?.evaluators.find(
       e => !(e.capabilities as string[] | undefined)?.includes(STEPPER_EVALUATOR_CAPABILITY),
     );

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { Chapter, Variant } from 'js-slang/dist/langs';
 import { isEqual } from 'lodash-es';
 import { decompressFromEncodedURIComponent } from 'lz-string';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
 import InterpreterActions from 'src/commons/application/actions/InterpreterActions';
@@ -768,6 +768,7 @@ function Playground(props: PlaygroundProps) {
   // Stepper tab wiring (conductor only). The Stepper tab is offered for any language that has a
   // stepper-capability evaluator; opening the tab selects that (dropdown-hidden) evaluator so a Run
   // produces steps, and leaving it restores the language's default evaluator. See the effect below.
+  const selectedLanguageId = useTypedSelector(state => state.languageDirectory.selectedLanguageId);
   const selectedEvaluatorId = useTypedSelector(
     state => state.languageDirectory.selectedEvaluatorId,
   );
@@ -775,8 +776,9 @@ function Playground(props: PlaygroundProps) {
     if (!selectConductorEnable(state)) {
       return null;
     }
-    const { selectedLanguageId, languageMap } = state.languageDirectory;
-    const lang = selectedLanguageId ? languageMap[selectedLanguageId] : undefined;
+    const lang = selectedLanguageId
+      ? state.languageDirectory.languageMap[selectedLanguageId]
+      : undefined;
     const evaluator = lang?.evaluators.find(e =>
       (e.capabilities as string[] | undefined)?.includes(STEPPER_EVALUATOR_CAPABILITY),
     );
@@ -786,8 +788,9 @@ function Playground(props: PlaygroundProps) {
     if (!selectConductorEnable(state)) {
       return null;
     }
-    const { selectedLanguageId, languageMap } = state.languageDirectory;
-    const lang = selectedLanguageId ? languageMap[selectedLanguageId] : undefined;
+    const lang = selectedLanguageId
+      ? state.languageDirectory.languageMap[selectedLanguageId]
+      : undefined;
     const evaluator = lang?.evaluators.find(
       e => !(e.capabilities as string[] | undefined)?.includes(STEPPER_EVALUATOR_CAPABILITY),
     );
@@ -802,16 +805,8 @@ function Playground(props: PlaygroundProps) {
       return;
     }
     const onStepperTab = selectedTab === CONDUCTOR_STEPPER_TAB_ID;
-    if (!stepperEvaluatorId) {
-      // This language offers no stepper; if we're stranded on the Stepper tab (e.g. after switching
-      // away from Python §1/§2), fall back to the Introduction tab.
-      if (onStepperTab) {
-        setSelectedTab(SideContentType.introduction);
-      }
-      return;
-    }
     if (onStepperTab) {
-      if (selectedEvaluatorId !== stepperEvaluatorId) {
+      if (stepperEvaluatorId && selectedEvaluatorId !== stepperEvaluatorId) {
         dispatch(LanguageDirectoryActions.setSelectedEvaluator(stepperEvaluatorId));
       }
     } else if (selectedEvaluatorId === stepperEvaluatorId && defaultEvaluatorId) {
@@ -823,9 +818,25 @@ function Playground(props: PlaygroundProps) {
     defaultEvaluatorId,
     selectedEvaluatorId,
     selectedTab,
-    setSelectedTab,
     dispatch,
   ]);
+
+  // Reset to the Introduction tab whenever the Conductor directory's selected language changes (e.g.
+  // Python §1 ⇌ §2). Not stepper-specific: any tab tied to the previous language — a plugin-provided
+  // one, or one only some languages offer, like the Stepper — may not exist or apply to the new one,
+  // so unconditionally falling back avoids stranding the user on a tab that no longer makes sense.
+  // (The legacy Source/full-JS/Java/C chapter-and-variant picker already does this: its `chapterSelect`
+  // saga dispatches `resetSideContent` whenever the chapter or variant actually changes.)
+  const previousSelectedLanguageIdRef = useRef(selectedLanguageId);
+  useEffect(() => {
+    // The directory auto-selects the first language on startup (see `LanguageDirectorySaga`); that
+    // transition away from "no language yet" is startup settling, not a user-initiated switch.
+    const previousSelectedLanguageId = previousSelectedLanguageIdRef.current;
+    previousSelectedLanguageIdRef.current = selectedLanguageId;
+    if (previousSelectedLanguageId !== null && previousSelectedLanguageId !== selectedLanguageId) {
+      setSelectedTab(SideContentType.introduction);
+    }
+  }, [selectedLanguageId, setSelectedTab]);
 
   const conductorWelcomeText = useTypedSelector(state => {
     if (!selectConductorEnable(state)) {


### PR DESCRIPTION
## Summary
- Fixes #4061 (Stepper tab loading forever after switching Python §1 ⇌ §2).
- Whenever the Conductor directory's selected language changes, the side content tab now unconditionally resets to Introduction, regardless of which tab was active.
- Not stepper-specific: a tab tied to the previous language (a plugin-provided one, or one only some languages offer, like the Stepper) has no guarantee of applying to the new language, so preserving it across a switch risks stranding the user on a tab that's no longer valid — exactly what happened in #4061.
- Replaces the previous, narrower fix in the Stepper-evaluator-sync effect (which only handled switching *away* from a stepper-capable language, missing the reported case of switching *between* two stepper-capable languages, e.g. Python §1 → §2).
- The legacy Source/full-JS/Java/C chapter+variant picker already resets the tab correctly today (its `chapterSelect` saga dispatches `resetSideContent` whenever the chapter or variant changes), so this change only needed to cover the Conductor language-directory picker, which had no equivalent.

## Test plan
- Added a regression test reproducing the exact repro steps from #4061: land on the Stepper tab under Python §1, switch to Python §2, assert the tab resets to Introduction. Verified it fails without the fix (`expected 'stepper' to be 'introduction'`) and passes with it.
- `tsc`, `eslint`, `prettier` clean.
- Full `Playground.test.tsx` suite (4 tests) and related suites (playground/sideContent/controlBar/directory/sagas, 87 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)