### PR TITLE
Allow deployments to pin the Conductor feature flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,12 @@ REACT_APP_CA_FULFILLMENT_LEVEL=24
 
 # Feature flags
 REACT_APP_FEATURE_ENABLE_SICP_CHATBOT=FALSE
+
+# Conductor / language directory
+# Set REACT_APP_CONDUCTOR_ENABLE to TRUE or FALSE to pin conductor.enable for every user; leave it
+# blank to let users control it from the Feature Flags page. The directory URLs below are only
+# applied while it is TRUE, and default to the public directories when left blank.
+REACT_APP_CONDUCTOR_ENABLE=
+# REACT_APP_LANGUAGE_DIRECTORY_URL=https://source-academy.github.io/language-directory/directory.json
+# REACT_APP_PLUGIN_DIRECTORY_URL=https://source-academy.github.io/plugins/directory.json
+# REACT_APP_MODULES_DIRECTORY_URL=https://source-academy.github.io/modules-conductor/modules.json

--- a/README.md
+++ b/README.md
@@ -47,13 +47,20 @@ the Python edition of Source Academy, the Conductor feature flag (`conductor.ena
 enabled. It is on by default; if it has been turned off, click on the top right down-arrow
 button, then Settings, then Feature Flags, and toggle `conductor.enable` back to `true`.
 
+The directories Conductor loads from also default to the public ones, and are editable on the same feature flags page:
+
 ```
 directory.language.url
 https://source-academy.github.io/language-directory/directory.json
 
 directory.plugin.url
-https://source-academy.github.io/plugin-directory/directory.json
+https://source-academy.github.io/plugins/directory.json
+
+directory.modules.url
+https://source-academy.github.io/modules-conductor/modules.json
 ```
+
+A deployment can pin these instead of leaving them to each user's browser. Set `REACT_APP_CONDUCTOR_ENABLE` to `TRUE` or `FALSE` in `.env` to fix `conductor.enable` for everyone; while it is `TRUE`, the three `REACT_APP_*_DIRECTORY_URL` variables likewise pin the directory URLs. Pinned flags are shown read-only on the Feature Flags page, and take precedence over anything a user has previously set there.
 
 ### Installation of [Source Academy @ NUS](https://sourceacademy.nus.edu.sg)
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ If you wish to set up the GitHub or Google Drive integrations, copy the `.env.ex
 
 ### Python
 
-To work with
-the Python edition of Source Academy, the Conductor feature flag (`conductor.enable`) must be
+To work with the Python edition of Source Academy, the Conductor feature flag (`conductor.enable`) must be
 enabled. It is on by default; if it has been turned off, click on the top right down-arrow
-button, then Settings, then Feature Flags, and toggle `conductor.enable` back to `true`.
+button, then Settings, then Feature Flags, and toggle `conductor.enable` back to `true`. If your
+deployment pins the flag (see below), it is read-only there and can only be changed in `.env`.
 
 The directories Conductor loads from also default to the public ones, and are editable on the same feature flags page:
 

--- a/src/commons/featureFlags/FeatureFlag.ts
+++ b/src/commons/featureFlags/FeatureFlag.ts
@@ -4,6 +4,8 @@ export class FeatureFlag<T> {
   private readonly _flagName: string;
   private readonly _defaultValue: T;
   private readonly _flagDesc?: string;
+  /** Value pinned by the deployment's build-time configuration, overriding any user setting. */
+  private readonly _lockedValue?: T;
   private readonly _callback?: (newValue: any) => SagaIterator; // using any as the action wipes out type-param
 
   get flagName(): string {
@@ -15,6 +17,12 @@ export class FeatureFlag<T> {
   get flagDesc(): string | undefined {
     return this._flagDesc;
   }
+  get lockedValue(): T | undefined {
+    return this._lockedValue;
+  }
+  get isLocked(): boolean {
+    return this._lockedValue !== undefined;
+  }
   onChange(newValue: T) {
     return this._callback?.(newValue);
   }
@@ -23,11 +31,13 @@ export class FeatureFlag<T> {
     flagName: string,
     defaultValue: T,
     flagDesc?: string,
+    lockedValue?: T,
     callback?: (newValue: T) => SagaIterator,
   ) {
     this._flagName = flagName;
     this._defaultValue = defaultValue;
     this._flagDesc = flagDesc;
+    this._lockedValue = lockedValue;
     this._callback = callback;
   }
 }

--- a/src/commons/featureFlags/featureSelector.test.ts
+++ b/src/commons/featureFlags/featureSelector.test.ts
@@ -20,4 +20,12 @@ describe('featureSelector', () => {
     expect(featureSelector(createFeatureFlag('number', 1))(makeState({ number: 0 }))).toBe(0);
     expect(featureSelector(createFeatureFlag('text', 'default'))(makeState({ text: '' }))).toBe('');
   });
+
+  test('a locked value wins over both a user override and the default', () => {
+    const flag = createFeatureFlag('locked', true, undefined, false);
+    const selectFlag = featureSelector(flag);
+
+    expect(selectFlag(makeState({ locked: true }))).toBe(false);
+    expect(selectFlag(makeState({}))).toBe(false);
+  });
 });

--- a/src/commons/featureFlags/featureSelector.ts
+++ b/src/commons/featureFlags/featureSelector.ts
@@ -3,5 +3,7 @@ import { FeatureFlag } from './FeatureFlag';
 
 export function featureSelector<T>(featureFlag: FeatureFlag<T>) {
   return (state: OverallState) =>
-    (state.featureFlags.modifiedFlags[featureFlag.flagName] ?? featureFlag.defaultValue) as T;
+    (featureFlag.lockedValue ??
+      state.featureFlags.modifiedFlags[featureFlag.flagName] ??
+      featureFlag.defaultValue) as T;
 }

--- a/src/commons/featureFlags/index.test.ts
+++ b/src/commons/featureFlags/index.test.ts
@@ -22,4 +22,24 @@ describe('FeatureFlagsReducer', () => {
 
     expect(state.modifiedFlags).toEqual({});
   });
+
+  test('resetFlag clears the override of an unlocked flag', () => {
+    const flag = createFeatureFlag('unlocked', true);
+    const state = FeatureFlagsReducer(
+      { modifiedFlags: { unlocked: false } },
+      FeatureFlagsActions.resetFlag({ featureFlag: flag }),
+    );
+
+    expect(state.modifiedFlags).toEqual({});
+  });
+
+  test('resetFlag on a locked flag does not touch persisted state', () => {
+    const flag = createFeatureFlag('locked', true, undefined, true);
+    const state = FeatureFlagsReducer(
+      { modifiedFlags: { locked: false } },
+      FeatureFlagsActions.resetFlag({ featureFlag: flag }),
+    );
+
+    expect(state.modifiedFlags).toEqual({ locked: false });
+  });
 });

