### PR TITLE
Bump @sourceacademy/conductor to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@sourceacademy/common-autocomplete": "^0.0.1",
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-tabs": "^0.0.1",
-    "@sourceacademy/conductor": "^0.8.2",
+    "@sourceacademy/conductor": "^0.8.3",
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.19",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4",
     "@sourceacademy/runner-module-loader": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,10 +4217,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "@sourceacademy/conductor@npm:0.8.2"
-  checksum: 10c0/a37dbed6c9ff1f92cb1b7938366c4647cc7c89aaa54b9b843ceaa2088933e251b84b2acae61753bad599c11f0becf95013a771bd7c999735ed8896c3195c9f53
+"@sourceacademy/conductor@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@sourceacademy/conductor@npm:0.8.3"
+  checksum: 10c0/25a35004fd92abc3f9342c1928a6be884388d3a8465cdc26491ccf56566121dd7a68a0c305defe668dfe7b96eebe61e93059631f80a92e0d9a4dc2775090f3e5
   languageName: node
   linkType: hard
 
@@ -8559,7 +8559,7 @@ __metadata:
     "@sourceacademy/common-autocomplete": "npm:^0.0.1"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-tabs": "npm:^0.0.1"
-    "@sourceacademy/conductor": "npm:^0.8.2"
+    "@sourceacademy/conductor": "npm:^0.8.3"
     "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.19"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4"
     "@sourceacademy/runner-module-loader": "npm:^0.1.0"


### PR DESCRIPTION
## Summary
Picks up source-academy/conductor#66 (`BasicEvaluator.startEvaluator` now loops on further chunks instead of stopping after the first, reporting `RunnerStatus.EVAL_READY` between them) - the piece #4213 (merged) actually depends on at runtime.

Without this bump, #4213's saga-level session persistence is in place but the underlying evaluator still only ever receives one chunk per Worker lifetime, so a REPL line still can't see an earlier line's declarations. This closes that gap.

py-slang's own dependency on conductor was bumped the same way in source-academy/py-slang#373.

## Test plan
- [x] `npx tsc -b --noEmit` - clean
- [x] `npx vitest run` (full suite) - 90 files / 746 tests passing
- [x] Pre-push hook (tsc/lint/format:ci/test) - clean

Note: this environment's default Node (20.19.1) can't run jsdom 30 + undici 8's test setup (`webidl.util.markAsUncloneable is not a function`) - reproduces identically on a clean `master` checkout too, unrelated to this change. CI runs Node 22, which this was verified against directly.

## Manual verification
Not yet done - the deployed frontend is still on the old conductor version as of this PR. Once this + #4213 are both live: Run a program (or leave the editor empty), type `x = 1` in the REPL, Enter, then `x` on the next line - should print `1`.