### PR TITLE
Show a popup for input() requests instead of hanging (py-slang#190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#d476416170412c4726c7becc2a5c0018fb7cc4f7",
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/common-cse-machine": "^0.2.0",
-    "@sourceacademy/conductor": "^0.5.0",
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.6.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3",
     "@sourceacademy/sharedb-ace": "2.1.1",
@@ -196,7 +196,6 @@
   },
   "resolutions": {
     "@types/estree": "1.0.9",
-    "vite": "^8.0.0",
-    "@sourceacademy/conductor": "portal:/home/vakshay/conductor"
+    "vite": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
   },
   "resolutions": {
     "@types/estree": "1.0.9",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "@sourceacademy/conductor": "portal:/home/vakshay/conductor"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#d476416170412c4726c7becc2a5c0018fb7cc4f7",
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/common-cse-machine": "^0.2.0",
-    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.6.0",
+    "@sourceacademy/conductor": "^0.6.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3",
     "@sourceacademy/sharedb-ace": "2.1.1",

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -372,6 +372,7 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): Wo
   stepLimit: 1000,
   globals: [],
   isRunning: false,
+  isWaitingForInput: false,
   isDebugging: false,
   enableDebugging: true,
   debuggerContext: {} as DebuggerContext,

--- a/src/commons/application/actions/InterpreterActions.ts
+++ b/src/commons/application/actions/InterpreterActions.ts
@@ -45,6 +45,10 @@ const InterpreterActions = createActions('interpreter', {
     isRunning,
     workspaceLocation,
   }),
+  setIsWaitingForInput: (isWaitingForInput: boolean, workspaceLocation: WorkspaceLocation) => ({
+    isWaitingForInput,
+    workspaceLocation,
+  }),
   beginInterruptExecution: (workspaceLocation: WorkspaceLocation) => ({ workspaceLocation }),
   endInterruptExecution: (workspaceLocation: WorkspaceLocation) => ({ workspaceLocation }),
   beginDebuggerPause: (workspaceLocation: WorkspaceLocation) => ({ workspaceLocation }),

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -29,6 +29,7 @@ import { type OverallState } from '../../../application/ApplicationTypes';
 import { visitSideContent } from '../../../sideContent/SideContentActions';
 import { type SideContentTabId, SideContentType } from '../../../sideContent/SideContentTypes';
 import { actions } from '../../../utils/ActionsHelper';
+import { closeDialog, showSimplePromptDialog } from '../../../utils/DialogHelper';
 import DisplayBufferService from '../../../utils/DisplayBufferService';
 import { showWarningMessage } from '../../../utils/notifications/NotificationsHelper';
 import { makeExternalBuiltins as makeSourcerorExternalBuiltins } from '../../../utils/SourcerorHelper';
@@ -457,6 +458,49 @@ function* handleStdout(
   }
 }
 