--- a/src/commons/featureFlags/index.test.ts
+++ b/src/commons/featureFlags/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { createFeatureFlag, FeatureFlagsActions, FeatureFlagsReducer } from '.';
+
+describe('FeatureFlagsReducer', () => {
+  test('setFlag stores the value of an unlocked flag', () => {
+    const flag = createFeatureFlag('unlocked', true);
+    const state = FeatureFlagsReducer(
+      { modifiedFlags: {} },
+      FeatureFlagsActions.setFlag({ featureFlag: flag, value: false }),
+    );
+
+    expect(state.modifiedFlags).toEqual({ unlocked: false });
+  });
+
+  test('setFlag on a locked flag does not write to persisted state', () => {
+    const flag = createFeatureFlag('locked', true, undefined, true);
+    const state = FeatureFlagsReducer(
+      { modifiedFlags: {} },
+      FeatureFlagsActions.setFlag({ featureFlag: flag, value: false }),
+    );
+
+    expect(state.modifiedFlags).toEqual({});
+  });
+});

--- a/src/commons/featureFlags/index.ts
+++ b/src/commons/featureFlags/index.ts
@@ -19,6 +19,9 @@ const featureFlagsSlice = createSlice({
       state: FeatureFlagsState,
       action: { payload: { featureFlag: FeatureFlag<T>; value: T } },
     ) {
+      if (action.payload.featureFlag.isLocked) {
+        return;
+      }
       state.modifiedFlags[action.payload.featureFlag.flagName] = action.payload.value;
     },
     resetFlag<T>(state: FeatureFlagsState, action: { payload: { featureFlag: FeatureFlag<T> } }) {
@@ -35,7 +38,8 @@ export function createFeatureFlag<T>(
   flagName: string,
   defaultValue: T,
   flagDesc?: string,
+  lockedValue?: T,
   callback?: (newValue: T) => SagaIterator,
 ): FeatureFlag<T> {
-  return new FeatureFlag<T>(flagName, defaultValue, flagDesc, callback);
+  return new FeatureFlag<T>(flagName, defaultValue, flagDesc, lockedValue, callback);
 }

--- a/src/commons/featureFlags/index.ts
+++ b/src/commons/featureFlags/index.ts
@@ -25,6 +25,9 @@ const featureFlagsSlice = createSlice({
       state.modifiedFlags[action.payload.featureFlag.flagName] = action.payload.value;
     },
     resetFlag<T>(state: FeatureFlagsState, action: { payload: { featureFlag: FeatureFlag<T> } }) {
+      if (action.payload.featureFlag.isLocked) {
+        return;
+      }
       delete state.modifiedFlags[action.payload.featureFlag.flagName];
     },
   },

--- a/src/commons/featureFlags/selectFeatureSaga.test.ts
+++ b/src/commons/featureFlags/selectFeatureSaga.test.ts
@@ -1,0 +1,26 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { describe, test } from 'vitest';
+
+import type { OverallState } from '../application/ApplicationTypes';
+import { createFeatureFlag } from '.';
+import { selectFeatureSaga } from './selectFeatureSaga';
+
+const makeState = (modifiedFlags: Record<string, unknown>) =>
+  ({ featureFlags: { modifiedFlags } }) as OverallState;
+
+describe('selectFeatureSaga', () => {
+  test('returns the user override when the flag is unlocked', () =>
+    expectSaga(selectFeatureSaga, createFeatureFlag('unlocked', 'default'))
+      .withState(makeState({ unlocked: 'override' }))
+      .returns('override')
+      .silentRun());
+
+  test('returns the locked value regardless of the user override', () =>
+    expectSaga(
+      selectFeatureSaga,
+      createFeatureFlag('locked', 'default', undefined, 'pinned'),
+    )
+      .withState(makeState({ locked: 'override' }))
+      .returns('pinned')
+      .silentRun());
+});

--- a/src/commons/featureFlags/selectFeatureSaga.test.ts
+++ b/src/commons/featureFlags/selectFeatureSaga.test.ts
@@ -16,10 +16,7 @@ describe('selectFeatureSaga', () => {
       .silentRun());
 
   test('returns the locked value regardless of the user override', () =>
-    expectSaga(
-      selectFeatureSaga,
-      createFeatureFlag('locked', 'default', undefined, 'pinned'),
-    )
+    expectSaga(selectFeatureSaga, createFeatureFlag('locked', 'default', undefined, 'pinned'))
       .withState(makeState({ locked: 'override' }))
       .returns('pinned')
       .silentRun());

--- a/src/commons/featureFlags/useFeature.test.tsx
+++ b/src/commons/featureFlags/useFeature.test.tsx
@@ -8,7 +8,9 @@ import { createFeatureFlag } from '.';
 import { useFeature } from './useFeature';
 
 const renderUseFeature = <T,>(flag: Parameters<typeof useFeature<T>>[0], modifiedFlags: object) => {
-  const store = createMockStore<OverallState>()({ featureFlags: { modifiedFlags } } as OverallState);
+  const store = createMockStore<OverallState>()({
+    featureFlags: { modifiedFlags },
+  } as OverallState);
   return renderHook(() => useFeature(flag), {
     wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
   }).result.current;

--- a/src/commons/featureFlags/useFeature.test.tsx
+++ b/src/commons/featureFlags/useFeature.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import createMockStore from 'redux-mock-store';
+import { describe, expect, test } from 'vitest';
+
+import type { OverallState } from '../application/ApplicationTypes';
+import { createFeatureFlag } from '.';
+import { useFeature } from './useFeature';
+
+const renderUseFeature = <T,>(flag: Parameters<typeof useFeature<T>>[0], modifiedFlags: object) => {
+  const store = createMockStore<OverallState>()({ featureFlags: { modifiedFlags } } as OverallState);
+  return renderHook(() => useFeature(flag), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  }).result.current;
+};
+
+describe('useFeature', () => {
+  test('returns the user override when the flag is unlocked', () => {
+    const flag = createFeatureFlag('unlocked', 'default');
+    expect(renderUseFeature(flag, { unlocked: 'override' })).toBe('override');
+    expect(renderUseFeature(flag, {})).toBe('default');
+  });
+
+  test('returns the locked value regardless of the user override', () => {
+    const flag = createFeatureFlag('locked', 'default', undefined, 'pinned');
+    expect(renderUseFeature(flag, { locked: 'override' })).toBe('pinned');
+    expect(renderUseFeature(flag, {})).toBe('pinned');
+  });
+});

--- a/src/commons/featureFlags/useFeature.ts
+++ b/src/commons/featureFlags/useFeature.ts
@@ -2,7 +2,7 @@ import { useAppSelector } from '../utils/Hooks';
 import { FeatureFlag } from './FeatureFlag';
 
 export function useFeature<T>(featureFlag: FeatureFlag<T>): T {
-  const { flagName, defaultValue } = featureFlag;
+  const { flagName, defaultValue, lockedValue } = featureFlag;
   const flagValue = useAppSelector(state => state.featureFlags.modifiedFlags[flagName]);
-  return flagValue ?? defaultValue;
+  return lockedValue ?? flagValue ?? defaultValue;
 }

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -6,7 +6,10 @@ import type {
 import { getEvaluatorDefinition } from '@sourceacademy/language-directory/dist/util';
 import { call, fork, put, select } from 'redux-saga/effects';
 import { selectConductorEnable } from 'src/features/conductor/flagConductorEnable';
-import { selectDirectoryLanguageUrl } from 'src/features/directory/flagDirectoryLanguageUrl';
+import {
+  flagDirectoryLanguageUrl,
+  selectDirectoryLanguageUrl,
+} from 'src/features/directory/flagDirectoryLanguageUrl';
 
 import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
 import type { LanguageDirectoryState } from '../../features/directory/LanguageDirectoryTypes';
@@ -61,9 +64,8 @@ const languageDirectoryHandlers = combineSagaHandlers({
   },
   [LanguageDirectoryActions.fetchLanguages.type]: function* () {
     const url: string = yield select(selectDirectoryLanguageUrl);
-    const defaultUrl = 'https://source-academy.github.io/language-directory/directory.json';
     let result: ILanguageDefinition[];
-    if (url === defaultUrl) {
+    if (url === flagDirectoryLanguageUrl.defaultValue) {
       result = yield call(() => Promise.resolve(languages));
     } else {
       const response = yield call(fetch, url);

--- a/src/commons/utils/Constants.ts
+++ b/src/commons/utils/Constants.ts
@@ -136,6 +136,17 @@ const featureFlags = {
   enableSicpChatbot: isTrue(process.env.REACT_APP_FEATURE_ENABLE_SICP_CHATBOT),
 };
 
+// Deployment-pinned Conductor settings; `undefined` leaves the corresponding feature flag under
+// the user's control on /features.
+const conductorConfig = {
+  enable: process.env.REACT_APP_CONDUCTOR_ENABLE
+    ? isTrue(process.env.REACT_APP_CONDUCTOR_ENABLE)
+    : undefined,
+  languageDirectoryUrl: process.env.REACT_APP_LANGUAGE_DIRECTORY_URL || undefined,
+  pluginDirectoryUrl: process.env.REACT_APP_PLUGIN_DIRECTORY_URL || undefined,
+  modulesDirectoryUrl: process.env.REACT_APP_MODULES_DIRECTORY_URL || undefined,
+};
+
 export enum Links {
   githubIssues = 'https://github.com/source-academy/frontend/issues',
   githubOrg = 'https://github.com/source-academy',
@@ -196,6 +207,7 @@ const Constants = {
   collabSessionIdLocalStorageKey,
   caFulfillmentLevel,
   featureFlags,
+  conductorConfig,
 };
 
 export default Constants;

--- a/src/features/conductor/flagConductorEnable.test.ts
+++ b/src/features/conductor/flagConductorEnable.test.ts
@@ -1,6 +1,33 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { OverallState } from '../../commons/application/ApplicationTypes';
+import Constants from '../../commons/utils/Constants';
 import { flagConductorEnable } from './flagConductorEnable';
+
+const emptyState = { featureFlags: { modifiedFlags: {} } } as OverallState;
+
+describe('flagConductorEnable pinned on by the deployment', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock('../../commons/utils/Constants', () => ({
+      default: { ...Constants, conductorConfig: { ...Constants.conductorConfig, enable: true } },
+    }));
+  });
+
+  test('is enabled outside of SICP JS', async () => {
+    window.history.pushState({}, '', '/playground');
+    const { selectConductorEnable } = await import('./flagConductorEnable');
+
+    expect(selectConductorEnable(emptyState)).toBe(true);
+  });
+
+  test('stays disabled on SICP JS, whose snippets are not Conductor-based', async () => {
+    window.history.pushState({}, '', '/sicpjs/2.2');
+    const { selectConductorEnable } = await import('./flagConductorEnable');
+
+    expect(selectConductorEnable(emptyState)).toBe(false);
+  });
+});
 
 describe('flagConductorEnable', () => {
   test('enabling or disabling it has no side effect on other flags (e.g. the directory URLs)', () => {

--- a/src/features/conductor/flagConductorEnable.ts
+++ b/src/features/conductor/flagConductorEnable.ts
@@ -3,12 +3,14 @@ import { useLocation } from 'react-router';
 import type { OverallState } from '../../commons/application/ApplicationTypes';
 import { createFeatureFlag } from '../../commons/featureFlags';
 import { featureSelector } from '../../commons/featureFlags/featureSelector';
+import Constants from '../../commons/utils/Constants';
 import { useAppSelector } from '../../commons/utils/Hooks';
 
 export const flagConductorEnable = createFeatureFlag(
   'conductor.enable',
   true,
   'Enables the Conductor framework for evaluation of user programs.',
+  Constants.conductorConfig.enable,
 );
 
 const selectConductorEnableFlag = featureSelector(flagConductorEnable);

--- a/src/features/directory/flagDirectoryLanguageUrl.ts
+++ b/src/features/directory/flagDirectoryLanguageUrl.ts
@@ -2,12 +2,16 @@ import { put } from 'redux-saga/effects';
 
 import { createFeatureFlag } from '../../commons/featureFlags';
 import { featureSelector } from '../../commons/featureFlags/featureSelector';
+import Constants from '../../commons/utils/Constants';
 import LanguageDirectoryActions from './LanguageDirectoryActions';
+
+const { enable, languageDirectoryUrl } = Constants.conductorConfig;
 
 export const flagDirectoryLanguageUrl = createFeatureFlag(
   'directory.language.url',
   'https://source-academy.github.io/language-directory/directory.json',
   'The URL where the language directory may be found.',
+  enable ? languageDirectoryUrl : undefined,
   function* () {
     yield put(LanguageDirectoryActions.fetchLanguages());
   },

--- a/src/features/directory/flagDirectoryModulesUrl.ts
+++ b/src/features/directory/flagDirectoryModulesUrl.ts
@@ -2,11 +2,15 @@ import { ModuleLoaderWebPlugin } from '@sourceacademy/web-module-loader';
 
 import { createFeatureFlag } from '../../commons/featureFlags';
 import { featureSelector } from '../../commons/featureFlags/featureSelector';
+import Constants from '../../commons/utils/Constants';
+
+const { enable, modulesDirectoryUrl } = Constants.conductorConfig;
 
 export const flagDirectoryModulesUrl = createFeatureFlag(
   'directory.modules.url',
   'https://source-academy.github.io/modules-conductor/modules.json',
   'The URL where the module directory may be found.',
+  enable ? modulesDirectoryUrl : undefined,
   // eslint-disable-next-line require-yield
   function* (url: string) {
     ModuleLoaderWebPlugin.instance?.onModuleDirectoryURLChange(url);

--- a/src/features/directory/flagDirectoryPluginUrl.ts
+++ b/src/features/directory/flagDirectoryPluginUrl.ts
@@ -2,12 +2,16 @@ import { put } from 'redux-saga/effects';
 
 import { createFeatureFlag } from '../../commons/featureFlags';
 import { featureSelector } from '../../commons/featureFlags/featureSelector';
+import Constants from '../../commons/utils/Constants';
 import PluginDirectoryActions from './PluginDirectoryActions';
+
+const { enable, pluginDirectoryUrl } = Constants.conductorConfig;
 
 export const flagDirectoryPluginUrl = createFeatureFlag(
   'directory.plugin.url',
   'https://source-academy.github.io/plugins/directory.json',
   'The URL where the plugin directory may be found.',
+  enable ? pluginDirectoryUrl : undefined,
   function* () {
     yield put(PluginDirectoryActions.fetchPlugins());
   },

--- a/src/new_routes/features.tsx
+++ b/src/new_routes/features.tsx
@@ -8,6 +8,7 @@ import {
   Section,
   SectionCard,
   SwitchCard,
+  Tag,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import type { BlueprintIcons_16Id } from '@blueprintjs/icons/lib/esm/generated/16px/blueprint-icons-16';
@@ -24,7 +25,7 @@ type FlagCardProps<T> = React.PropsWithChildren<{
 }>;
 
 function BooleanFlagCard({ flag, modifiedFlag }: FlagCardProps<boolean>) {
-  const currentFlag = modifiedFlag ?? flag.defaultValue;
+  const currentFlag = flag.lockedValue ?? modifiedFlag ?? flag.defaultValue;
   const isModified = modifiedFlag !== undefined;
 
   const dispatch = useAppDispatch();
@@ -34,14 +35,19 @@ function BooleanFlagCard({ flag, modifiedFlag }: FlagCardProps<boolean>) {
   };
 
   return (
-    <SwitchCard checked={currentFlag} onChange={onChange} selected={isModified}>
+    <SwitchCard
+      checked={currentFlag}
+      onChange={onChange}
+      selected={isModified}
+      disabled={flag.isLocked}
+    >
       {isModified ? <b>{String(currentFlag)}</b> : String(currentFlag)}
     </SwitchCard>
   );
 }
 
 function NumberFlagCard({ flag, modifiedFlag }: FlagCardProps<number>) {
-  const currentFlag = modifiedFlag ?? flag.defaultValue;
+  const currentFlag = flag.lockedValue ?? modifiedFlag ?? flag.defaultValue;
   const isModified = modifiedFlag !== undefined;
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -57,6 +63,7 @@ function NumberFlagCard({ flag, modifiedFlag }: FlagCardProps<number>) {
       <NumericInput
         fill
         selectAllOnFocus
+        disabled={flag.isLocked}
         defaultValue={String(currentFlag)}
         onValueChange={onValueChange}
         rightElement={isModified ? <Icon icon={IconNames.ASTERISK} /> : undefined}
@@ -67,7 +74,7 @@ function NumberFlagCard({ flag, modifiedFlag }: FlagCardProps<number>) {
 }
 
 function StringFlagCard({ flag, modifiedFlag }: FlagCardProps<string>) {
-  const currentFlag = modifiedFlag ?? flag.defaultValue;
+  const currentFlag = flag.lockedValue ?? modifiedFlag ?? flag.defaultValue;
   const isModified = modifiedFlag !== undefined;
 
   const inputRef = useRef<HTMLDivElement>(null);
@@ -77,6 +84,10 @@ function StringFlagCard({ flag, modifiedFlag }: FlagCardProps<string>) {
   const onConfirm = (value: string) => {
     dispatch(FeatureFlagsActions.setFlag({ featureFlag: flag, value: value }));
   };
+
+  if (flag.isLocked) {
+    return <Card style={{ overflowY: 'hidden' }}>{currentFlag}</Card>;
+  }
 
   let inputField = (
     <EditableText onConfirm={onConfirm} defaultValue={currentFlag} elementRef={inputRef} />
@@ -132,13 +143,19 @@ function FeatureFlagSection({
     onToggle: toggleIsOpen,
   };
 
+  const rightElement = flag.isLocked ? (
+    <Tag minimal>set by deployment</Tag>
+  ) : isModified ? (
+    <Button icon={IconNames.RESET} onClick={onReset} />
+  ) : undefined;
+
   return (
     <Section
       title={flag.flagName}
       subtitle={flag.flagDesc}
       collapsible
       collapseProps={collapseProps}
-      rightElement={isModified ? <Button icon={IconNames.RESET} onClick={onReset} /> : undefined}
+      rightElement={rightElement}
       icon={icon}
     >
       <SectionCard>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Move conductor feature flag and directory flags into env/constants so that it can be set up deployment wide. Also lock the conductor enable feature if the REACT_APP_CONDUCTOR_ENABLE is set to TRUE, and locked to disabled if set to FALSE, and unset allows toggling of the feature flag, like how it currently works (tri-state).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Added some simple tests by Claude, not carefully checked yet, but they do pass.

### Checklist

<!-- Please delete options that are not relevant. -->

- [?] I have tested this code
- [ ] I have updated the documentation
