### PR TITLE
Fix Autograder Run not triggering all testcases

### DIFF
--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -50,6 +50,7 @@ import Markdown from '../Markdown';
 import SideContentToneMatrix from '../sideContent/content/SideContentToneMatrix';
 import type { SideContentProps } from '../sideContent/SideContent';
 import { changeSideContentHeight } from '../sideContent/SideContentActions';
+import { useSideContent } from '../sideContent/SideContentHelper';
 import type { SideContentTab } from '../sideContent/SideContentTypes';
 import { SideContentType } from '../sideContent/SideContentTypes';
 import { useAppSelector } from '../utils/Hooks';
@@ -91,6 +92,8 @@ function EditingWorkspace(props: EditingWorkspaceProps) {
     currentAssessment: storedAssessmentId,
     currentQuestion: storedQuestionId,
   } = useAppSelector(store => store.workspaces[workspaceLocation]);
+
+  const { selectedTab } = useSideContent(workspaceLocation);
 
   /**
    * After mounting (either an older copy of the assessment
@@ -328,6 +331,23 @@ function EditingWorkspace(props: EditingWorkspaceProps) {
     const editorTestcases = [testcase];
     handleUpdateWorkspace({ editorTestcases });
     dispatch(WorkspaceActions.evalTestcase(workspaceLocation, 0));
+  };
+
+  const handleRunAllTestcases = () => {
+    const question = assessment!.questions[formatedQuestionId()] as IProgrammingQuestion;
+    const editorTestcases = question.testcases.concat(question.testcasesPrivate ?? []);
+    handleUpdateWorkspace({ editorTestcases });
+    dispatch(WorkspaceActions.runAllTestcases(workspaceLocation));
+  };
+
+  // Run all testcases (instead of just evaluating the editor) when the Run button/shift-enter
+  // is used while the Autograder tab is active - matches AssessmentWorkspace/GradingWorkspace.
+  const handleEval = () => {
+    if (selectedTab === SideContentType.editorAutograder) {
+      handleRunAllTestcases();
+    } else {
+      handleEditorEval();
+    }
   };
 
   const handleSave = () => {
@@ -603,7 +623,7 @@ function EditingWorkspace(props: EditingWorkspaceProps) {
     const runButton = (
       <ControlBarRunButton
         isEntrypointFileDefined={activeEditorTabIndex !== null}
-        handleEditorEval={handleEditorEval}
+        handleEditorEval={handleEval}
         key="run"
       />
     );
@@ -675,7 +695,7 @@ function EditingWorkspace(props: EditingWorkspaceProps) {
             editorSessionId: '',
             sessionDetails: null,
             handleDeclarationNavigate: handleDeclarationNavigate,
-            handleEditorEval: handleEditorEval,
+            handleEditorEval: handleEval,
             handleEditorValueChange: handleEditorValueChange,
             handleEditorUpdateBreakpoints: handleEditorUpdateBreakpoints,
             handleUpdateHasUnsavedChanges: handleUpdateHasUnsavedChanges,

--- a/src/commons/sagas/WorkspaceSaga.test.ts
+++ b/src/commons/sagas/WorkspaceSaga.test.ts
@@ -27,6 +27,11 @@ vi.mock('../../pages/createStore', () => ({
 }));
 
 import { flagConductorEnable } from '../../features/conductor/flagConductorEnable';
+import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
+import {
+  TEST_CASE_EVALUATOR_ID,
+  TEST_CASE_LANGUAGE_ID,
+} from '../../features/directory/testCaseLanguage';
 import { WORKSPACE_BASE_PATHS } from '../../pages/fileSystem/createInBrowserFileSystem';
 import InterpreterActions from '../application/actions/InterpreterActions';
 import SessionActions from '../application/actions/SessionActions';
@@ -1857,15 +1862,15 @@ describe('EVAL_EDITOR_AND_TESTCASES', () => {
       })
       .call(showSuccessMessage, 'Running all testcases!', 2000)
       .call.fn(evalEditorSaga)
-      .call(runTestCase, workspaceLocation, 0)
-      .call(runTestCase, workspaceLocation, 1)
-      .call(runTestCase, workspaceLocation, 2)
-      .call(runTestCase, workspaceLocation, 3)
+      .call(runTestCase, workspaceLocation, 0, false)
+      .call(runTestCase, workspaceLocation, 1, false)
+      .call(runTestCase, workspaceLocation, 2, false)
+      .call(runTestCase, workspaceLocation, 3, false)
       .provide([
-        [call(runTestCase, workspaceLocation, 0), true],
-        [call(runTestCase, workspaceLocation, 1), true],
-        [call(runTestCase, workspaceLocation, 2), true],
-        [call(runTestCase, workspaceLocation, 3), true],
+        [call(runTestCase, workspaceLocation, 0, false), true],
+        [call(runTestCase, workspaceLocation, 1, false), true],
+        [call(runTestCase, workspaceLocation, 2, false), true],
+        [call(runTestCase, workspaceLocation, 3, false), true],
       ])
       .silentRun(2000);
   });
@@ -1883,12 +1888,77 @@ describe('EVAL_EDITOR_AND_TESTCASES', () => {
       })
       .call(showSuccessMessage, 'Running all testcases!', 2000)
       .call.fn(evalEditorSaga)
-      .call(runTestCase, workspaceLocation, 0)
-      .not.call(runTestCase, workspaceLocation, 1)
-      .not.call(runTestCase, workspaceLocation, 2)
-      .not.call(runTestCase, workspaceLocation, 3)
-      .provide([[call(runTestCase, workspaceLocation, 0), false]])
+      .call(runTestCase, workspaceLocation, 0, false)
+      .not.call(runTestCase, workspaceLocation, 1, false)
+      .not.call(runTestCase, workspaceLocation, 2, false)
+      .not.call(runTestCase, workspaceLocation, 3, false)
+      .provide([[call(runTestCase, workspaceLocation, 0, false), false]])
       .silentRun(2000);
+  });
+
+  test('under Conductor, switches the test-case language once for the whole batch instead of once per testcase', () => {
+    state = {
+      ...generateDefaultState(workspaceLocation, {
+        editorTestcases: mockTestcases,
+      }),
+      featureFlags: { modifiedFlags: { [flagConductorEnable.flagName]: true } },
+      languageDirectory: {
+        ...defaultState.languageDirectory,
+        selectedLanguageId: 'python1',
+        selectedEvaluatorId: 'python1Py2js',
+      },
+    };
+
+    const capturedSkipFlags: unknown[] = [];
+    let setTestCaseLanguageCount = 0;
+    let setTestCaseEvaluatorCount = 0;
+    let restoreLanguageCount = 0;
+    let restoreEvaluatorCount = 0;
+
+    return expectSaga(workspaceSaga)
+      .withState(state)
+      .provide([
+        {
+          call(effect, next) {
+            if (effect.fn === runTestCase) {
+              capturedSkipFlags.push(effect.args[2]);
+              return true;
+            }
+            return next();
+          },
+          put(effect, next) {
+            if (effect.action.type === LanguageDirectoryActions.setSelectedLanguage.type) {
+              if (effect.action.payload.languageId === TEST_CASE_LANGUAGE_ID) {
+                setTestCaseLanguageCount++;
+              } else if (effect.action.payload.languageId === 'python1') {
+                restoreLanguageCount++;
+              }
+            }
+            if (effect.action.type === LanguageDirectoryActions.setSelectedEvaluator.type) {
+              if (effect.action.payload.evaluatorId === TEST_CASE_EVALUATOR_ID) {
+                setTestCaseEvaluatorCount++;
+              } else if (effect.action.payload.evaluatorId === 'python1Py2js') {
+                restoreEvaluatorCount++;
+              }
+            }
+            return next();
+          },
+        },
+        [matchers.call.fn(evalEditorSaga), undefined],
+        [matchers.call.fn(showSuccessMessage), undefined],
+      ])
+      .dispatch({
+        type: WorkspaceActions.runAllTestcases.type,
+        payload: { workspaceLocation },
+      })
+      .run(2000)
+      .then(() => {
+        expect(capturedSkipFlags).toEqual([true, true, true, true]);
+        expect(setTestCaseLanguageCount).toBe(1);
+        expect(setTestCaseEvaluatorCount).toBe(1);
+        expect(restoreLanguageCount).toBe(1);
+        expect(restoreEvaluatorCount).toBe(1);
+      });
   });
 });
 

--- a/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
@@ -55,6 +55,18 @@ export function* runTestCaseConductor(
   prepend: string,
   postpend: string,
   execTime: number,
+  /**
+   * Skip this call's own switch-to-TEST_CASE-language/restore dance - set by runAllTestcases
+   * (WorkspaceSaga/index.ts), which switches once for the whole batch of testcases instead of
+   * once per testcase. Repeatedly switching `state.languageDirectory`'s selection back and forth
+   * between every testcase (each switch tears down and rebuilds the Conductor session - see
+   * conductorEvaluatorCache.ts's ensureConductorSessionSaga) raced with Conductor's own internal
+   * teardown often enough to throw an uncaught "Conduit already terminated" from inside the
+   * vendored library - see source-academy/frontend#4232. A single testcase run from the
+   * Autograder tab's individual "click to test" button still does its own switch/restore, since
+   * there's no batch to hoist it out of.
+   */
+  skipLanguageSwitch?: boolean,
 ): Generator<StrictEffect, boolean, any> {
   const context: Context<any> = yield select(
     (state: OverallState) => state.workspaces[workspaceLocation].context,
@@ -82,11 +94,17 @@ export function* runTestCaseConductor(
   // Grading always runs under TEST_CASE_LANGUAGE_ID/EVALUATOR_ID (see testCaseLanguage.ts),
   // regardless of the assessment's own chapter-derived language - temporarily override the
   // shared selection for this call, then restore it, so a subsequent Run (outside the testing
-  // tab) goes back to using the student's assigned sub-chapter.
-  const { selectedLanguageId, selectedEvaluatorId }: OverallState['languageDirectory'] =
-    yield select((state: OverallState) => state.languageDirectory);
-  yield put(LanguageDirectoryActions.setSelectedLanguage(TEST_CASE_LANGUAGE_ID));
-  yield put(LanguageDirectoryActions.setSelectedEvaluator(TEST_CASE_EVALUATOR_ID));
+  // tab) goes back to using the student's assigned sub-chapter. Skipped when the caller (see
+  // runAllTestcases in WorkspaceSaga/index.ts) already switched once for the whole batch.
+  let selectedLanguageId: string | null = null;
+  let selectedEvaluatorId: string | null = null;
+  if (!skipLanguageSwitch) {
+    ({ selectedLanguageId, selectedEvaluatorId } = yield select(
+      (state: OverallState) => state.languageDirectory,
+    ));
+    yield put(LanguageDirectoryActions.setSelectedLanguage(TEST_CASE_LANGUAGE_ID));
+    yield put(LanguageDirectoryActions.setSelectedEvaluator(TEST_CASE_EVALUATOR_ID));
+  }
 
   try {
     yield call(
@@ -99,13 +117,15 @@ export function* runTestCaseConductor(
       workspaceLocation,
     );
   } finally {
-    if (selectedLanguageId) {
-      yield put(LanguageDirectoryActions.setSelectedLanguage(selectedLanguageId));
-      if (selectedEvaluatorId) {
-        yield put(LanguageDirectoryActions.setSelectedEvaluator(selectedEvaluatorId));
+    if (!skipLanguageSwitch) {
+      if (selectedLanguageId) {
+        yield put(LanguageDirectoryActions.setSelectedLanguage(selectedLanguageId));
+        if (selectedEvaluatorId) {
+          yield put(LanguageDirectoryActions.setSelectedEvaluator(selectedEvaluatorId));
+        }
+      } else {
+        yield put(LanguageDirectoryActions.clearSelectedLanguage());
       }
-    } else {
-      yield put(LanguageDirectoryActions.clearSelectedLanguage());
     }
   }
 
@@ -146,6 +166,7 @@ export function* runTestCaseConductor(
 export function* runTestCase(
   workspaceLocation: WorkspaceLocation,
   index: number,
+  skipLanguageSwitch?: boolean,
 ): Generator<StrictEffect, boolean, any> {
   const {
     editorTabs: {
@@ -174,6 +195,7 @@ export function* runTestCase(
       prepend,
       postpend,
       execTime,
+      skipLanguageSwitch,
     );
   }
 

--- a/src/commons/sagas/WorkspaceSaga/index.ts
+++ b/src/commons/sagas/WorkspaceSaga/index.ts
@@ -16,7 +16,12 @@ import { EventType } from '../../../features/achievement/AchievementTypes';
 import { selectConductorEnable } from '../../../features/conductor/flagConductorEnable';
 import CseMachine from '../../../features/cseMachine/CseMachine';
 import DataVisualizer from '../../../features/dataVisualizer/dataVisualizer';
+import LanguageDirectoryActions from '../../../features/directory/LanguageDirectoryActions';
 import { selectDefaultFileExtension } from '../../../features/directory/LanguageDirectoryTypes';
+import {
+  TEST_CASE_EVALUATOR_ID,
+  TEST_CASE_LANGUAGE_ID,
+} from '../../../features/directory/testCaseLanguage';
 import { WORKSPACE_BASE_PATHS } from '../../../pages/fileSystem/createInBrowserFileSystem';
 import {
   defaultEditorValue,
@@ -530,18 +535,57 @@ const WorkspaceSaga = combineSagaHandlers({
         (state: OverallState) => state.workspaces[workspaceLocation].editorTestcases,
       );
       // Avoid displaying message if there are no testcases
-      if (testcases.length > 0) {
-        // Display a message to the user
-        yield call(showSuccessMessage, `Running all testcases!`, 2000);
+      if (testcases.length === 0) {
+        return;
+      }
+
+      // Display a message to the user
+      yield call(showSuccessMessage, `Running all testcases!`, 2000);
+
+      // Grading always runs under TEST_CASE_LANGUAGE_ID/EVALUATOR_ID (see testCaseLanguage.ts) -
+      // switch once for this whole batch (rather than once per testcase inside
+      // runTestCaseConductor), since each switch tears down and rebuilds the Conductor session
+      // (conductorEvaluatorCache.ts's ensureConductorSessionSaga). Doing that up to 2N times in
+      // quick succession raced with Conductor's own internal teardown often enough to throw an
+      // uncaught "Conduit already terminated" from inside the vendored library - see
+      // source-academy/frontend#4232.
+      const isConductorEnabled: boolean = yield select(selectConductorEnable);
+      let selectedLanguageId: string | null = null;
+      let selectedEvaluatorId: string | null = null;
+      if (isConductorEnabled) {
+        ({ selectedLanguageId, selectedEvaluatorId } = yield select(
+          (state: OverallState) => state.languageDirectory,
+        ));
+        yield put(LanguageDirectoryActions.setSelectedLanguage(TEST_CASE_LANGUAGE_ID));
+        yield put(LanguageDirectoryActions.setSelectedEvaluator(TEST_CASE_EVALUATOR_ID));
+      }
+
+      try {
         for (const idx of testcases.keys()) {
           // break each testcase up into separate event loop iterations
           // so that the UI updates
           yield new Promise(resolve => setTimeout(resolve, 0));
 
-          const programSucceeded: boolean = yield call(runTestCase, workspaceLocation, idx);
+          const programSucceeded: boolean = yield call(
+            runTestCase,
+            workspaceLocation,
+            idx,
+            isConductorEnabled,
+          );
           // Prematurely terminate if execution of the program failed (not the testcase)
           if (!programSucceeded) {
             return;
+          }
+        }
+      } finally {
+        if (isConductorEnabled) {
+          if (selectedLanguageId) {
+            yield put(LanguageDirectoryActions.setSelectedLanguage(selectedLanguageId));
+            if (selectedEvaluatorId) {
+              yield put(LanguageDirectoryActions.setSelectedEvaluator(selectedEvaluatorId));
+            }
+          } else {
+            yield put(LanguageDirectoryActions.clearSelectedLanguage());
           }
         }
       }

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -517,11 +517,11 @@ function GradingWorkspace(props: Props) {
   };
 
   const handleEval = () => {
-    handleEditorEval();
-
     // Run testcases when the autograder tab is selected
     if (selectedTab === SideContentType.autograder) {
       handleRunAllTestcases();
+    } else {
+      handleEditorEval();
     }
   };
 


### PR DESCRIPTION
Fixes #4232.

## Summary
Three separate bugs contributed to "Run" not triggering all testcases from the Autograder tab:

- **The actual crash** (`ConductorInternalError: Conduit already terminated`, uncaught, aborting the whole batch): `runAllTestcases` switched `state.languageDirectory`'s selection to force the test-case language/evaluator and back for **every single testcase**. Each switch tears down and rebuilds the whole Conductor session (`ensureConductorSessionSaga` in `conductorEvaluatorCache.ts`). With N testcases that's up to 2N+1 rapid session teardown/rebuild cycles in a row - on a real network connection (reproduced on staging, not locally, since it's a latency-dependent race) an in-flight async teardown could race a new one and throw uncaught from inside the vendored `@sourceacademy/conductor` library. Now switches once for the whole batch and restores once afterward, regardless of testcase count.
- `EditingWorkspace.tsx` (the question-editing/preview "Mission Control" view) had **no** autograder-tab check at all - Run always just evaluated the editor regardless of which side-content tab was active.
- `GradingWorkspace.tsx` fired **both** a plain editor eval and the full testcase run back-to-back when the Autograder tab was active (the testcase run itself already re-evaluates the editor internally).

## Test plan
- [x] `yarn tsc --noEmit`, `yarn eslint`, `yarn oxfmt` all clean
- [x] `WorkspaceSaga.test.ts` (115 tests, including a new one asserting the language/evaluator switch happens exactly once per batch instead of once per testcase) passing
- [x] Verified locally against a real mission with testcases: Run correctly triggers all testcases from the Autograder tab in the student assessment view
