### PR TITLE
Bump @sourceacademy/language-directory to 0.0.13 for the PVML evaluator

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/conductor": "^0.6.0",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.13",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3",
     "@sourceacademy/sharedb-ace": "2.1.1",
     "@sourceacademy/sling-client": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,10 +3933,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.12":
-  version: 0.0.9
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=e80b87a827f6b2ed098fd9ffc4d171aee9c70e61"
-  checksum: 10c0/70f79e59d3eb3f4e3bbecbb5858daa7ec8ff14f2e77e8340d86a0ef80ab2790adb1141b4e16c89aa9c10e4bcd6d58b605865148330e51f9b2bbb88d7679af0d1
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.13":
+  version: 0.0.13
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=21808f59da7dc04637758e2377d0fce2cbb1299a"
+  checksum: 10c0/f98c279b96254497ee3454eab8e664b2fd725e4a9ad728d1fbc60767bf490d22c692d0d1ad2e90c8cf18d0dc579d5f1ab819ab7766b573730f9e28b081cfe961
   languageName: node
   linkType: hard
 
@@ -8198,7 +8198,7 @@ __metadata:
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/conductor": "npm:^0.6.0"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.12"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.13"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"
     "@sourceacademy/sling-client": "npm:^0.1.0"


### PR DESCRIPTION
## Summary

- Bumps `@sourceacademy/language-directory` from tag `0.0.12` to `0.0.13` (commit `21808f5`).
- Unblocks the new **PVML** evaluator (source-academy/py-slang#236, source-academy/language-directory#39) from appearing in the Python §1–4 evaluator dropdown.

## Why this was needed

`LanguageDirectorySaga.ts` statically imports `languages` from `@sourceacademy/language-directory` rather than fetching `directory.json` at runtime, whenever the configured directory URL is the default GitHub Pages one:

```js
if (url === defaultUrl) {
  result = yield call(() => Promise.resolve(languages));   // bundled at build time
} else {
  const response = yield call(fetch, url);                  // dynamic fetch
  ...
}
```

So even though both upstream PRs were merged and deployed (py-slang's `PyPvmlEvaluator1..4` bundles are live on GitHub Pages, and language-directory's `main` has the new evaluator entries), frontend never picked them up — it was still pinned to `0.0.12`, which resolved to a commit two versions behind the PR that added them.

`0.0.13` is a fresh tag cut specifically for this (previous tag `0.0.12` had drifted — it pointed at an older commit than the one that actually bumped `package.json` to that version number, so it couldn't be reused without moving an already-published tag).

## Test plan
- [x] `yarn install` — resolves `@sourceacademy/language-directory` to commit `21808f5`
- [x] `tsc -b` — clean
- [x] `yarn build` — clean production build; confirmed `PyPvmlEvaluator1` (and 2/3/4) present in the bundled output
- [x] Pre-push hook (`tsc`, `eslint`, `format:ci`, `test`) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)