### PR TITLE
fix(conductor): switch to Introduction tab on any error while CSE Machine tab is active

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -490,8 +490,9 @@ function* handleResults(
 
 /**
  * Surfaces a conductor evaluation error: appends it to the REPL and, when the (REPL-hiding) conductor
- * Stepper tab is active, switches to the Introduction tab so the error is visible rather than failing
- * silently — the conductor analogue of the legacy `usingSubst` path. Also unblocks the run loop.
+ * Stepper or CSE Machine tab is active, switches to the Introduction tab so the error is visible
+ * rather than failing silently — the conductor analogue of the legacy `usingSubst`/`usingCse` path.
+ * Also unblocks the run loop.
  */
 function* surfaceConductorError(
   error: unknown,
@@ -501,7 +502,7 @@ function* surfaceConductorError(
   const selectedTab: SideContentTabId | undefined = yield select(
     (state: OverallState) => state.sideContent[workspaceLocation]?.selectedTab,
   );
-  if (selectedTab === CONDUCTOR_STEPPER_TAB_ID) {
+  if (selectedTab === CONDUCTOR_STEPPER_TAB_ID || selectedTab === SideContentType.cseMachine) {
     yield put(visitSideContent(SideContentType.introduction, selectedTab, workspaceLocation));
   }
   // Unblock the run loop (the runner should also send a terminal status, but this is a safety net).


### PR DESCRIPTION
## Summary
- Today, if the CSE Machine tab is open (for a Conductor language) and Run is clicked on a program with an error, the tab is left stranded — the REPL is hidden while that tab is active, so the error has nowhere visible to surface.
- The Stepper tab already has this handled: `surfaceConductorError` in `evalCode.ts` switches to Introduction whenever an error occurs while the Stepper tab is active. This extends the same check to the CSE Machine tab (`SideContentType.cseMachine`), which hides the REPL the same way.
- `surfaceConductorError` is the single choke point for all three Conductor error paths — runtime errors delivered over the error channel, preprocessing/syntax errors delivered by rejection, and conductor setup failures — so this one change covers "any kind of error" for the CSE Machine tab, matching the existing Stepper behaviour.
- The legacy (non-Conductor) path already does this correctly for both `usingSubst` and `usingCse` (`evalCode.ts` lines ~344-349), so this was specifically a Conductor-side gap, same shape as the original Stepper fix.

## Test plan
- `tsc`, `eslint`, `prettier` clean.
- Existing `WorkspaceSaga.test.ts` suite (50 tests) passes unchanged.
- No new automated test added: `surfaceConductorError` is a private, unexported helper in a saga file with no existing test harness (mocking the conduit/host-plugin/CSE-plugin/event-channels from scratch would be a large, disproportionate lift for what is a one-line conditional mirroring an already-proven pattern in the same function).
- Manually traced all three call sites of `surfaceConductorError` to confirm each one exercises the new branch correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)