### PR TITLE
fix(conductor): stop conductor.enable from overriding directory URLs

### DIFF
--- a/src/features/conductor/flagConductorEnable.test.ts
+++ b/src/features/conductor/flagConductorEnable.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+import { flagConductorEnable } from './flagConductorEnable';
+
+describe('flagConductorEnable', () => {
+  test('enabling or disabling it has no side effect on other flags (e.g. the directory URLs)', () => {
+    // Regression test: this flag previously force-set directory.language.url/directory.plugin.url
+    // to local dev paths whenever enabled (and reset them whenever disabled) — a dev-only convenience
+    // that leaked into production. Toggling it must not modify any other flag.
+    expect(flagConductorEnable.onChange(true)).toBeUndefined();
+    expect(flagConductorEnable.onChange(false)).toBeUndefined();
+  });
+});

--- a/src/features/conductor/flagConductorEnable.ts
+++ b/src/features/conductor/flagConductorEnable.ts
@@ -1,39 +1,10 @@
-import { put } from 'redux-saga/effects';
-
-import { createFeatureFlag, FeatureFlagsActions } from '../../commons/featureFlags';
+import { createFeatureFlag } from '../../commons/featureFlags';
 import { featureSelector } from '../../commons/featureFlags/featureSelector';
-import { flagDirectoryLanguageUrl } from '../directory/flagDirectoryLanguageUrl';
-import { flagDirectoryPluginUrl } from '../directory/flagDirectoryPluginUrl';
-
-/** Local directory paths served by the frontend dev server / production build. */
-const LOCAL_LANGUAGE_DIR = '/languages/directory.json';
-const LOCAL_PLUGIN_DIR = '/plugins/directory.json';
 
 export const flagConductorEnable = createFeatureFlag(
   'conductor.enable',
   false,
   'Enables the Conductor framework for evaluation of user programs.',
-  function* (enabled: boolean) {
-    if (enabled) {
-      // Switch to the locally-served stepper evaluators and web plugin.
-      yield put(
-        FeatureFlagsActions.setFlag({
-          featureFlag: flagDirectoryLanguageUrl,
-          value: LOCAL_LANGUAGE_DIR,
-        }),
-      );
-      yield put(
-        FeatureFlagsActions.setFlag({
-          featureFlag: flagDirectoryPluginUrl,
-          value: LOCAL_PLUGIN_DIR,
-        }),
-      );
-    } else {
-      // Restore the production remote directories.
-      yield put(FeatureFlagsActions.resetFlag({ featureFlag: flagDirectoryLanguageUrl }));
-      yield put(FeatureFlagsActions.resetFlag({ featureFlag: flagDirectoryPluginUrl }));
-    }
-  },
 );
 
 export const selectConductorEnable = featureSelector(flagConductorEnable);


### PR DESCRIPTION
## Summary
- In Settings → Feature Flags, enabling `conductor.enable` was silently force-setting `directory.language.url` to `/languages/directory.json` and `directory.plugin.url` to `/plugins/directory.json`; disabling it reset both. This was a local-dev convenience (one click to point the directories at the frontend's own dev-served JSON) that leaked into production, where those paths don't serve anything meaningful.
- `flagConductorEnable`'s `createFeatureFlag` call took a 4th argument — a saga callback — that did this. Removed the callback entirely; the flag is now a plain boolean with no side effects on any other flag. Toggling it now only affects the Conductor framework itself, matching the intended behaviour.
- `directory.language.url`/`directory.plugin.url` already default to the correct production remote URLs on their own, so nothing else needed to change.

## Test plan
- Added a regression test asserting that enabling/disabling `conductor.enable` triggers no callback at all. Verified it fails against the old code (the callback ran and returned a generator, not `undefined`) and passes against the fix.
- `tsc`, `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)