### PR TITLE
Default directory.modules.url to the primary modules site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,4 +83,4 @@ REACT_APP_FEATURE_ENABLE_SICP_CHATBOT=FALSE
 REACT_APP_CONDUCTOR_ENABLE=
 # REACT_APP_LANGUAGE_DIRECTORY_URL=https://source-academy.github.io/language-directory/directory.json
 # REACT_APP_PLUGIN_DIRECTORY_URL=https://source-academy.github.io/plugins/directory.json
-# REACT_APP_MODULES_DIRECTORY_URL=https://source-academy.github.io/modules-conductor/modules.json
+# REACT_APP_MODULES_DIRECTORY_URL=https://source-academy.github.io/modules/modules.json

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ directory.plugin.url
 https://source-academy.github.io/plugins/directory.json
 
 directory.modules.url
-https://source-academy.github.io/modules-conductor/modules.json
+https://source-academy.github.io/modules/modules.json
 ```
 
 A deployment can pin these instead of leaving them to each user's browser. Set `REACT_APP_CONDUCTOR_ENABLE` to `TRUE` or `FALSE` in `.env` to fix `conductor.enable` for everyone; while it is `TRUE`, the three `REACT_APP_*_DIRECTORY_URL` variables likewise pin the directory URLs. Pinned flags are shown read-only on the Feature Flags page, and take precedence over anything a user has previously set there.

--- a/src/features/directory/flagDirectoryModulesUrl.ts
+++ b/src/features/directory/flagDirectoryModulesUrl.ts
@@ -8,7 +8,7 @@ const { enable, modulesDirectoryUrl } = Constants.conductorConfig;
 
 export const flagDirectoryModulesUrl = createFeatureFlag(
   'directory.modules.url',
-  'https://source-academy.github.io/modules-conductor/modules.json',
+  'https://source-academy.github.io/modules/modules.json',
   'The URL where the module directory may be found.',
   enable ? modulesDirectoryUrl : undefined,
   // eslint-disable-next-line require-yield


### PR DESCRIPTION
## Summary
- `directory.modules.url` (and the matching `.env.example`/README docs) defaulted to `https://source-academy.github.io/modules-conductor/modules.json`, the shadow site used while `source-academy/modules`' `master` branch was still on the pre-Conductor bundle format.
- `master` there has since merged the Conductor migration (source-academy/modules#680), and its deploy workflow now publishes to both `source-academy.github.io/modules` and `.../modules-conductor` from the same commit (source-academy/modules#864) — the two are equivalent now, so default to the primary one instead of the shadow mirror.
- Production (`sourceacademy.org`) already pins this via `REACT_APP_MODULES_DIRECTORY_URL` to the primary URL, so this only changes the unpinned default — e.g. other deployments or local dev setups that don't set the env var.

## Test plan
- [x] `yarn tsc`, `yarn lint`, `yarn format:ci`, `yarn test` all pass locally (via pre-push hook)
- [ ] Confirm Feature Flags page shows the new default for a deployment that doesn't pin `REACT_APP_MODULES_DIRECTORY_URL`