### PR TITLE
fix: encode Python language selection in share links

### DIFF
--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -1,7 +1,7 @@
 import { languages } from '@sourceacademy/language-directory';
 import type {
   IEvaluatorDefinition,
-  ILanguageDefinition
+  ILanguageDefinition,
 } from '@sourceacademy/language-directory/dist/types';
 import { getEvaluatorDefinition } from '@sourceacademy/language-directory/dist/util';
 import { call, fork, put, select } from 'redux-saga/effects';

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -1,5 +1,8 @@
 import { languages } from '@sourceacademy/language-directory';
-import type { ILanguageDefinition } from '@sourceacademy/language-directory/dist/types';
+import type {
+  IEvaluatorDefinition,
+  ILanguageDefinition
+} from '@sourceacademy/language-directory/dist/types';
 import { getEvaluatorDefinition } from '@sourceacademy/language-directory/dist/util';
 import { call, fork, put, select } from 'redux-saga/effects';
 import { selectConductorEnable } from 'src/features/conductor/flagConductorEnable';
@@ -97,16 +100,25 @@ const languageDirectoryHandlers = combineSagaHandlers({
       console.error('Failed to preload:', error);
     }
   },
-  [LanguageDirectoryActions.setSelectedLanguage.type]: function* () {
-    // Selecting a language defaults its evaluator to the first one. The actual conductor preload
-    // happens in the setSelectedEvaluator handler above (this dispatch triggers it), so switching
-    // evaluators afterwards re-preloads the correct one.
+  [LanguageDirectoryActions.setSelectedLanguage.type]: function* (
+    action: ReturnType<typeof LanguageDirectoryActions.setSelectedLanguage>,
+  ) {
+    // Selecting a language defaults its evaluator to the first one, unless a specific evaluator
+    // was requested (e.g. restoring a share link) and it's valid for this language. The actual
+    // conductor preload happens in the setSelectedEvaluator handler above (this dispatch triggers
+    // it), so switching evaluators afterwards re-preloads the correct one.
     const language = yield call(getLanguageDefinitionSaga);
     if (!language) {
       return;
     }
-    if (language.evaluators.length > 0) {
-      yield put(LanguageDirectoryActions.setSelectedEvaluator(language.evaluators[0].id));
+    const requestedEvaluatorId = action.payload.evaluatorId;
+    const evaluatorId = language.evaluators.some(
+      (e: IEvaluatorDefinition) => e.id === requestedEvaluatorId,
+    )
+      ? requestedEvaluatorId
+      : language.evaluators[0]?.id;
+    if (evaluatorId) {
+      yield put(LanguageDirectoryActions.setSelectedEvaluator(evaluatorId));
     }
   },
 });

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -131,8 +131,8 @@ function* updateQueryString() {
     isFolderModeEnabled,
   } = yield* selectWorkspace('playground');
 
-  const selectedLanguageId: string | null = yield select(
-    (state: OverallState) => state.languageDirectory.selectedLanguageId,
+  const { selectedLanguageId, selectedEvaluatorId } = yield select(
+    (state: OverallState) => state.languageDirectory,
   );
 
   const editorTabFilePaths = editorTabs
@@ -147,6 +147,7 @@ function* updateQueryString() {
     chap: chapter,
     variant,
     lang: selectedLanguageId ?? undefined,
+    evaluator: selectedEvaluatorId ?? undefined,
     ext: external,
     exec: execTime,
   });

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -131,6 +131,10 @@ function* updateQueryString() {
     isFolderModeEnabled,
   } = yield* selectWorkspace('playground');
 
+  const selectedLanguageId: string | null = yield select(
+    (state: OverallState) => state.languageDirectory.selectedLanguageId,
+  );
+
   const editorTabFilePaths = editorTabs
     .map(editorTab => editorTab.filePath)
     .filter((filePath): filePath is string => filePath !== undefined);
@@ -142,6 +146,7 @@ function* updateQueryString() {
     tabIdx: activeEditorTabIndex,
     chap: chapter,
     variant,
+    lang: selectedLanguageId ?? undefined,
     ext: external,
     exec: execTime,
   });

--- a/src/features/directory/LanguageDirectoryReducer.ts
+++ b/src/features/directory/LanguageDirectoryReducer.ts
@@ -15,6 +15,9 @@ export const LanguageDirectoryReducer: Reducer<LanguageDirectoryState, SourceAct
       })
       .addCase(Actions.setSelectedLanguage, (state, action) => {
         state.selectedLanguageId = action.payload.languageId;
+        if (action.payload.evaluatorId) {
+          state.selectedEvaluatorId = action.payload.evaluatorId;
+        }
       })
       .addCase(Actions.setSelectedEvaluator, (state, action) => {
         state.selectedEvaluatorId = action.payload.evaluatorId;

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -193,8 +193,8 @@ export async function handleHash(
       dispatch(playgroundConfigLanguage(languageConfig));
     } else if (qs.lang) {
       // Conductor-based languages (e.g. Python) aren't part of the js-slang Chapter
-      // enum, so they're shared via a separate `lang` param instead of `chap`.
-      dispatch(LanguageDirectoryActions.setSelectedLanguage(qs.lang));
+      // enum, so they're shared via separate `lang`/`evaluator` params instead of `chap`/`variant`.
+      dispatch(LanguageDirectoryActions.setSelectedLanguage(qs.lang, qs.evaluator));
     }
 
     const execTime = Math.max(convertParamToInt(qs.exec || '1000') || 1000, 1000);

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -191,6 +191,10 @@ export async function handleHash(
       // Hardcoded for Playground only for now, while we await workspace refactoring
       // to decouple the SicpWorkspace from the Playground.
       dispatch(playgroundConfigLanguage(languageConfig));
+    } else if (qs.lang) {
+      // Conductor-based languages (e.g. Python) aren't part of the js-slang Chapter
+      // enum, so they're shared via a separate `lang` param instead of `chap`.
+      dispatch(LanguageDirectoryActions.setSelectedLanguage(qs.lang));
     }
 
     const execTime = Math.max(convertParamToInt(qs.exec || '1000') || 1000, 1000);


### PR DESCRIPTION
## Summary
- Share links only encoded the js-slang `Chapter`/`Variant`, so a Conductor-based language selection (currently Python) was silently dropped when generating a share link.
- Adds a `lang` query param carrying `languageDirectory.selectedLanguageId` in `PlaygroundSaga.updateQueryString`, and restores it via `LanguageDirectoryActions.setSelectedLanguage` in `Playground.handleHash` when present.

Fixes #4144

## Test plan
- [x] `yarn tsc --noEmit` passes
- [ ] Manually verify: select Python in the playground, generate a share link, open it in a new tab, confirm Python is selected
- [ ] Manually verify: existing Source share links (chap/variant) still restore correctly
