### PR TITLE
Fix Version History diff colors washing out

### DIFF
--- a/src/commons/controlBar/AceDiffViewer.tsx
+++ b/src/commons/controlBar/AceDiffViewer.tsx
@@ -1,7 +1,7 @@
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
-import 'ace-diff/styles-twilight.css';
 import 'ace-diff/styles.css';
+import 'ace-diff/styles-twilight.css';
 
 import * as ace from 'ace-builds';
 import AceDiff from 'ace-diff';


### PR DESCRIPTION
## Summary
- Fixes #4231: changed lines in the Version History diff view were highlighted with a light-blue background, making the twilight-theme (light/white) syntax colors nearly unreadable.
- `ace-diff` ships two stylesheets that both set the same CSS custom properties on `.acediff` (e.g. `--acediff-diff-bg`): `styles.css` (light preset, `#d8f2ff`) and `styles-twilight.css` (dark preset matching the twilight editor theme already in use, `#004d7a`). Same selector, same specificity — whichever import runs last wins the cascade.
- `AceDiffViewer.tsx` imported `styles-twilight.css` before `styles.css`, so the light preset silently overrode the dark one. Swapping the import order restores the shipped dark preset — no new colors needed.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `VersionHistoryPanel.test.tsx` (8 tests) passes
- [x] Verified visually with a standalone harness loading both `ace-diff` stylesheets in each order — confirmed the buggy order reproduces the washed-out light-blue background from the issue screenshot, and the fixed order renders legible white text on a dark blue background matching the twilight theme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SwJ3o6C3cZgXDPLdGB2HTo