### PR TITLE
Bump conductor to 0.8.0 and await plugin loading in BrowserHostPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@sourceacademy/c-slang": "^1.0.21",
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-tabs": "^0.0.1",
-    "@sourceacademy/conductor": "^0.7.1",
+    "@sourceacademy/conductor": "^0.8.0",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.16",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3",
     "@sourceacademy/sharedb-ace": "2.1.1",

--- a/src/commons/sagas/helpers/conductorEvaluatorCache.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.ts
@@ -150,9 +150,8 @@ async function createPreparedConductor(path: string): Promise<PreparedConductor>
   const { hostPlugin, csePlugin, conduit, moduleLoaderPlugin } = createConductor(
     evaluatorUrl,
     async (fileName: string) => currentFiles[fileName],
-    (pluginName: string) => {
-      void loadWebPlugin(hostPluginRef, pluginName, tabService, moduleLoaderPlugin);
-    },
+    (pluginName: string) =>
+      loadWebPlugin(hostPluginRef, pluginName, tabService, moduleLoaderPlugin),
   );
   hostPluginRef = hostPlugin;
 

--- a/src/features/conductor/BrowserHostPlugin.ts
+++ b/src/features/conductor/BrowserHostPlugin.ts
@@ -5,8 +5,8 @@ export class BrowserHostPlugin extends BasicHostPlugin {
   requestFile(fileName: string): Promise<string | undefined> {
     return this.__onRequestFile(fileName);
   }
-  requestLoadPlugin(pluginName: string): void {
-    return this.__onRequestLoadPlugin(pluginName);
+  async requestLoadPlugin(pluginName: string): Promise<void> {
+    await this.__onRequestLoadPlugin(pluginName);
   }
   queryPluginResolutions(pluginId: string): Record<string, string> {
     // Fallback identity resolution; host can still load explicit plugin URLs/IDs.
@@ -15,13 +15,13 @@ export class BrowserHostPlugin extends BasicHostPlugin {
   receiveResult?(result: any): void;
 
   private __onRequestFile: (fileName: string) => Promise<string | undefined>;
-  private __onRequestLoadPlugin: (pluginName: string) => void;
+  private __onRequestLoadPlugin: (pluginName: string) => Promise<void>;
 
   constructor(
     conduit: IConduit,
     channels: IChannel<any>[],
     onRequestFile: (fileName: string) => Promise<string | undefined>,
-    onRequestLoadPlugin: (pluginName: string) => void,
+    onRequestLoadPlugin: (pluginName: string) => Promise<void>,
   ) {
     super(conduit, channels);
     this.__onRequestFile = onRequestFile;

--- a/src/features/conductor/createConductor.ts
+++ b/src/features/conductor/createConductor.ts
@@ -9,7 +9,7 @@ import { CseMachineHostPlugin } from './CseMachineHostPlugin';
 export function createConductor(
   evaluatorPath: string,
   onRequestFile: (fileName: string) => Promise<string | undefined>,
-  onRequestLoadPlugin: (pluginName: string) => void,
+  onRequestLoadPlugin: (pluginName: string) => Promise<void>,
 ): {
   hostPlugin: BrowserHostPlugin;
   csePlugin: CseMachineHostPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4260,10 +4260,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@sourceacademy/conductor@npm:0.7.1"
-  checksum: 10c0/293cdd2552eeb6cebd795806d841ef4118eb9aeedbfb1e3000c38032b55466269da31b524e37d58d52a068b96522766642ccc7838a4fbc23c9b244fd04cb44da
+"@sourceacademy/conductor@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@sourceacademy/conductor@npm:0.8.0"
+  checksum: 10c0/8b970b1f5fffbcb5242f5c358fb25af8d916cb5af9ca7fa9e0128928fde1783ed65465241858a82002bd8b5f21f5f5b80d3ea57bbd05faed604e6dd1c36600e9
   languageName: node
   linkType: hard
 
@@ -8580,7 +8580,7 @@ __metadata:
     "@sourceacademy/c-slang": "npm:^1.0.21"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-tabs": "npm:^0.0.1"
-    "@sourceacademy/conductor": "npm:^0.7.1"
+    "@sourceacademy/conductor": "npm:^0.8.0"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.16"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.3"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"


### PR DESCRIPTION
## Summary
- Bumps `@sourceacademy/conductor` from `^0.7.1` to `^0.8.0`.
- [conductor#53](https://github.com/source-academy/conductor/pull/53) makes `hostLoadPlugin`/`requestLoadPlugin` async (`Promise<void>` instead of `void`) and renames the RPC procedure from the notification `$requestLoadPlugin` to the awaitable `requestLoadPlugin` — this repo's `BrowserHostPlugin` is the actual `IHostPlugin` implementation, so it's the one place that must change for anything depending on conductor to compile.
- `BrowserHostPlugin.requestLoadPlugin` is now `async`/`Promise<void>`, and the `onRequestLoadPlugin` callback type threads through `createConductor.ts` down to `conductorEvaluatorCache.ts`.
- `conductorEvaluatorCache.ts`'s `loadWebPlugin` callback previously used `void loadWebPlugin(...)` to sidestep the old synchronous signature, even though `loadWebPlugin` is itself already async (resolves the plugin URL, then `import()`s it). This is the actual point of conductor#53: large tab bundles (plotly, etc.) now properly block the runner via `hostLoadPlugin`'s `await` instead of racing it.

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn eslint` clean on touched files
- [x] Targeted suites (`src/features/conductor`, `src/features/cseMachine`, `Playground.test.tsx`) — 5 files / 35 tests pass
- [x] Full pre-push hook (tsc, lint, format, full test suite) passes

Draft — not merging yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)