+/**
+ * Listens for the runner requesting standard-input (e.g. Python's `input(...)`), shows a
+ * blocking popup asking the user for a string, and sends the answer back via `hostPlugin.sendInput`.
+ * Runs for the lifetime of the evaluation so a program may call `input()` any number of times.
+ */
+function* handleInputRequest(
+  hostPlugin: BrowserHostPlugin,
+  workspaceLocation: WorkspaceLocation,
+): SagaIterator {
+  const inputRequestChan = eventChannel<string>(emitter => {
+    hostPlugin.receiveInputRequest = emitter;
+    return () => {
+      if (hostPlugin.receiveInputRequest === emitter) {
+        delete hostPlugin.receiveInputRequest;
+      }
+    };
+  });
+  try {
+    while (true) {
+      const prompt: string = yield take(inputRequestChan);
+      yield put(actions.setIsWaitingForInput(true, workspaceLocation));
+      try {
+        const response: { buttonResponse: boolean; value: string } = yield call(
+          showSimplePromptDialog,
+          {
+            title: 'Program is requesting input',
+            contents: prompt || undefined,
+            positiveLabel: 'Submit',
+          },
+        );
+        hostPlugin.sendInput(response.buttonResponse ? response.value : '');
+      } finally {
+        yield put(actions.setIsWaitingForInput(false, workspaceLocation));
+      }
+    }
+  } finally {
+    if (yield cancelled()) {
+      inputRequestChan.close();
+      closeDialog();
+    }
+  }
+}
+
 function* handleResults(
   hostPlugin: BrowserHostPlugin,
   workspaceLocation: WorkspaceLocation,
@@ -650,6 +694,7 @@ export function* evalCodeConductorSaga(
 
   let conduit: IConduit | undefined;
   let stdoutTask: any;
+  let inputTask: any;
   let resultTask: any;
   let errorTask: any;
   let statusTask: any;
@@ -671,6 +716,7 @@ export function* evalCodeConductorSaga(
 
     // Begin evaluation
     stdoutTask = yield fork(handleStdout, hostPlugin, workspaceLocation);
+    inputTask = yield fork(handleInputRequest, hostPlugin, workspaceLocation);
     resultTask = yield fork(handleResults, hostPlugin, workspaceLocation);
     errorTask = yield fork(handleErrors, hostPlugin, workspaceLocation);
     statusTask = yield fork(handleStatuses, hostPlugin, workspaceLocation);
@@ -679,10 +725,35 @@ export function* evalCodeConductorSaga(
     yield call([hostPlugin, 'startEvaluator'], entrypointFilePath);
 
     // OneShot: wait for the runner to send STOPPED/ERROR (dispatched by handleStatuses),
-    // or for the user to manually interrupt execution.
+    // or for the user to manually interrupt execution. The watchdog below is suspended
+    // for as long as the program is waiting on an input() popup, so a user who takes a
+    // while to type an answer doesn't get their run killed out from under them.
     const { done } = yield race({
       done: take(actions.beginInterruptExecution.type),
-      timeout: call(() => new Promise(resolve => setTimeout(resolve, execTime + 10000))),
+      timeout: call(function* (): SagaIterator {
+        while (true) {
+          const { timedOut } = yield race({
+            timedOut: call(() => new Promise(resolve => setTimeout(resolve, execTime + 10000))),
+            waiting: take(
+              (a: any) =>
+                a.type === actions.setIsWaitingForInput.type &&
+                a.payload.workspaceLocation === workspaceLocation &&
+                a.payload.isWaitingForInput === true,
+            ),
+          });
+          if (timedOut) {
+            return;
+          }
+          // Waiting on the input() popup: suspend the watchdog entirely until it's answered,
+          // then restart a fresh execTime window.
+          yield take(
+            (a: any) =>
+              a.type === actions.setIsWaitingForInput.type &&
+              a.payload.workspaceLocation === workspaceLocation &&
+              a.payload.isWaitingForInput === false,
+          );
+        }
+      }),
     });
 
     // Drain pending result/error/output before teardown. Each conductor channel is its own
@@ -711,6 +782,9 @@ export function* evalCodeConductorSaga(
       }
       if (stdoutTask) {
         yield cancel(stdoutTask);
+      }
+      if (inputTask) {
+        yield cancel(inputTask);
       }
       if (resultTask) {
         yield cancel(resultTask);

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -489,6 +489,12 @@ function* handleInputRequest(
           },
         );
         hostPlugin.sendInput(response.buttonResponse ? response.value : '');
+      } catch {
+        // showSimplePromptDialog's underlying promise rejects if the dialog is dismissed via its
+        // onClose path (e.g. clicking outside) rather than a button response. Without this catch,
+        // that rejection would escape the while(true) loop and kill this saga permanently, leaving
+        // the runner blocked forever with no way to answer any future input() call either.
+        hostPlugin.sendInput('');
       } finally {
         yield put(actions.setIsWaitingForInput(false, workspaceLocation));
       }

--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -251,6 +251,10 @@ const newWorkspaceReducer = createReducer(defaultWorkspaceManager, builder => {
       const workspaceLocation = getWorkspaceLocation(action);
       state[workspaceLocation].isRunning = action.payload.isRunning;
     })
+    .addCase(InterpreterActions.setIsWaitingForInput, (state, action) => {
+      const workspaceLocation = getWorkspaceLocation(action);
+      state[workspaceLocation].isWaitingForInput = action.payload.isWaitingForInput;
+    })
     /**
      * Called to signal the end of an interruption,
      * i.e called after the interpreter is told to stop interruption,

--- a/src/commons/workspace/WorkspaceTypes.ts
+++ b/src/commons/workspace/WorkspaceTypes.ts
@@ -103,6 +103,7 @@ export type WorkspaceState = {
   readonly editorTestcases: Testcase[];
   readonly execTime: number;
   readonly isRunning: boolean;
+  readonly isWaitingForInput: boolean;
   readonly isDebugging: boolean;
   readonly enableDebugging: boolean;
   readonly isEditorReadonly: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,10 +3222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@https://github.com/source-academy/conductor.git#0.6.0":
+"@sourceacademy/conductor@npm:^0.6.0":
   version: 0.6.0
-  resolution: "@sourceacademy/conductor@https://github.com/source-academy/conductor.git#commit=e105c9cf1ee61a05bc1d3cab88078b5253451bd2"
-  checksum: 10c0/f45ec8600a30a0066b710b075a01bdde64b45d31bbb3908bbc98337252cb2c4f630c33383b759b5a7c143e1032e3403d4c6c4cd3009f4b431cc76d7e09ceecb0
+  resolution: "@sourceacademy/conductor@npm:0.6.0"
+  checksum: 10c0/51c38382854718c10594534e59746309dbd9c6ee919bdec87fc4f9d4c74bb6ac3fd3ad7a7b0a56911bda4ac12241c4231a09e48aa0f56080cdd8286abf78c0ba
   languageName: node
   linkType: hard
 
@@ -7297,7 +7297,7 @@ __metadata:
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#d476416170412c4726c7becc2a5c0018fb7cc4f7"
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/common-cse-machine": "npm:^0.2.0"
-    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.6.0"
+    "@sourceacademy/conductor": "npm:^0.6.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,10 +3222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@sourceacademy/conductor@npm:0.5.0"
-  checksum: 10c0/e87c54febc0c68498ba4ebb29de79028798fa2d3183e2f4b09ba8d7992f44f8a04600409fa08a7b2e07d38261e23ee300140e6c982181d0a549636c0a944813d
+"@sourceacademy/conductor@https://github.com/source-academy/conductor.git#0.6.0":
+  version: 0.6.0
+  resolution: "@sourceacademy/conductor@https://github.com/source-academy/conductor.git#commit=e105c9cf1ee61a05bc1d3cab88078b5253451bd2"
+  checksum: 10c0/f45ec8600a30a0066b710b075a01bdde64b45d31bbb3908bbc98337252cb2c4f630c33383b759b5a7c143e1032e3403d4c6c4cd3009f4b431cc76d7e09ceecb0
   languageName: node
   linkType: hard
 
@@ -7297,7 +7297,7 @@ __metadata:
     "@sourceacademy/autocomplete": "github:source-academy/autocomplete#d476416170412c4726c7becc2a5c0018fb7cc4f7"
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/common-cse-machine": "npm:^0.2.0"
-    "@sourceacademy/conductor": "npm:^0.5.0"
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor.git#0.6.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"


### PR DESCRIPTION
## Summary

Wires up Conductor's new `receiveInputRequest` hook (source-academy/conductor#40) so `input()` in Python programs shows a popup instead of hanging silently, on both the home tab and the viz CSE Machine tab.

- New `handleInputRequest` saga (`evalCode.ts`) listens for input requests from the runner, shows the existing `PromptDialog` popup (`showSimplePromptDialog`, already used elsewhere e.g. Google Drive save), and answers via `hostPlugin.sendInput`.
- The home tab and the viz CSE Machine tab share the same `evalCodeConductorSaga` run, so this single fix covers both surfaces from the issue — no separate viz-tab handling needed.
- New `isWaitingForInput` workspace state, used to suspend the `execTime`-based execution watchdog while a popup is open (previously that raced against a small fixed window and would have killed a run mid-prompt for anyone who took a few seconds to type an answer).
- Points `@sourceacademy/conductor` at the local checkout via a `portal:` resolution for now, since the protocol change it depends on isn't released yet.

## Depends on

- source-academy/conductor#40 (merge + release needed first — an npm publish, since this repo pins conductor via semver)
- source-academy/py-slang#254 (draft, same dependency, needs a bit more py-slang-side work to fully populate the prompt text shown in the popup)

Opening as **draft**: CI will fail on `yarn install` until conductor#40 is released and this branch's `portal:` pin is swapped for the real version — same situation as py-slang#254.

## Test plan
- [x] Full project `tsc --noEmit` passes clean
- [ ] Manual verification of the popup flow (submit/cancel/timeout-pause/interrupt) pending the conductor release and repin — not runnable against a `portal:`-only dependency in CI