### PR TITLE
Remove ESLint step from yarn format

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "analyze": "cross-env RSDOCTOR=true yarn build",
     "build": "tsc -b && rsbuild build",
     "coverage": "./scripts/coverage-fix.sh do && yarn test --coverage && ./scripts/coverage-fix.sh undo",
-    "format": "oxfmt \"src/**/*.{js,jsx,ts,tsx,scss,json}\" && eslint --fix src",
+    "format": "oxfmt \"src/**/*.{js,jsx,ts,tsx,scss,json}\"",
     "format:ci": "oxfmt --list-different \"src/**/*.{js,jsx,ts,tsx,scss,json}\"",
     "start": "rsbuild dev",
     "test": "cross-env TZ=Asia/Singapore vitest run",


### PR DESCRIPTION
## Summary

`yarn format` was chaining `oxfmt` with `eslint --fix src`. This drops the
ESLint step so that `yarn format` only runs the formatter.

Linting is unchanged — it is still available via the standalone `yarn lint`
script (`eslint src`).

## Changes

- `package.json`: `format` script now runs only `oxfmt ...` (no longer chained
  with `eslint --fix src`).

## Test plan

- [ ] Run `yarn format` and confirm it only invokes `oxfmt` and no longer runs
  ESLint.
- [ ] Confirm `yarn lint` still works as before.