### PR TITLE
Stop drops queued Conductor output instead of rendering the whole backlog

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -458,7 +458,20 @@ function* handleStdout(
   });
   try {
     while (true) {
-      const output = yield take(outputChan);
+      const { output, interrupted } = yield race({
+        output: take(outputChan),
+        interrupted: take(actions.beginInterruptExecution.type),
+      });
+      if (interrupted) {
+        // Stop is a hard Worker.terminate(), not a cooperative signal the runner checks - so a
+        // fast-but-large output burst (e.g. a module's per-sample loop calling print() tens of
+        // thousands of times) can already be fully buffered and about to flood this channel by
+        // the time Stop is clicked. Once interrupted, stop rendering: the runner is already gone,
+        // so draining and dispatching every remaining queued message would just make the REPL
+        // look like the program kept running long after Stop was pressed.
+        outputChan.close();
+        break;
+      }
       receivedCount.count++;
       yield put(actions.handleConsoleLog(workspaceLocation, output));
     }


### PR DESCRIPTION
## Summary
- Fixes the appearance that Stop can't interrupt long, print-heavy Conductor runs (see [source-academy/py-slang#355](https://github.com/source-academy/py-slang/issues/355)).
- Stop already hard-terminates the runner Worker (`Conduit.terminate()`), but `handleStdout` kept unconditionally draining and dispatching every already-queued output message to the REPL. A fast, print-heavy loop (e.g. a module's per-sample loop calling a student closure tens of thousands of times) can finish and flood the output channel before Stop is even clicked, so pressing Stop looked like a no-op while the REPL kept "printing" - in reality there was no runner left, just a large backlog still being rendered.
- `handleStdout` now races the next output message against `beginInterruptExecution` and stops draining the channel the moment Stop fires, instead of rendering out the rest of the backlog.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn eslint src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts`
- [x] Manually reproduced the linked issue's repro (`sound` module `play_wave` with a printing wave function) in the Playground (Py2JS evaluator) and confirmed Stop now immediately truncates the output flood instead of continuing to render it.