### PR TITLE
Use more neutral language for the multi-language platform

### DIFF
--- a/src/commons/__snapshots__/Markdown.test.tsx.snap
+++ b/src/commons/__snapshots__/Markdown.test.tsx.snap
@@ -11,18 +11,7 @@ exports[`Markdown page renders correctly 1`] = `
     
 
     <p>
-      The book 
-      <a
-        href="https://sourceacademy.org/sicpjs/"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        <em>
-          Structure and Interpretation of Computer Programs, JavaScript Edition
-        </em>
-      </a>
-      
-uses JavaScript sublanguages that we call 
+      This language is 
       <a
         href="https://docs.sourceacademy.org/"
         rel="noopener noreferrer"
@@ -30,6 +19,17 @@ uses JavaScript sublanguages that we call
       >
         <em>
           Source
+        </em>
+      </a>
+      , a family of JavaScript sublanguages designed
+for the book 
+      <a
+        href="https://sourceacademy.org/sicpjs/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <em>
+          Structure and Interpretation of Computer Programs, JavaScript Edition
         </em>
       </a>
       . You have chosen the sublanguage 

--- a/src/commons/dropdown/DropdownAbout.tsx
+++ b/src/commons/dropdown/DropdownAbout.tsx
@@ -21,13 +21,14 @@ function DropdownAbout(props: Props) {
       <DialogBody>
         <p>
           The <i>Source Academy</i> is a computer-mediated learning environment for studying the
-          structure and interpretation of computer programs. Students write and run their programs
-          in their web browser, using sublanguages of JavaScript called{' '}
-          <a href={Links.sourceDocs}>Source</a>, designed for the textbook{' '}
+          structure and interpretation of computer programs, across multiple programming languages.
+          Students write and run their programs in their web browser, in a language chosen for their
+          course — including <a href={Links.sourceDocs}>Source</a>, a family of JavaScript
+          sublanguages designed for the textbook{' '}
           <a href={Links.textbook}>
             Structure and Interpretation of Computer Programs, JavaScript Edition
           </a>
-          .
+          , and other languages such as Python.
         </p>
         <p>
           The Source Academy is available under the Apache License 2.0 at the GitHub organisation{' '}

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -6,8 +6,8 @@ import { Links } from './Constants';
 const MAIN_INTRODUCTION = `
 Welcome to the Source Academy playground!
 
-The book [_Structure and Interpretation of Computer Programs, JavaScript Edition_](${Links.textbook})
-uses JavaScript sublanguages that we call [_Source_](${Links.sourceDocs}). `;
+This language is [_Source_](${Links.sourceDocs}), a family of JavaScript sublanguages designed
+for the book [_Structure and Interpretation of Computer Programs, JavaScript Edition_](${Links.textbook}). `;
 
 const HOTKEYS_INTRODUCTION = `
 

--- a/src/features/adminPanel/subcomponents/PixelbotConfigPanel.tsx
+++ b/src/features/adminPanel/subcomponents/PixelbotConfigPanel.tsx
@@ -53,10 +53,13 @@ IF no course documents are attached:
 - Be helpful and provide a clear, accurate answer.
 
 GENERAL INSTRUCTIONS:
-- The Source Academy platform uses the "Source" language, a restricted subset of JavaScript. When providing code examples, use valid Source language syntax.
-- Do NOT use JavaScript features not supported in Source (classes, modules, imports/exports, async/await, generators).
-- Use display or display_list instead of console.log.
-- Format your response using markdown. Use fenced code blocks with the language identifier for all code examples, e.g. \`\`\`javascript ... \`\`\`.`;
+- Match the programming language used by the course. If the course uses "Source" (a restricted
+  subset of JavaScript designed for the Structure and Interpretation of Computer Programs,
+  JavaScript Edition textbook), do NOT use JavaScript features not supported in Source (classes,
+  modules, imports/exports, async/await, generators), and use display or display_list instead of
+  console.log.
+- Format your response using markdown, with fenced code blocks labelled for the language you're
+  using.`;
 
 function PixelbotConfigPanel(props: Props) {
   const { pixelbotRoutingPrompt, pixelbotAnswerPrompt, feedbackUrl } = props.courseConfiguration;

--- a/src/pages/playground/__snapshots__/Playground.test.tsx.snap
+++ b/src/pages/playground/__snapshots__/Playground.test.tsx.snap
@@ -724,18 +724,7 @@ exports[`Playground tests > Playground renders correctly 1`] = `
                             
 
                             <p>
