### PR TITLE
docs: add local backend setup and py-slang testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ Before pushing to Github, ensure that your code is formatted and your tests are 
 
 See [js-slang README](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) for instructions how to run your own js-slang in the frontend.
 
+## Running your own py-slang
+
+See [py-slang README](https://github.com/source-academy/py-slang#using-your-py-slang-in-your-local-source-academy) for instructions how to run your own py-slang in the frontend. Unlike js-slang, py-slang is loaded at runtime via a URL from the [Language Directory](https://github.com/source-academy/language-directory), rather than as a build-time npm dependency.
+
 ## TypeScript Coding Conventions
 
 We reference [this guide](https://github.com/piotrwitek/react-redux-typescript-guide).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See [js-slang README](https://github.com/source-academy/js-slang#using-your-js-s
 
 ## Running your own py-slang
 
-See [py-slang README](https://github.com/source-academy/py-slang#using-your-py-slang-in-your-local-source-academy) for instructions how to run your own py-slang in the frontend. Unlike js-slang, py-slang is loaded at runtime via a URL from the [Language Directory](https://github.com/source-academy/language-directory), rather than as a build-time npm dependency.
+See [py-slang README](https://github.com/source-academy/py-slang#using-your-py-slang-in-your-local-source-academy) for instructions on how to run your own py-slang in the frontend. Unlike js-slang, py-slang is loaded at runtime via a URL from the [Language Directory](https://github.com/source-academy/language-directory), rather than as a build-time npm dependency.
 
 ## TypeScript Coding Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before pushing to Github, ensure that your code is formatted and your tests are 
 
 ## Running your own js-slang
 
-See [js-slang README](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) for instructions how to run your own js-slang in the frontend.
+See [js-slang README](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) for instructions on how to run your own js-slang in the frontend.
 
 ## Running your own py-slang
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,52 @@ The project requires some environment variables to be set to work properly. In t
 1. `REACT_APP_SHAREDB_BACKEND_URL`: The base URL of the [ShareDB collaborative editor backend](https://github.com/source-academy/sharedb-ace-backend). The protocol must be HTTP or HTTPS (it will automatically be set to WS/WSS as appropriate). **Must end in a trailing `/`.**
 1. `REACT_APP_SICPJS_BACKEND_URL`: The base URL from which [SICP JS](https://github.com/source-academy/sicp) content is loaded.
 
+#### Running a local backend
+
+If `REACT_APP_USE_BACKEND` is `TRUE` and no backend is reachable at `REACT_APP_BACKEND_URL` (`http://localhost:4000` by default), the frontend shows a "Source Academy is under maintenance" page instead of logging in. To run a local [backend](https://github.com/source-academy/backend):
+
+1. Install [asdf](https://asdf-vm.com/) and add the Erlang and Elixir plugins:
+
+   ```bash
+   asdf plugin add erlang
+   asdf plugin add elixir
+   ```
+
+1. Clone the backend and install the toolchain versions pinned in its `.tool-versions`:
+
+   ```bash
+   git clone https://github.com/source-academy/backend.git
+   cd backend
+   asdf install
+   ```
+
+1. Start a local PostgreSQL instance (only needs to be done once; on subsequent runs use `docker start sa-backend-db` instead):
+
+   ```bash
+   docker run --name sa-backend-db -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -d postgres
+   ```
+
+1. Set up the development secrets and install dependencies:
+
+   ```bash
+   cp config/dev.secrets.exs.example config/dev.secrets.exs
+   mix deps.get
+   ```
+
+1. Initialise and seed the development database:
+
+   ```bash
+   mix ecto.setup
+   ```
+
+1. Run the server:
+
+   ```bash
+   mix phx.server
+   ```
+
+The backend is now reachable at `http://localhost:4000` (Swagger docs at `http://localhost:4000/swagger`), and the frontend's `.env.example` test OAuth providers (`test_admin`, `test_staff`, `test_student`) will log you in against the accounts seeded above. See the [backend's own README](https://github.com/source-academy/backend#developer-setup) for feature-specific setup (e.g. MQTT for Sling) beyond this base configuration.
+
 #### URL shortener configuration
 
 Unless you need to use the shortener locally, you can leave these values blank. Otherwise, ask your backend engineer.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If `REACT_APP_USE_BACKEND` is `TRUE` and no backend is reachable at `REACT_APP_B
    mix deps.get
    ```
 
-1. Initialise and seed the development database:
+1. Initialize and seed the development database:
 
    ```bash
    mix ecto.setup


### PR DESCRIPTION
## Summary
- The README's "Backend configuration" section explains what each `REACT_APP_*_BACKEND_URL` env var means, but never explains how to actually get a backend running locally — without one, the frontend just shows a "Source Academy is under maintenance" page. Adds a "Running a local backend" subsection with the full clone-to-running sequence (asdf toolchain, postgres via Docker, dev secrets, `mix ecto.setup`, `mix phx.server`).
  - Also corrects the Docker command copied from the backend repo's own README: it has a stray `-e` flag placed right before `-p 5432:5432`, which causes `-p` to be consumed as `-e`'s value instead of being parsed as its own flag — so the port never actually gets published if run verbatim.
- Adds a "Running your own py-slang" section to `CONTRIBUTING.md`, mirroring the existing "Running your own js-slang" section. Links out to py-slang's own README (source-academy/py-slang#199), which now documents the workflow, rather than duplicating it here — consistent with how the js-slang section is written.

(Originally two separate PRs — #4071 folded in here via cherry-pick so only one review is needed. #4071 is now closed.)

## Test plan
- [x] Docs-only change, verified against the backend's actual router/config/README and cross-checked against a working local backend setup.