### PR TITLE
Clear side content tabs when switching questions

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -70,7 +70,7 @@ import SideContentContestLeaderboard from '../sideContent/content/SideContentCon
 import SideContentContestVotingContainer from '../sideContent/content/SideContentContestVotingContainer';
 import SideContentToneMatrix from '../sideContent/content/SideContentToneMatrix';
 import type { SideContentProps } from '../sideContent/SideContent';
-import { changeSideContentHeight } from '../sideContent/SideContentActions';
+import { changeSideContentHeight, resetSideContent } from '../sideContent/SideContentActions';
 import { useSideContent } from '../sideContent/SideContentHelper';
 import {
   type SideContentTab,
@@ -456,6 +456,9 @@ function AssessmentWorkspace(props: AssessmentWorkspaceProps) {
       question.library.execTimeMs ?? defaultWorkspaceManager.assessment.execTime,
     );
     handleClearContext(question.library, true);
+    // Clear out any module tabs (e.g. Runes, Curves) left over from the
+    // previous question, so they don't linger until the next run.
+    dispatch(resetSideContent(workspaceLocation));
     handleUpdateHasUnsavedChanges(false);
     handleFetchVersionHistory();
 

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -49,7 +49,7 @@ import type { Position } from '../editor/EditorTypes';
 import Markdown from '../Markdown';
 import SideContentToneMatrix from '../sideContent/content/SideContentToneMatrix';
 import type { SideContentProps } from '../sideContent/SideContent';
-import { changeSideContentHeight } from '../sideContent/SideContentActions';
+import { changeSideContentHeight, resetSideContent } from '../sideContent/SideContentActions';
 import { useSideContent } from '../sideContent/SideContentHelper';
 import type { SideContentTab } from '../sideContent/SideContentTypes';
 import { SideContentType } from '../sideContent/SideContentTypes';
@@ -292,6 +292,8 @@ function EditingWorkspace(props: EditingWorkspaceProps) {
       };
     }
     handleClearContext(library, true);
+    // Clear out any module tabs left over from the previous question/library.
+    dispatch(resetSideContent(workspaceLocation));
   };
 
   const resetWorkspaceValues = () => {

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -5,7 +5,10 @@ import { Chapter, Variant } from 'js-slang/dist/langs';
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import SessionActions from 'src/commons/application/actions/SessionActions';
-import { changeSideContentHeight } from 'src/commons/sideContent/SideContentActions';
+import {
+  changeSideContentHeight,
+  resetSideContent,
+} from 'src/commons/sideContent/SideContentActions';
 import { showSimpleErrorDialog } from 'src/commons/utils/DialogHelper';
 import { useAppDispatch, useAppSelector } from 'src/commons/utils/Hooks';
 import WorkspaceActions from 'src/commons/workspace/WorkspaceActions';
@@ -322,6 +325,8 @@ function GradingWorkspace(props: Props) {
     });
     handleChangeExecTime(question.library.execTimeMs ?? defaultWorkspaceManager.grading.execTime);
     handleClearContext(question.library, true);
+    // Clear out any module tabs left over from the previously viewed submission.
+    dispatch(resetSideContent(workspaceLocation));
     handleUpdateHasUnsavedChanges(false);
     if (editorValue) {
       // TODO: Hardcoded to make use of the first editor tab. Refactoring is needed for this workspace to enable Folder mode.


### PR DESCRIPTION
Fixes #4248

The side content tab list only got refreshed after running code, so switching to a different question kept showing module tabs (Runes, Curves, etc) from the previous one until you hit run again. Now it clears out as soon as the question actually changes, in the assessment, grading, and question editor workspaces.

Tested locally against a seeded backend by opening a path with Runes/Curves questions, switching to an unrelated path without running any code, and confirming the leftover tabs are gone.