### PR TITLE
Correct off-by-one prepend line shift in Conductor error messages

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.test.ts
+++ b/src/commons/sagas/WorkspaceSaga.test.ts
@@ -670,50 +670,64 @@ describe('EVAL_EDITOR under Conductor', () => {
   });
 });
 
+/**
+ * A minimal fake Conductor host driving evalCodeConductorSaga's real session-management logic
+ * while faking only the underlying Worker transport. startEvaluator()/sendChunk() each simulate a
+ * chunk settling on the next microtask by calling back through whatever handleStatuses (spawned
+ * for real, not mocked) assigned to hostPlugin.receiveStatusUpdate - mirroring conductor's own
+ * BasicEvaluator chunk loop (RUNNING, then EVAL_READY between chunks - see
+ * source-academy/conductor#66), unless overridden via `nextStatus`.
+ *
+ * `options.error`, if given, is delivered through hostPlugin.receiveError on the *next* settle -
+ * simulating the runner reporting an error (e.g. a py-slang EvaluatorError) on this chunk, the way
+ * conductor's RunnerPlugin.sendError does - before the chunk's own status update. Like
+ * `setNextStatus` below, it can also be changed later via `setNextError` for a later chunk (e.g. a
+ * REPL line sent to an already-live session) sent to this same fake.
+ */
+function makeFakeConductor(options: { error?: unknown } = {}) {
+  const sentChunks: string[] = [];
+  const terminate = vi.fn();
+  let nextStatus: RunnerStatus = RunnerStatus.EVAL_READY;
+  let nextError: unknown = options.error;
+  const settle = () => {
+    Promise.resolve().then(() => {
+      if (nextError !== undefined) {
+        hostPlugin.receiveError?.(nextError);
+      }
+      hostPlugin.receiveStatusUpdate?.(RunnerStatus.RUNNING, true, 0);
+      hostPlugin.receiveStatusUpdate?.(nextStatus, true, 0);
+    });
+  };
+  const hostPlugin: any = {
+    startEvaluator: vi.fn(() => settle()),
+    sendChunk: vi.fn((chunk: string) => {
+      sentChunks.push(chunk);
+      settle();
+    }),
+  };
+  const csePlugin: any = { sendSnapshots: vi.fn() };
+  const conduit: any = { terminate };
+  return {
+    hostPlugin,
+    csePlugin,
+    conduit,
+    sentChunks,
+    terminate,
+    /** Makes the *next* settle() report `status` instead of the default EVAL_READY - e.g.
+     * RunnerStatus.STOPPED, to simulate the runner (or Stop) ending the session. */
+    setNextStatus: (status: RunnerStatus) => {
+      nextStatus = status;
+    },
+    /** Makes the *next* settle() also deliver `error` through hostPlugin.receiveError first, or
+     * stop delivering one if called with `undefined`. */
+    setNextError: (error: unknown) => {
+      nextError = error;
+    },
+  };
+}
+
 describe('EVAL_REPL session persistence under Conductor', () => {
   const workspaceLocation: WorkspaceLocation = 'playground';
-
-  /**
-   * A minimal fake Conductor host driving evalCodeConductorSaga's real session-management logic
-   * (everything this describe block cares about) while faking only the underlying Worker
-   * transport. startEvaluator()/sendChunk() each simulate a chunk settling on the next
-   * microtask by calling back through whatever handleStatuses (spawned for real, not mocked)
-   * assigned to hostPlugin.receiveStatusUpdate - mirroring conductor's own BasicEvaluator
-   * chunk loop (RUNNING, then EVAL_READY between chunks - see source-academy/conductor#66),
-   * unless overridden via `nextStatus`.
-   */
-  function makeFakeConductor() {
-    const sentChunks: string[] = [];
-    const terminate = vi.fn();
-    let nextStatus: RunnerStatus = RunnerStatus.EVAL_READY;
-    const settle = () => {
-      Promise.resolve().then(() => {
-        hostPlugin.receiveStatusUpdate?.(RunnerStatus.RUNNING, true, 0);
-        hostPlugin.receiveStatusUpdate?.(nextStatus, true, 0);
-      });
-    };
-    const hostPlugin: any = {
-      startEvaluator: vi.fn(() => settle()),
-      sendChunk: vi.fn((chunk: string) => {
-        sentChunks.push(chunk);
-        settle();
-      }),
-    };
-    const csePlugin: any = { sendSnapshots: vi.fn() };
-    const conduit: any = { terminate };
-    return {
-      hostPlugin,
-      csePlugin,
-      conduit,
-      sentChunks,
-      terminate,
-      /** Makes the *next* settle() report `status` instead of the default EVAL_READY - e.g.
-       * RunnerStatus.STOPPED, to simulate the runner (or Stop) ending the session. */
-      setNextStatus: (status: RunnerStatus) => {
-        nextStatus = status;
-      },
-    };
-  }
 
   test('a REPL chunk after a Run reuses the live session instead of requesting a new conductor', async () => {
     const fake = makeFakeConductor();
@@ -811,6 +825,137 @@ describe('EVAL_REPL session persistence under Conductor', () => {
         payload: { workspaceLocation },
       })
       .silentRun();
+  });
+});
+
+describe('Conductor errors subtract the prepend line shift (source-academy/frontend#4244)', () => {
+  const workspaceLocation: WorkspaceLocation = 'playground';
+
+  test("a one-line prepend shifts a reported error line back to the student's own line", async () => {
+    // Mirrors the reported bug exactly: a one-line PREPEND made every error line off-by-one.
+    // evalEditorSaga concatenates `${prepend}\n${entrypoint}` before this saga ever runs (see
+    // toConductorSourceError's doc comment), so the student's own first line becomes combined-file
+    // line 2 - simulate the evaluator (e.g. py-slang) reporting an error there via a structured,
+    // EvaluatorError-shaped object (line/column/rawMessage own properties survive a Worker's
+    // postMessage structured clone even though the class prototype doesn't).
+    const programPrependValue = 'COUNTER = 0';
+    const editorValue = 'undefined_name';
+    const entrypointFilePath = '/code.py';
+    const fakeError = {
+      name: 'EvaluatorRuntimeError',
+      line: 2,
+      column: 0,
+      rawMessage: "NameError: name 'undefined_name' is not defined",
+      message: "2:0: NameError: name 'undefined_name' is not defined",
+    };
+    const fake = makeFakeConductor({ error: fakeError });
+    fake.setNextStatus(RunnerStatus.STOPPED);
+    const context = createContext();
+    const state = generateDefaultState(workspaceLocation, {
+      context,
+      programPrependValue,
+      editorTabs: [{ value: editorValue, highlightedLines: [], breakpoints: [] }],
+      activeEditorTabIndex: 0,
+    });
+
+    let capturedErrors: SourceError[] | undefined;
+    await expectSaga(
+      evalCodeConductorSaga,
+      { [entrypointFilePath]: `${programPrependValue}\n${editorValue}` },
+      entrypointFilePath,
+      context,
+      workspaceLocation,
+      WorkspaceActions.evalEditor.type,
+    )
+      .withState(state)
+      .provide([
+        [matchers.call.fn(getEvaluatorDefinitionSaga), { path: 'fake-evaluator-path' }],
+        [matchers.call.fn(getPreparedConductorSaga), fake],
+        [matchers.spawn.fn(preloadConductorEvaluatorSaga), undefined],
+        {
+          put(effect, next) {
+            if (effect.action.type === InterpreterActions.appendInterpreterError.type) {
+              capturedErrors = effect.action.payload.errors;
+            }
+            return next();
+          },
+        },
+      ])
+      .silentRun();
+
+    expect(capturedErrors).toHaveLength(1);
+    // Corrected back to the student's own line 1 (2 minus the 1-line prepend), not the raw
+    // combined-file line 2 the evaluator actually reported.
+    expect(capturedErrors![0].location.start.line).toBe(1);
+    expect(capturedErrors![0].explain()).toBe("NameError: name 'undefined_name' is not defined");
+  });
+
+  test("a REPL chunk sent to an already-live session is not shifted by that session's own prepend", async () => {
+    // The offset only applies to a session's initial entrypoint chunk (which had prepend
+    // concatenated onto it) - a REPL line sent afterwards is raw input with no prepend involved,
+    // so an error there must be reported as-is, not shifted by the Run's prepend all over again.
+    const programPrependValue = 'COUNTER = 0';
+    const context = createContext();
+    const state = generateDefaultState(workspaceLocation, { context, programPrependValue });
+    const providers: [Matcher, unknown][] = [
+      [matchers.call.fn(getEvaluatorDefinitionSaga), { path: 'fake-evaluator-path' }],
+      [matchers.spawn.fn(preloadConductorEvaluatorSaga), undefined],
+    ];
+
+    // A Run establishes the session (no error on this chunk). handleErrors is spawn()ed as a
+    // detached task inside *this* expectSaga call and keeps running (and keeps dispatching
+    // through *this* call's own store/middleware) after this call's own silentRun() resolves -
+    // it's the same task that later handles the REPL chunk's error below, so the put-capturing
+    // provider has to be registered here, not on the second expectSaga call, to see it.
+    let capturedErrors: SourceError[] | undefined;
+    const runFake = makeFakeConductor();
+    await expectSaga(
+      evalCodeConductorSaga,
+      { '/code.py': `${programPrependValue}\nx = 1` },
+      '/code.py',
+      context,
+      workspaceLocation,
+      WorkspaceActions.evalEditor.type,
+    )
+      .withState(state)
+      .provide([
+        ...providers,
+        [matchers.call.fn(getPreparedConductorSaga), runFake],
+        {
+          put(effect, next) {
+            if (effect.action.type === InterpreterActions.appendInterpreterError.type) {
+              capturedErrors = effect.action.payload.errors;
+            }
+            return next();
+          },
+        },
+      ])
+      .silentRun();
+
+    // A later REPL line reuses that live session and errors on its own (unshifted) line 1.
+    runFake.setNextError({
+      name: 'EvaluatorRuntimeError',
+      line: 1,
+      column: 0,
+      rawMessage: "NameError: name 'undefined_name' is not defined",
+      message: "1:0: NameError: name 'undefined_name' is not defined",
+    });
+    runFake.setNextStatus(RunnerStatus.STOPPED);
+    await expectSaga(
+      evalCodeConductorSaga,
+      { '/code.py': 'undefined_name' },
+      '/code.py',
+      context,
+      workspaceLocation,
+      WorkspaceActions.evalRepl.type,
+    )
+      .withState(state)
+      .provide([...providers])
+      .silentRun();
+
+    expect(capturedErrors).toHaveLength(1);
+    // Reported as-is (line 1), not shifted down by the Run's prepend all over again.
+    expect(capturedErrors![0].location.start.line).toBe(1);
   });
 });
 

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -51,7 +51,49 @@ import { selectWorkspace } from '../../SafeEffects';
 import { dumpDisplayBuffer } from './dumpDisplayBuffer';
 import { updateInspector } from './updateInspector';
 
