### PR TITLE
fix: stop legacy chap param from shadowing Python share links

### DIFF
--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -43,9 +43,21 @@ export function* getEvaluatorDefinitionSaga() {
 const languageDirectoryHandlers = combineSagaHandlers({
   [LanguageDirectoryActions.setLanguages.type]: function* () {
     const directory = yield select((state: OverallState) => state.languageDirectory);
-    if (directory.languages.length > 0) {
-      yield put(LanguageDirectoryActions.setSelectedLanguage(directory.languages[0].id));
+    if (directory.languages.length === 0) {
+      return;
     }
+    // Something (e.g. a share link's handleHash) may have already requested a language
+    // before the directory finished loading; at that point languageMap was still empty, so
+    // the setSelectedLanguage handler below couldn't resolve it and bailed out early. Re-run
+    // that same selection now that the directory is populated, instead of unconditionally
+    // overwriting it with the first language.
+    const languageId = directory.selectedLanguageId ?? directory.languages[0].id;
+    yield put(
+      LanguageDirectoryActions.setSelectedLanguage(
+        languageId,
+        directory.selectedEvaluatorId ?? undefined,
+      ),
+    );
   },
   [LanguageDirectoryActions.fetchLanguages.type]: function* () {
     const url: string = yield select(selectDirectoryLanguageUrl);

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -3,6 +3,7 @@ import { Chapter } from 'js-slang/dist/langs';
 import { compressToEncodedURIComponent } from 'lz-string';
 import qs from 'query-string';
 import { call, delay, put, race, select } from 'redux-saga/effects';
+import { selectConductorEnable } from 'src/features/conductor/flagConductorEnable';
 import CseMachine from 'src/features/cseMachine/CseMachine';
 import { CseMachine as JavaCseMachine } from 'src/features/cseMachine/java/CseMachine';
 
@@ -131,6 +132,7 @@ function* updateQueryString() {
     isFolderModeEnabled,
   } = yield* selectWorkspace('playground');
 
+  const conductorEnabled: boolean = yield select(selectConductorEnable);
   const { selectedLanguageId, selectedEvaluatorId } = yield select(
     (state: OverallState) => state.languageDirectory,
   );
@@ -144,10 +146,13 @@ function* updateQueryString() {
     files: compressToEncodedURIComponent(qs.stringify(files)),
     tabs: editorTabFilePaths.map(compressToEncodedURIComponent),
     tabIdx: activeEditorTabIndex,
-    chap: chapter,
-    variant,
-    lang: selectedLanguageId ?? undefined,
-    evaluator: selectedEvaluatorId ?? undefined,
+    // Conductor-based languages (e.g. Python) and legacy js-slang chapters are mutually
+    // exclusive, so only one pair is ever meaningful. Encoding both unconditionally would
+    // make `chap` (which always has a real default value) win on decode and shadow `lang`.
+    chap: conductorEnabled ? undefined : chapter,
+    variant: conductorEnabled ? undefined : variant,
+    lang: conductorEnabled ? (selectedLanguageId ?? undefined) : undefined,
+    evaluator: conductorEnabled ? (selectedEvaluatorId ?? undefined) : undefined,
     ext: external,
     exec: execTime,
   });

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -6,6 +6,7 @@ import { call, delay, put, race, select } from 'redux-saga/effects';
 import { selectConductorEnable } from 'src/features/conductor/flagConductorEnable';
 import CseMachine from 'src/features/cseMachine/CseMachine';
 import { CseMachine as JavaCseMachine } from 'src/features/cseMachine/java/CseMachine';
+import { splitEvaluatorId, splitLanguageId } from 'src/features/directory/languageIdCodec';
 
 import PlaygroundActions from '../../features/playground/PlaygroundActions';
 import { isSourceLanguage, type OverallState } from '../application/ApplicationTypes';
@@ -137,6 +138,16 @@ function* updateQueryString() {
     (state: OverallState) => state.languageDirectory,
   );
 
+  // Decompose the compound directory ids (e.g. "python2" / "python2Pvml") into the three
+  // fields a share link exposes, instead of leaking the raw id-concatenation convention.
+  const { language: dirLanguage, variant: dirVariant } = selectedLanguageId
+    ? splitLanguageId(selectedLanguageId)
+    : { language: undefined, variant: undefined };
+  const dirEvaluator =
+    selectedLanguageId && selectedEvaluatorId
+      ? splitEvaluatorId(selectedLanguageId, selectedEvaluatorId)
+      : undefined;
+
   const editorTabFilePaths = editorTabs
     .map(editorTab => editorTab.filePath)
     .filter((filePath): filePath is string => filePath !== undefined);
@@ -147,12 +158,14 @@ function* updateQueryString() {
     tabs: editorTabFilePaths.map(compressToEncodedURIComponent),
     tabIdx: activeEditorTabIndex,
     // Conductor-based languages (e.g. Python) and legacy js-slang chapters are mutually
-    // exclusive, so only one pair is ever meaningful. Encoding both unconditionally would
-    // make `chap` (which always has a real default value) win on decode and shadow `lang`.
+    // exclusive, so only one set is ever meaningful. Encoding both unconditionally would
+    // make `chap` (which always has a real default value) win on decode and shadow `language`.
     chap: conductorEnabled ? undefined : chapter,
-    variant: conductorEnabled ? undefined : variant,
-    lang: conductorEnabled ? (selectedLanguageId ?? undefined) : undefined,
-    evaluator: conductorEnabled ? (selectedEvaluatorId ?? undefined) : undefined,
+    // `variant` doubles as the js-slang Variant enum (legacy chapters) or the directory
+    // language's chapter number (Conductor languages) — the two are mutually exclusive.
+    variant: conductorEnabled ? dirVariant : variant,
+    language: conductorEnabled ? dirLanguage : undefined,
+    evaluator: conductorEnabled ? dirEvaluator : undefined,
     ext: external,
     exec: execTime,
   });

--- a/src/features/directory/languageIdCodec.test.ts
+++ b/src/features/directory/languageIdCodec.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  joinEvaluatorId,
+  joinLanguageId,
+  splitEvaluatorId,
+  splitLanguageId,
+} from './languageIdCodec';
+
+describe('splitLanguageId', () => {
+  test('splits a chaptered language id into language and variant', () => {
+    expect(splitLanguageId('python2')).toEqual({ language: 'python', variant: '2' });
+    expect(splitLanguageId('source1')).toEqual({ language: 'source', variant: '1' });
+  });
+
+  test('leaves a non-chaptered language id as-is', () => {
+    expect(splitLanguageId('pythonFull')).toEqual({ language: 'pythonFull' });
+    expect(splitLanguageId('scheme')).toEqual({ language: 'scheme' });
+  });
+});
+
+describe('joinLanguageId', () => {
+  test('appends the variant when present', () => {
+    expect(joinLanguageId('python', '2')).toBe('python2');
+  });
+
+  test('returns the language unchanged when there is no variant', () => {
+    expect(joinLanguageId('pythonFull', undefined)).toBe('pythonFull');
+  });
+});
+
+describe('splitEvaluatorId', () => {
+  test('strips the language id prefix', () => {
+    expect(splitEvaluatorId('python2', 'python2Pvml')).toBe('Pvml');
+    expect(splitEvaluatorId('source1', 'source1Default')).toBe('Default');
+  });
+
+  test('returns undefined when the evaluator id does not belong to the language', () => {
+    expect(splitEvaluatorId('python2', 'python3Pvml')).toBeUndefined();
+  });
+});
+
+describe('joinEvaluatorId', () => {
+  test('prefixes the evaluator suffix with the language id', () => {
+    expect(joinEvaluatorId('python2', 'Pvml')).toBe('python2Pvml');
+  });
+});

--- a/src/features/directory/languageIdCodec.ts
+++ b/src/features/directory/languageIdCodec.ts
@@ -1,0 +1,28 @@
+// Language directory ids follow an unenforced but consistent convention (see
+// @sourceacademy/language-directory's directory.json): a language id is an optional trailing
+// chapter/variant number appended to a base name (e.g. "python2", "source1", "pythonFull" has
+// none), and an evaluator id is always its language id followed by a PascalCase suffix (e.g.
+// "python2Pvml"). Share links encode these as three separate fields (language/variant/evaluator)
+// instead of the raw compound ids, so this module is the single place that (de)composes them.
+
+const LANGUAGE_ID_VARIANT_PATTERN = /^(.+?)(\d+)$/;
+
+export function splitLanguageId(languageId: string): { language: string; variant?: string } {
+  const match = languageId.match(LANGUAGE_ID_VARIANT_PATTERN);
+  if (!match) {
+    return { language: languageId };
+  }
+  return { language: match[1], variant: match[2] };
+}
+
+export function joinLanguageId(language: string, variant?: string): string {
+  return variant ? `${language}${variant}` : language;
+}
+
+export function splitEvaluatorId(languageId: string, evaluatorId: string): string | undefined {
+  return evaluatorId.startsWith(languageId) ? evaluatorId.slice(languageId.length) : undefined;
+}
+
+export function joinEvaluatorId(languageId: string, evaluatorSuffix: string): string {
+  return `${languageId}${evaluatorSuffix}`;
+}

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -41,6 +41,7 @@ import {
 } from 'src/features/conductor/stepperTab';
 import CseMachine from 'src/features/cseMachine/CseMachine';
 import LanguageDirectoryActions from 'src/features/directory/LanguageDirectoryActions';
+import { joinEvaluatorId, joinLanguageId } from 'src/features/directory/languageIdCodec';
 import GithubActions from 'src/features/github/GitHubActions';
 import PersistenceActions from 'src/features/persistence/PersistenceActions';
 import {
@@ -191,10 +192,13 @@ export async function handleHash(
       // Hardcoded for Playground only for now, while we await workspace refactoring
       // to decouple the SicpWorkspace from the Playground.
       dispatch(playgroundConfigLanguage(languageConfig));
-    } else if (qs.lang) {
-      // Conductor-based languages (e.g. Python) aren't part of the js-slang Chapter
-      // enum, so they're shared via separate `lang`/`evaluator` params instead of `chap`/`variant`.
-      dispatch(LanguageDirectoryActions.setSelectedLanguage(qs.lang, qs.evaluator));
+    } else if (qs.language) {
+      // Conductor-based languages (e.g. Python) aren't part of the js-slang Chapter enum, so
+      // they're shared via separate `language`/`variant`/`evaluator` params instead of
+      // `chap`/`variant`. Reassemble the directory's compound ids from those three fields.
+      const languageId = joinLanguageId(qs.language, qs.variant);
+      const evaluatorId = qs.evaluator ? joinEvaluatorId(languageId, qs.evaluator) : undefined;
+      dispatch(LanguageDirectoryActions.setSelectedLanguage(languageId, evaluatorId));
     }
 
     const execTime = Math.max(convertParamToInt(qs.exec || '1000') || 1000, 1000);


### PR DESCRIPTION
## Summary
- Follow-up to #4152. That PR added `lang`/`evaluator` share-link params for Conductor-based languages (e.g. Python), but `handleHash` never actually reached that decode path: `playground.context.chapter` always holds a real js-slang `Chapter` value (defaults to Source 1) regardless of whether Conductor is active, so `chap` was always present and truthy in the URL, and the `if (chapter) {...} else if (qs.lang)` branch always took the legacy path.
- `updateQueryString` now only encodes `chap`/`variant` when Conductor is disabled, and only encodes `lang`/`evaluator` when it's enabled — the two are mutually exclusive, so this lets `handleHash` reach the correct branch on decode.

## Test plan
- [x] `yarn tsc --noEmit` passes
- [x] `yarn oxfmt --list-different` passes
- [ ] Manually verify: with `conductor.enable` on, select Python + a non-default evaluator (e.g. PVML), share, reopen in a new tab in the same browser — language and evaluator now correctly restore instead of defaulting
- [ ] Manually verify: regular Source chapter share links still restore chapter/variant correctly