-                              The book 
-                              <a
-                                href="https://sourceacademy.org/sicpjs/"
-                                rel="noopener noreferrer"
-                                target="_blank"
-                              >
-                                <em>
-                                  Structure and Interpretation of Computer Programs, JavaScript Edition
-                                </em>
-                              </a>
-                              
-uses JavaScript sublanguages that we call 
+                              This language is 
                               <a
                                 href="https://docs.sourceacademy.org/"
                                 rel="noopener noreferrer"
@@ -743,6 +732,17 @@ uses JavaScript sublanguages that we call
                               >
                                 <em>
                                   Source
+                                </em>
+                              </a>
+                              , a family of JavaScript sublanguages designed
+for the book 
+                              <a
+                                href="https://sourceacademy.org/sicpjs/"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                <em>
+                                  Structure and Interpretation of Computer Programs, JavaScript Edition
                                 </em>
                               </a>
                               . You have chosen the sublanguage 
@@ -2339,18 +2339,7 @@ exports[`Playground tests > Playground with link renders correctly 1`] = `
                             
 
                             <p>
-                              The book 
-                              <a
-                                href="https://sourceacademy.org/sicpjs/"
-                                rel="noopener noreferrer"
-                                target="_blank"
-                              >
-                                <em>
-                                  Structure and Interpretation of Computer Programs, JavaScript Edition
-                                </em>
-                              </a>
-                              
-uses JavaScript sublanguages that we call 
+                              This language is 
                               <a
                                 href="https://docs.sourceacademy.org/"
                                 rel="noopener noreferrer"
@@ -2358,6 +2347,17 @@ uses JavaScript sublanguages that we call
                               >
                                 <em>
                                   Source
+                                </em>
+                              </a>
+                              , a family of JavaScript sublanguages designed
+for the book 
+                              <a
+                                href="https://sourceacademy.org/sicpjs/"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                <em>
+                                  Structure and Interpretation of Computer Programs, JavaScript Edition
                                 </em>
                               </a>
                               . You have chosen the sublanguage 


### PR DESCRIPTION
## Summary
Source Academy now hosts multiple languages via the Language Directory (Python/py-slang alongside Source/JavaScript - source-academy/py-slang#359), but three user- and admin-facing strings still described the whole platform as JavaScript-only. Found during a sweep for JavaScript remnants (same spirit as source-academy/py-slang#372/#373 on the py-slang side).

- **`DropdownAbout.tsx`**: the "About" dialog said students "write and run their programs... using sublanguages of JavaScript called Source." Now says the platform covers multiple languages, naming Source and Python as examples.
- **`IntroductionHelper.ts`**: `MAIN_INTRODUCTION` (the Playground's fallback welcome text, shown when a Conductor language doesn't supply its own `welcome` string via the language directory) opened with "The book ... uses JavaScript sublanguages that we call Source" as if that described the whole platform. Reworded to scope the JavaScript claim to "this language" instead - still accurate (this text only ever renders for Source/JS chapters, per the file's own `// TODO: Remove this after migrated to language config`), without asserting it platform-wide.
- **`PixelbotConfigPanel.tsx`**: `DEFAULT_ANSWER_PROMPT`, the default AI-tutor system prompt for the Pixelbot feature, unconditionally instructed the model to use "Source" syntax and forbade JavaScript features not in Source - actively wrong guidance if a Python-track course admin uses the default prompt as-is. Reworded to match the course's actual language, keeping the Source-specific guidance conditional.

Two other findings from the same sweep were considered but left as-is (out of scope for this PR): a hardcoded `mode="javascript"` in the admin assessment-template editor, and a JS-flavored placeholder in the course-level LLM prompt field - both minor/cosmetic rather than actively wrong.

## Test plan
- [x] `npx tsc -b --noEmit` - clean
- [x] `npx vitest run` (full suite) - 90 files / 746 tests passing (2 snapshot tests updated to reflect the intentional text change - `Markdown.test.tsx`, `Playground.test.tsx`)
- [x] `npx eslint` - clean
- [x] `npx oxfmt --list-different` - clean
- [x] Pre-push hook (tsc/lint/format:ci/test) - clean

Note: as with #4215, this environment's default Node (20.19.1) can't run the test suite (`jsdom`/`undici` incompatibility, reproduces on clean `master` too) - verified against Node 22 directly, matching CI.