-function toConductorSourceError(error: unknown): SourceError {
+/**
+ * `lineOffset` is the number of prepend lines concatenated onto the entrypoint before it was sent
+ * to the evaluator (see evalEditorSaga's Conductor branch, which joins `${prepend}\n` onto the
+ * entrypoint, and evalCodeConductorSaga's own `preludeLineOffset`, which shifts breakpointLines the
+ * other way for the same reason) - without subtracting it back out here, an error at the student's
+ * own line 1 would be reported as `prepend line count + 1` (source-academy/frontend#4244).
+ *
+ * A Worker's postMessage clones a thrown EvaluatorError via the structured clone algorithm, which
+ * drops its prototype chain (EvaluatorError's `name` isn't a recognised built-in Error subtype, so
+ * the clone lands on plain `Error.prototype`) but keeps custom own properties like
+ * `line`/`column`/`rawMessage` intact - so this checks shape rather than `instanceof
+ * EvaluatorError`.
+ */
+function toConductorSourceError(error: unknown, lineOffset: number = 0): SourceError {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'line' in error &&
+    typeof (error as { line: unknown }).line === 'number'
+  ) {
+    const evaluatorError = error as {
+      line: number;
+      column?: number;
+      rawMessage?: string;
+      message?: unknown;
+    };
+    const line = Math.max(1, evaluatorError.line - lineOffset);
+    const column = evaluatorError.column ?? 0;
+    const explanation =
+      typeof evaluatorError.rawMessage === 'string'
+        ? evaluatorError.rawMessage
+        : String(evaluatorError.message);
+    return {
+      type: ErrorType.RUNTIME,
+      severity: ErrorSeverity.ERROR,
+      location: {
+        start: { line, column },
+        end: { line, column },
+      },
+      explain: () => explanation,
+      elaborate: () => '',
+    };
+  }
   const message =
     typeof error === 'object' && error !== null && 'message' in error
       ? String((error as { message?: unknown }).message)
@@ -444,6 +486,17 @@ export function* evalCodeSaga(
  */
 type ReceivedCount = { count: number };
 
+/**
+ * Mutable box holding the prepend line-offset (see toConductorSourceError's doc comment) to apply
+ * to errors from whichever chunk a session is currently evaluating. It's mutable, not a value
+ * baked into handleErrors at spawn time, because a single session's handleErrors task outlives
+ * every chunk sent to it (see ReplSession's own doc comment): the offset applies to the initial
+ * entrypoint chunk (which had prepend concatenated onto it), but must be reset to 0 before any
+ * later REPL chunk is sent to that same session, since sendChunk sends raw REPL input with no
+ * prepend concatenation at all.
+ */
+type LineOffsetRef = { current: number };
+
 /** Reported by handleStatuses (via a session's chunkSettledChan) each time a chunk finishes:
  * `terminal: false` for an ordinary chunk boundary (RunnerStatus.EVAL_READY - the evaluator is
  * alive and waiting for the next chunk), `terminal: true` when the session is actually over
@@ -582,13 +635,18 @@ function* handleResults(
  * one even exists). A genuine `sendError` from a still-running evaluator (handleErrors' normal path)
  * passes `interrupt: false`: the runner is expected to still send its own terminal STOPPED/ERROR once
  * any pending work (e.g. Python's set_timeout) settles, and handleStatuses drives the interrupt then.
+ *
+ * `lineOffset` is forwarded to toConductorSourceError - see its own doc comment for why.
  */
 function* surfaceConductorError(
   error: unknown,
   workspaceLocation: WorkspaceLocation,
   interrupt: boolean = true,
+  lineOffset: number = 0,
 ): SagaIterator {
-  yield put(actions.appendInterpreterError([toConductorSourceError(error)], workspaceLocation));
+  yield put(
+    actions.appendInterpreterError([toConductorSourceError(error, lineOffset)], workspaceLocation),
+  );
   const selectedTab: SideContentTabId | undefined = yield select(
     (state: OverallState) => state.sideContent[workspaceLocation]?.selectedTab,
   );
@@ -611,6 +669,7 @@ function* handleErrors(
   hostPlugin: BrowserHostPlugin,
   workspaceLocation: WorkspaceLocation,
   receivedCount: ReceivedCount,
+  lineOffsetRef: LineOffsetRef,
 ): SagaIterator {
   const errorChan = eventChannel(emitter => {
     // Same undefined-forbidden-by-eventChannel issue as the result channel: the
@@ -628,7 +687,7 @@ function* handleErrors(
     while (true) {
       const error = yield take(errorChan);
       receivedCount.count++;
-      yield* surfaceConductorError(error, workspaceLocation, false);
+      yield* surfaceConductorError(error, workspaceLocation, false, lineOffsetRef.current);
     }
   } catch (e) {
     // A conductor evaluator may report a preprocessing/syntax error by rejecting its run rather than
@@ -638,7 +697,7 @@ function* handleErrors(
     // not Error instances, so re-raise those to preserve normal teardown. No runner is expected to send
     // a terminal status after this kind of failure, so this path still interrupts immediately.
     if (e instanceof Error) {
-      yield* surfaceConductorError(e, workspaceLocation);
+      yield* surfaceConductorError(e, workspaceLocation, true, lineOffsetRef.current);
     } else {
       throw e;
     }
@@ -778,6 +837,9 @@ type ReplSession = {
    * lifetime is this session's, not tied to whichever saga call happens to be sending the
    * current chunk, so they must keep running after that call returns. */
   tasks: Task[];
+  /** See LineOffsetRef's own doc comment - shared with handleErrors so this session's error
+   * offset can be updated in place per chunk without restarting that task. */
+  lineOffsetRef: LineOffsetRef;
 };
 
 const replSessions = new Map<WorkspaceLocation, ReplSession>();
@@ -898,6 +960,11 @@ export function* evalCodeConductorSaga(
   // gone via endConductorSession's own teardown on a language switch) and must not receive a
   // chunk meant for a different evaluator; fall through to establishing a fresh one instead.
   if (isReplChunk && existingSession && existingSession.evaluatorPath === evaluator.path) {
+    // A REPL chunk sent to an already-live session is raw REPL input with no prepend
+    // concatenated onto it (unlike the session's own initial entrypoint chunk, see
+    // toConductorSourceError's doc comment) - reset the shared offset so errors from *this*
+    // chunk aren't corrected using whatever offset applied to the session's first chunk.
+    existingSession.lineOffsetRef.current = 0;
     try {
       existingSession.hostPlugin.sendChunk(files[entrypointFilePath]);
     } catch (runError) {
@@ -990,18 +1057,25 @@ export function* evalCodeConductorSaga(
     // had already been spawned by that point.
     const receivedCount: ReceivedCount = { count: 0 };
     const chunkSettledChan = channel<ChunkSettled>();
+    // preludeLineOffset only ever applies to this session's initial entrypoint chunk (the one
+    // about to be sent via startEvaluator, below) - see LineOffsetRef's own doc comment for why a
+    // later REPL chunk reuses this same ref but resets it to 0 first.
+    const lineOffsetRef: LineOffsetRef = { current: preludeLineOffset };
     const session: ReplSession = {
       hostPlugin,
       conduit,
       evaluatorPath: evaluator.path,
       chunkSettledChan,
       tasks: [],
+      lineOffsetRef,
     };
     replSessions.set(workspaceLocation, session);
     session.tasks.push(yield spawn(handleStdout, hostPlugin, workspaceLocation, receivedCount));
     session.tasks.push(yield spawn(handleInputRequest, hostPlugin, workspaceLocation));
     session.tasks.push(yield spawn(handleResults, hostPlugin, workspaceLocation, receivedCount));
-    session.tasks.push(yield spawn(handleErrors, hostPlugin, workspaceLocation, receivedCount));
+    session.tasks.push(
+      yield spawn(handleErrors, hostPlugin, workspaceLocation, receivedCount, lineOffsetRef),
+    );
     session.tasks.push(
       yield spawn(handleStatuses, hostPlugin, workspaceLocation, receivedCount, chunkSettledChan),
     );


### PR DESCRIPTION
## Summary
- Fixes #4244: under Conductor, `evalEditorSaga` concatenates `${prepend}\n${entrypoint}` before sending it to the evaluator, so a reported error's line number was relative to that combined text — a one-line PREPEND made every error line off-by-one.
- `toConductorSourceError` now uses the evaluator's structured `line`/`column`/`rawMessage` fields (duck-typed, since a Worker's `postMessage` clone drops the original `EvaluatorError` prototype) and subtracts the same prepend-line offset already applied to `breakpointLines`, instead of passing through the evaluator's pre-baked message string untouched.
- The offset is tracked per Conductor REPL session via a mutable ref, reset to 0 for a later REPL chunk sent to an already-live session (a REPL line has no prepend concatenated onto it, unlike the session's initial entrypoint chunk).

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `yarn test src/commons/sagas/WorkspaceSaga.test.ts` — 67/67 passing, including two new cases:
  - a one-line PREPEND shifts a reported error line back to the student's own line
  - a REPL chunk sent to an already-live session is not shifted by that session's own prepend
- [x] `eslint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2e6QFxwCn1rkTjdhKCSS