### PR TITLE
Thread gutter-click breakpoint lines into Conductor runs

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -176,15 +176,19 @@ const makeHandleGutterClick =
   };
 
 /**
- * Returns an array of breakpoint line numbers from the Ace Editor's breakpoint
+ * Returns an array of breakpoint line numbers (0-indexed) from the Ace Editor's breakpoint
  * array representation.
  *
  * Breakpoints are elements in the array with the value 'ace_breakpoint' where
  * the associated line number is the index of the element in the array.
  *
+ * Exported for evalCode.ts, which threads these into a Conductor run's /__cse_config__ (as
+ * 1-indexed lines) so a gutter click resolves to a breakpoint the same way an explicit
+ * `breakpoint()`/`debugger;` call does - see py-slang#383.
+ *
  * @param breakpoints The Ace Editor's breakpoint representation.
  */
-const getBreakpointLineNumbers = (breakpoints: string[]): number[] => {
+export const getBreakpointLineNumbers = (breakpoints: string[]): number[] => {
   const breakpointLineNumbers: number[] = [];
   breakpoints.forEach((value: string, index: number) => {
     if (value !== 'ace_breakpoint') {

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -920,16 +920,36 @@ export function* evalCodeConductorSaga(
   yield* endReplSessionSaga(workspaceLocation);
 
   // Inject step limit so the evaluator knows how many snapshots to collect
-  const { stepLimit, editorTabs, activeEditorTabIndex } = yield* selectWorkspace(workspaceLocation);
+  const { stepLimit, editorTabs, activeEditorTabIndex, programPrependValue } =
+    yield* selectWorkspace(workspaceLocation);
   // Gutter-click breakpoints (py-slang#383): the active tab's ace breakpoints, resolved to
   // 1-indexed lines and threaded into /__cse_config__ so the evaluator can mark the closest
   // enclosing statement, exactly like an explicit `breakpoint()` call. Conductor's own analogue of
   // insertDebuggerStatements.ts's `debugger;` insertion (which is a no-op under Conductor, see its
   // own doc comment) - a *line* is host-side editor state, so the host, not the evaluator bundle,
   // is what can resolve "the active tab's breakpoints" in the first place.
-  const activeEditorTab = editorTabs[activeEditorTabIndex ?? 0];
+  //
+  // Only a Run (EVAL_EDITOR) has editor-authored `entrypointFilePath` content to speak of - a REPL
+  // chunk (isReplChunk, above) is unrelated one-off input that just happens to run through this
+  // same saga, so a gutter breakpoint must not leak into it (nor into e.g. a test-case or
+  // block/restoreExtraMethods run - none of those are "the student's Run" either). No active tab
+  // (activeEditorTabIndex === null) likewise means there is nothing to source breakpoints from -
+  // never guess by falling back to the first tab.
+  const isEditorRun = actionType === WorkspaceActions.evalEditor.type;
+  const activeEditorTab =
+    isEditorRun && activeEditorTabIndex !== null ? editorTabs[activeEditorTabIndex] : undefined;
+  // evalEditorSaga (evalEditor.ts) concatenates `${programPrependValue}\n` onto the entrypoint
+  // before this saga ever runs, for a non-TYPED Conductor Run with a non-empty prepend - shifting
+  // every line of the student's own code down by the prepend's own line count. (The TYPED-variant
+  // prepend, by contrast, is joined onto line 1 with no newlines - no lines shift, so no offset is
+  // needed there.) Breakpoints are recorded against the student's un-prepended editor content, so
+  // that same shift must be applied here to still land on the right line post-concatenation.
+  const preludeLineOffset =
+    isEditorRun && context.variant !== Variant.TYPED && programPrependValue.length > 0
+      ? programPrependValue.split('\n').length
+      : 0;
   const breakpointLines = getBreakpointLineNumbers(activeEditorTab?.breakpoints ?? []).map(
-    line => line + 1,
+    line => line + 1 + preludeLineOffset,
   );
   const filesWithConfig = {
     ...files,

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -14,6 +14,7 @@ import { call, cancel, cancelled, put, race, select, spawn, take } from 'redux-s
 import * as Sourceror from 'sourceror';
 
 import InterpreterActions from '../../../../commons/application/actions/InterpreterActions';
+import { getBreakpointLineNumbers } from '../../../../commons/editor/Editor';
 import { makeCCompilerConfig, specialCReturnObject } from '../../../../commons/utils/CToWasmHelper';
 import { javaRun } from '../../../../commons/utils/JavaHelper';
 import { EventType } from '../../../../features/achievement/AchievementTypes';
@@ -919,10 +920,20 @@ export function* evalCodeConductorSaga(
   yield* endReplSessionSaga(workspaceLocation);
 
   // Inject step limit so the evaluator knows how many snapshots to collect
-  const { stepLimit }: { stepLimit: number } = yield* selectWorkspace(workspaceLocation);
+  const { stepLimit, editorTabs, activeEditorTabIndex } = yield* selectWorkspace(workspaceLocation);
+  // Gutter-click breakpoints (py-slang#383): the active tab's ace breakpoints, resolved to
+  // 1-indexed lines and threaded into /__cse_config__ so the evaluator can mark the closest
+  // enclosing statement, exactly like an explicit `breakpoint()` call. Conductor's own analogue of
+  // insertDebuggerStatements.ts's `debugger;` insertion (which is a no-op under Conductor, see its
+  // own doc comment) - a *line* is host-side editor state, so the host, not the evaluator bundle,
+  // is what can resolve "the active tab's breakpoints" in the first place.
+  const activeEditorTab = editorTabs[activeEditorTabIndex ?? 0];
+  const breakpointLines = getBreakpointLineNumbers(activeEditorTab?.breakpoints ?? []).map(
+    line => line + 1,
+  );
   const filesWithConfig = {
     ...files,
-    '/__cse_config__': JSON.stringify({ stepLimit }),
+    '/__cse_config__': JSON.stringify({ stepLimit, breakpointLines }),
   };
 
   try {


### PR DESCRIPTION
## Summary

- Companion to [py-slang#384](https://github.com/source-academy/py-slang/pull/384), which implements gutter-click breakpoints on the evaluator side but has no way to learn which lines were clicked - `/__cse_config__` (the virtual file Conductor evaluators already fetch for `stepLimit`) never carried anything else. The legacy `insertDebuggerStatements` (`debugger;`-insertion) path is explicitly a no-op under Conductor (see its own doc comment), so gutter clicks currently do nothing for any Conductor-backed language, Python included.
- `evalCodeConductorSaga` (`evalCode.ts`) now resolves the active editor tab's ace breakpoints (`Editor.tsx`'s `getBreakpointLineNumbers`, now exported) to 1-indexed lines and includes them as `breakpointLines` in `/__cse_config__`, alongside the existing `stepLimit`.
- py-slang's `PyCseEvaluator`/`PyStepperEvaluator` read this field, resolve each line to its closest enclosing statement, and treat it exactly like an explicit `breakpoint()` call - reusing the host's existing breakpoint-navigation controls.

## Test plan

- [x] `tsc -b` - clean
- [x] `eslint` on both changed files - no new errors (pre-existing warnings elsewhere in `Editor.tsx` untouched)
- [x] `vitest run src/commons/editor/Editor.test.tsx src/commons/sagas/WorkspaceSaga.test.ts` - 66/66 pass
- [x] Full pre-push hook (`tsc`, `lint`, `format:ci`, `test`) - pass
- [x] Manually verified end-to-end against a local py-slang build (source-academy/py-slang#384) + local language-directory: wrote a 4-line program with no `breakpoint()` call, clicked the gutter on one line, ran it, and confirmed the CSE Machine's and Stepper's "jump to next breakpoint" (»​) button landed exactly on that line - for both the CSE machine and Stepper evaluators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvqZCkjN8CLSBWCoNSZbAG