### PR TITLE
docs: add "Running your own py-slang" section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ Before pushing to Github, ensure that your code is formatted and your tests are 
 
 See [js-slang README](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) for instructions how to run your own js-slang in the frontend.
 
+## Running your own py-slang
+
+See [py-slang README](https://github.com/source-academy/py-slang#using-your-py-slang-in-your-local-source-academy) for instructions how to run your own py-slang in the frontend. Unlike js-slang, py-slang is loaded at runtime via a URL from the [Language Directory](https://github.com/source-academy/language-directory), rather than as a build-time npm dependency.
+
 ## TypeScript Coding Conventions
 
 We reference [this guide](https://github.com/piotrwitek/react-redux-typescript-guide).


### PR DESCRIPTION
## Summary
- Mirrors the existing "Running your own js-slang" section in `CONTRIBUTING.md`.
- Links out to py-slang's own README, which now documents this workflow (companion PR: source-academy/py-slang#199) — consistent with how the js-slang section links out rather than duplicating instructions.
- Notes the one key difference contributors should know upfront: py-slang is loaded at runtime via a URL from the Language Directory, not as a build-time npm dependency like js-slang, so the local-testing mechanics differ.

## Test plan
- [x] Docs-only change.