### PR TITLE
Module tabs outside Playground + Ground Control default language from language directory

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -931,7 +931,11 @@ export function* evalCodeConductorSaga(
       hostPlugin: BrowserHostPlugin;
       csePlugin: CseMachineHostPlugin;
       conduit: IConduit;
-    } = yield call(getPreparedConductorSaga, { files: filesWithConfig, consume: true });
+    } = yield call(getPreparedConductorSaga, {
+      files: filesWithConfig,
+      consume: true,
+      workspaceLocation,
+    });
     const { hostPlugin, csePlugin, conduit } = prepared;
 
     // Immediately start warming the next conductor in the background. forceFresh is required

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -215,7 +215,7 @@ const newActions = createActions('workspace', {
     workspaceLocation,
     hasUnsavedChanges,
   }),
-  changeSublanguage: (sublang: SALanguage) => ({ sublang }),
+  changeSublanguage: (sublang: Pick<SALanguage, 'chapter' | 'variant'>) => ({ sublang }),
   updateSublanguage: (sublang: SALanguage) => ({ sublang }),
   promptAutocomplete: (
     workspaceLocation: WorkspaceLocation,

--- a/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
+++ b/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
@@ -12,7 +12,7 @@ import { type ItemListRenderer, type ItemRenderer, Select } from '@blueprintjs/s
 import { Variant } from 'js-slang/dist/langs';
 import { useCallback, useState } from 'react';
 import Constants from 'src/commons/utils/Constants';
-import { useAppDispatch, useSession } from 'src/commons/utils/Hooks';
+import { useAppDispatch, useAppSelector, useSession } from 'src/commons/utils/Hooks';
 
 import {
   type SALanguage,
@@ -21,9 +21,18 @@ import {
 } from '../../../../commons/application/ApplicationTypes';
 import ControlButton from '../../../../commons/ControlButton';
 import WorkspaceActions from '../../../../commons/workspace/WorkspaceActions';
+import { selectConductorEnable } from '../../../../features/conductor/flagConductorEnable';
+
+/**
+ * Just the fields `changeSublanguage` actually persists (course config only stores
+ * `sourceChapter`/`sourceVariant`) - lets a Conductor language-directory entry (which has no
+ * `variant`, `mainLanguage` or `supports` of its own) be selected through the same menu/dialog
+ * as a legacy Source `SALanguage` without having to fake those fields.
+ */
+type LanguageChoice = Pick<SALanguage, 'chapter' | 'variant' | 'displayName'>;
 
 function DefaultChapterSelect() {
-  const [chosenSublang, setSublanguage] = useState<SALanguage>(sourceLanguages[0]);
+  const [chosenLanguage, setChosenLanguage] = useState<LanguageChoice>(sourceLanguages[0]);
   const [isDialogOpen, setDialogState] = useState(false);
 
   const {
@@ -32,35 +41,53 @@ function DefaultChapterSelect() {
     sourceVariant = Constants.defaultSourceVariant,
   } = useSession();
 
+  const isConductorEnabled = useAppSelector(selectConductorEnable);
+  const languages = useAppSelector(state => state.languageDirectory.languages);
+
+  // Once Conductor is enabled, `sourceChapter` is a 1-based index into the language directory's
+  // `languages` array (see chapterLanguage.ts's `deriveLanguageFromChapter`) rather than a Source
+  // chapter - Source is no longer used, so there's no other meaning to distinguish from.
+  const items: LanguageChoice[] = isConductorEnabled
+    ? languages.map((lang, index) => ({
+        chapter: index + 1,
+        variant: Variant.DEFAULT,
+        displayName: lang.name,
+      }))
+    : sourceLanguages;
+
+  const currentLanguageName = isConductorEnabled
+    ? (languages[sourceChapter - 1]?.name ?? 'Loading…')
+    : styliseSublanguage(sourceChapter, sourceVariant);
+
   const dispatch = useAppDispatch();
-  const handleUpdateSublanguage = useCallback(
-    (sublang: SALanguage) => dispatch(WorkspaceActions.changeSublanguage(sublang)),
+  const handleUpdateLanguage = useCallback(
+    (lang: LanguageChoice) => dispatch(WorkspaceActions.changeSublanguage(lang)),
     [dispatch],
   );
 
   const handleOpenDialog = useCallback(
-    (choice: SALanguage) => {
+    (choice: LanguageChoice) => {
       setDialogState(true);
-      setSublanguage(choice);
+      setChosenLanguage(choice);
     },
-    [setDialogState, setSublanguage],
+    [setDialogState, setChosenLanguage],
   );
   const handleCloseDialog = useCallback(() => {
     setDialogState(false);
   }, [setDialogState]);
   const handleConfirmDialog = useCallback(() => {
     setDialogState(false);
-    handleUpdateSublanguage(chosenSublang);
-  }, [chosenSublang, setDialogState, handleUpdateSublanguage]);
+    handleUpdateLanguage(chosenLanguage);
+  }, [chosenLanguage, setDialogState, handleUpdateLanguage]);
 
-  const chapterRenderer: ItemRenderer<SALanguage> = useCallback(
+  const chapterRenderer: ItemRenderer<LanguageChoice> = useCallback(
     (lang, { handleClick }) => (
       <MenuItem key={lang.displayName} onClick={handleClick} text={lang.displayName} />
     ),
     [],
   );
 
-  const chapterListRenderer: ItemListRenderer<SALanguage> = useCallback(
+  const chapterListRenderer: ItemListRenderer<LanguageChoice> = useCallback(
     ({ itemsParentRef, renderItem, items }) => {
       const defaultChoices = items.filter(({ variant }) => variant === Variant.DEFAULT);
       const variantChoices = items.filter(({ variant }) => variant !== Variant.DEFAULT);
@@ -88,11 +115,11 @@ function DefaultChapterSelect() {
       isCloseButtonShown
       isOpen={isDialogOpen}
       onClose={handleCloseDialog}
-      title="Updating default Source sublanguage"
+      title="Updating default language"
     >
       <DialogBody>
-        Are you sure you want to update the <b>default Playground Source sublanguage</b> from{' '}
-        {styliseSublanguage(sourceChapter, sourceVariant)} to <b>{chosenSublang.displayName}</b>?
+        Are you sure you want to update the <b>default Playground language</b> from{' '}
+        {currentLanguageName} to <b>{chosenLanguage.displayName}</b>?
       </DialogBody>
       <DialogFooter
         actions={
@@ -115,16 +142,16 @@ function DefaultChapterSelect() {
 
   return (
     <>
-      <Select<SALanguage>
-        items={sourceLanguages}
+      <Select<LanguageChoice>
+        items={items}
         onItemSelect={handleOpenDialog}
         itemRenderer={chapterRenderer}
         itemListRenderer={chapterListRenderer}
         filterable={false}
       >
         <Button endIcon={IconNames.DOUBLE_CARET_VERTICAL}>
-          <span className="hidden-xs hidden-sm">Default sublanguage: </span>
-          <span>{styliseSublanguage(sourceChapter, sourceVariant)}</span>
+          <span className="hidden-xs hidden-sm">Default language: </span>
+          <span>{currentLanguageName}</span>
         </Button>
       </Select>
       {dialog}


### PR DESCRIPTION
## Summary
- Pass `workspaceLocation` into `getPreparedConductorSaga` so the side-content manager is scoped to the actual workspace (quest/mission/path) instead of always defaulting to `playground` - module tabs (e.g. rune, sound, pix_n_flix) now render outside Playground. (#4230's underlying tab issue, verified across three real module-using missions.)
- Fixes #4230: Ground Control's "Default language" menu was hard-wired to the legacy Source-only `sourceLanguages` array, so it never listed Python/Scheme even though Conductor already makes those selectable everywhere else. Once Conductor is enabled, its items and current selection now come from `state.languageDirectory.languages` instead, reusing `sourceChapter` as a 1-based index into that array - the same convention `chapterLanguage.ts`'s `deriveLanguageFromChapter` already uses for assessments - so no backend schema change is needed. Legacy Source behaviour is unchanged when Conductor is disabled.
- Narrows `changeSublanguage`'s payload type to just the `chapter`/`variant` fields it actually persists (all `BackendSaga` reads from it).

## Test plan
- [x] `yarn tsc --noEmit`, `yarn eslint`, `yarn oxfmt` all clean
- [x] `BackendSaga.test.ts` (115 tests) passing
- [x] Verified live against a local backend across three real module-using missions (rune, sound, pix_n_flix): module tab now renders in assessment/quest/mission workspaces the same way it already did in Playground
