### PR TITLE
Fix conductor web plugin URLs resolving against the wrong origin

### DIFF
--- a/src/commons/sagas/helpers/conductorEvaluatorCache.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.ts
@@ -4,6 +4,7 @@ import { ModuleLoaderWebPlugin } from '@sourceacademy/web-module-loader';
 import type { SagaIterator } from 'redux-saga';
 import { call, select } from 'redux-saga/effects';
 import { selectDirectoryModulesUrl } from 'src/features/directory/flagDirectoryModulesUrl';
+import { selectDirectoryPluginUrl } from 'src/features/directory/flagDirectoryPluginUrl';
 
 import type { BrowserHostPlugin } from '../../../features/conductor/BrowserHostPlugin';
 import { createConductor } from '../../../features/conductor/createConductor';
@@ -98,7 +99,12 @@ async function resolveWebPluginUrl(
     const url =
       store.getState().pluginDirectory.pluginMap?.[pluginId]?.resolutions?.[PluginType.WEB];
     if (url) {
-      return url;
+      // Resolutions are relative to the plugin directory's own URL (e.g. "./web/stepper/index.mjs"
+      // relative to .../plugins/directory.json), not to wherever this bundle happens to be served
+      // from. A bare relative string handed to import() resolves against the importing module's own
+      // URL instead, silently 404ing (or worse, resolving to an unrelated same-origin path) - resolve
+      // it against the directory's URL explicitly so import() always gets an absolute URL.
+      return new URL(url, selectDirectoryPluginUrl(store.getState())).href;
     }
     const moduleUrl = moduleLoaderPlugin.getModuleTabLocation(pluginId);
     if (moduleUrl) {


### PR DESCRIPTION
## Summary
The Python (and Source) Stepper side-content tab is stuck on "Loading the stepper…" in production, even after #59 in `source-academy/plugins` fixed the plugin directory's `.js`→`.mjs` mismatch.

The real bug is in `resolveWebPluginUrl()` (`src/commons/sagas/helpers/conductorEvaluatorCache.ts`): it returns the plugin directory's `resolutions.web` string as-is — e.g. `"./web/stepper/index.mjs"`, which is relative to where `directory.json` itself lives (`https://source-academy.github.io/plugins/`). That string is handed straight to a dynamic `import()` in `importAndRegisterWebPlugin`. A relative specifier passed to `import()` resolves against the **importing module's own URL**, not against wherever the string logically "came from" — so in production this resolves to a nonsensical same-origin path like `https://sourceacademy.org/static/js/web/stepper/index.mjs`, which just serves the SPA's `index.html` for any unmatched route. The dynamic import then fails with a MIME-type error, `StepperHostPlugin` never constructs, and the placeholder tab never gets replaced.

This explains why the plugins-repo fix (#59) didn't actually resolve the user-visible bug — that fix was necessary (the directory data was wrong) but not sufficient, since the frontend never even reaches `source-academy.github.io` for this fetch.

## Fix
Resolve the plugin's URL against the plugin directory's own address (`directory.plugin.url`) via `new URL(url, directoryUrl)` before returning it from `resolveWebPluginUrl()`, so `import()` always receives an absolute URL. (`new URL()` is a no-op passthrough if the resolution is already absolute, so this is safe for any future plugin that lists a fully-qualified URL too.)

## How this was found
Reproduced against the *live production* plugin directory and evaluators using a local dev server + Playwright: with `conductor.enable` toggled on, selecting Python and opening the Stepper tab showed the runner correctly loading `PyStepperEvaluator1.js`, but the web-plugin `import()` went to `sourceacademy.org/static/js/web/stepper/index.mjs` (served `index.html`, MIME-type error, "Conductor: failed to load web plugin \"stepper\""). After the fix, the same flow requests `source-academy.github.io/plugins/web/stepper/index.mjs` (200) and the Stepper tab renders real content end to end.

## Test plan
- [x] `npx tsc -b` — clean
- [x] `npx eslint src/commons/sagas/helpers/conductorEvaluatorCache.ts` — clean
- [x] `TZ=Asia/Singapore npx vitest run` — 678 passed, 0 failed
- [x] Manual end-to-end verification via local dev server against production plugin directory/evaluators (see above) — confirmed broken before the fix, working after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtafwFAYacm4Xyjgnq5yE2